### PR TITLE
React Router + GitHub Pages 404.html fallback for GitHub Pages SPA routing issue

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,8 +5,8 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "build-with-types": "tsc --noEmit && vite build",
+    "build": "vite build && cp dist/index.html dist/404.html",
+    "build-with-types": "tsc --noEmit && vite build && cp dist/index.html dist/404.html",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "npm run eslint && npm run stylelint",


### PR DESCRIPTION
Issue: 
GitHub Pages only serves static files and doesn’t support server-side routing.
Deep links (e.g., /about) normally cause 404 because the server can’t find the file.

Solution: 

copy index.html → 404.html during build.
On unknown paths, GitHub Pages serves 404.html, which boots the React app.
React Router reads the path and renders the correct component.

This PR:
- Adds cp command to build scripts to create 404.html
- Fixes direct navigation to routes (e.g., /us) returning 404
- GitHub Pages will serve 404.html for unknown routes, allowing React Router to handle them
- Temporary solution until migration to Vercel or similar platform

Limitations:
The GitHub server possibly returns a status code 404 for everything that is not in root /