### PR TITLE
Attempt to fix basename issue

### DIFF
--- a/app/src/Router.tsx
+++ b/app/src/Router.tsx
@@ -1,12 +1,17 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import HomePage from './pages/Home.page';
 
-const router = createBrowserRouter([
+const router = createBrowserRouter(
+  [
+    {
+      path: '/',
+      element: <HomePage />,
+    },
+  ],
   {
-    path: '/',
-    element: <HomePage />,
-  },
-]);
+    basename: import.meta.env.BASE_URL,
+  }
+);
 
 export function Router() {
   return <RouterProvider router={router} />;


### PR DESCRIPTION
Getting this on the GH pages site- it'll be to do with the basename and how GH pages doesn't serve from / (which is a small issue) 
<img width="686" height="391" alt="image" src="https://github.com/user-attachments/assets/8b678df9-7021-4ab1-9ab1-f6ebd7617d4a" />
