### PR TITLE
Simplifies routing structure for Layout and Country Validation

### DIFF
--- a/app/src/Router.tsx
+++ b/app/src/Router.tsx
@@ -16,50 +16,52 @@ const router = createBrowserRouter(
     },
     {
       path: '/:countryId',
-      // CountryGuard wraps Layout directly instead of using Outlet pattern.
-      // This keeps the structure simple - guard is just a validation wrapper,
-      // not a route layer. Avoids extra nesting in route config.
-      element: (
-        <CountryGuard>
-          <Layout />
-        </CountryGuard>
-      ),
+      element: <CountryGuard />,
       children: [
+        // Calculator/app pages - wrapped in Layout for sidebar/header
         {
-          index: true,
-          element: <HomePage />,
+          element: <Layout />,
+          children: [
+            {
+              index: true,
+              // TODO: Move HomePage out of Layout once actual static homepage is merged
+              // Currently HomePage has calculator navigation buttons so needs Layout
+              element: <HomePage />,
+            },
+            {
+              path: 'reports',
+              element: <div>Reports page</div>,
+            },
+            {
+              path: 'reportOutput/:reportId',
+              element: <ReportOutputFrame />,
+            },
+            {
+              path: 'simulations',
+              element: <SimulationsPage />,
+            },
+            {
+              path: 'configurations',
+              element: <div>Configurations page</div>,
+            },
+            {
+              path: 'populations',
+              element: <PopulationsPage />,
+            },
+            {
+              path: 'policies',
+              element: <PoliciesPage />,
+            },
+            {
+              path: 'account',
+              element: <div>Account settings page</div>,
+            },
+          ],
         },
-        {
-          path: 'reports',
-          element: <div>Reports page</div>,
-        },
-        {
-          path: 'reportOutput/:reportId',
-          element: <ReportOutputFrame />,
-        },
-        {
-          path: 'simulations',
-          element: <SimulationsPage />,
-        },
-        {
-          path: 'configurations',
-          element: <div>Configurations page</div>,
-        },
-        {
-          path: 'populations',
-          element: <PopulationsPage />,
-        },
-        {
-          path: 'policies',
-          element: <PoliciesPage />,
-        },
+        // Static pages - no Layout wrapper needed
         {
           path: 'methodology',
           element: <div>Methodology page</div>,
-        },
-        {
-          path: 'account',
-          element: <div>Account settings page</div>,
         },
         {
           path: 'support',

--- a/app/src/routing/guards/CountryGuard.tsx
+++ b/app/src/routing/guards/CountryGuard.tsx
@@ -1,38 +1,21 @@
-import { Navigate, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Outlet, useParams } from 'react-router-dom';
 import { countryIds } from '@/libs/countries';
-
-interface CountryGuardProps {
-  children: React.ReactNode;
-}
 
 /**
  * Guard component that validates country parameter in the route.
- * Wraps the Layout component and redirects if country is invalid.
+ * Acts as a layout component that either redirects or renders child routes.
  */
-export function CountryGuard({ children }: CountryGuardProps) {
+export function CountryGuard() {
   const { countryId } = useParams<{ countryId: string }>();
-  const location = useLocation();
 
   // Validation logic
   const isValid = countryId && countryIds.includes(countryId as any);
 
   if (!isValid) {
-    // Extract path after country segment to preserve user's intended destination.
-    // We can't use useParams for this - it only gives us { countryId }, not the rest.
-    // Route pattern /:countryId doesn't capture /policies/123 part.
-    // Using /:countryId/* would capture it but breaks child route matching.
-    // So we must use string manipulation on location.pathname.
-    const currentPath = location.pathname;
-    const pathAfterCountry = countryId
-      ? currentPath.substring(countryId.length + 1) // Skip "/{country}"
-      : currentPath;
-    const defaultCountry = 'us';
-    const redirectPath = `/${defaultCountry}${pathAfterCountry}`;
-
-    return <Navigate to={redirectPath} replace />;
+    // Redirect to root path and let the root route handler determine the country.
+    return <Navigate to="/" replace />;
   }
 
-  // Render children (Layout) when validation passes.
-  // Using {children} instead of <Outlet /> keeps this a simple wrapper component.
-  return <>{children}</>;
+  // Render child routes when validation passes.
+  return <Outlet />;
 }

--- a/app/src/tests/fixtures/routing/guards/countryGuardMocks.ts
+++ b/app/src/tests/fixtures/routing/guards/countryGuardMocks.ts
@@ -74,19 +74,21 @@ export const TEST_PATHS = {
 } as const;
 
 // Expected redirect paths
+// NOTE: After simplification, CountryGuard now redirects to '/' for all invalid countries,
+// letting the root route handler decide the country (instead of preserving paths)
 export const EXPECTED_REDIRECTS = {
   DEFAULT_COUNTRY: 'us',
 
-  // Preserve paths after redirect
-  POLICIES: '/us/policies',
-  HOUSEHOLD: '/us/household/123',
-  REPORTS: '/us/reports/annual/2024',
-  ROOT_REDIRECT: '/us/',
+  // All invalid countries now redirect to root
+  POLICIES: '/',
+  HOUSEHOLD: '/',
+  REPORTS: '/',
+  ROOT_REDIRECT: '/',
 
-  // Complex path preservation
-  NESTED_PATH: '/us/reports/123/edit',
-  WITH_QUERY: '/us/policies?filter=active&sort=date',
-  WITH_HASH: '/us/policies#section',
+  // Complex paths also redirect to root (no path preservation)
+  NESTED_PATH: '/',
+  WITH_QUERY: '/',
+  WITH_HASH: '/',
 } as const;
 
 // Helper function to create mock Navigate tracking

--- a/app/src/tests/unit/routing/guards/CountryGuard.test.tsx
+++ b/app/src/tests/unit/routing/guards/CountryGuard.test.tsx
@@ -27,14 +27,9 @@ describe('CountryGuard', () => {
       const { getByText } = render(
         <MemoryRouter initialEntries={[TEST_PATHS.US_POLICIES]}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>Protected Content</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+              <Route path="*" element={<div>Protected Content</div>} />
+            </Route>
           </Routes>
         </MemoryRouter>
       );
@@ -47,14 +42,11 @@ describe('CountryGuard', () => {
       const { getByText } = render(
         <MemoryRouter initialEntries={[TEST_PATHS.UK_HOUSEHOLD]}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>UK Content</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>UK Content</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
@@ -67,14 +59,11 @@ describe('CountryGuard', () => {
       const { getByText } = render(
         <MemoryRouter initialEntries={[TEST_PATHS.CA_REPORTS]}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>CA Content</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>CA Content</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
@@ -89,14 +78,11 @@ describe('CountryGuard', () => {
       render(
         <MemoryRouter initialEntries={[TEST_PATHS.INVALID_SIMPLE]}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>Should not render</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>Should not render</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
@@ -108,14 +94,9 @@ describe('CountryGuard', () => {
       render(
         <MemoryRouter initialEntries={[TEST_PATHS.ROOT]}>
           <Routes>
-            <Route
-              path="/*"
-              element={
-                <CountryGuard>
-                  <div>Should not render</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/" element={<CountryGuard />}>
+              <Route path="*" element={<div>Should not render</div>} />
+            </Route>
           </Routes>
         </MemoryRouter>
       );
@@ -129,108 +110,85 @@ describe('CountryGuard', () => {
       render(
         <MemoryRouter initialEntries={[TEST_PATHS.SQL_PATH]}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>Should not render</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>Should not render</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
 
       // Should safely redirect without executing SQL
-      expect(mockNavigate).toHaveBeenCalledWith('/us/household', true);
+      expect(mockNavigate).toHaveBeenCalledWith('/', true);
     });
 
     test('given XSS script injection then safely redirects', () => {
       render(
         <MemoryRouter initialEntries={[TEST_PATHS.XSS_PATH]}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>Should not render</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>Should not render</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
 
-      // NOTE: Current implementation has path extraction issue with special chars
-      // This should ideally redirect to '/us/reports' but the substring logic
-      // doesn't handle malicious input properly. This is a known limitation.
-      expect(mockNavigate).toHaveBeenCalled();
-      const [[redirectPath]] = mockNavigate.mock.calls;
-      expect(redirectPath).toContain('/us');
+      // Should safely redirect to root
+      expect(mockNavigate).toHaveBeenCalledWith('/', true);
     });
 
     test('given path traversal attempt then safely redirects', () => {
       render(
         <MemoryRouter initialEntries={[TEST_PATHS.TRAVERSAL_PATH]}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>Should not render</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>Should not render</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
 
-      // NOTE: Path traversal attempts show limitation in substring logic
-      expect(mockNavigate).toHaveBeenCalled();
-      const [[redirectPath]] = mockNavigate.mock.calls;
-      expect(redirectPath).toContain('/us');
+      // Should safely redirect to root
+      expect(mockNavigate).toHaveBeenCalledWith('/', true);
     });
 
     test('given special characters garbage then safely redirects', () => {
       render(
         <MemoryRouter initialEntries={[TEST_PATHS.GARBAGE_PATH]}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>Should not render</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>Should not render</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
 
-      // NOTE: Special characters cause path extraction issues
-      expect(mockNavigate).toHaveBeenCalled();
-      const [[redirectPath]] = mockNavigate.mock.calls;
-      expect(redirectPath.startsWith('/us')).toBe(true);
+      // Should safely redirect to root
+      expect(mockNavigate).toHaveBeenCalledWith('/', true);
     });
 
     test('given unicode and emoji then safely redirects', () => {
       render(
         <MemoryRouter initialEntries={[TEST_PATHS.UNICODE_PATH]}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>Should not render</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>Should not render</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
 
       // Should handle unicode safely
-      expect(mockNavigate).toHaveBeenCalledWith('/us/about', true);
+      expect(mockNavigate).toHaveBeenCalledWith('/', true);
     });
 
     test('given extremely long string (buffer overflow attempt) then safely redirects', () => {
@@ -241,20 +199,17 @@ describe('CountryGuard', () => {
       render(
         <MemoryRouter initialEntries={[longPath]}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>Should not render</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>Should not render</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
 
       // Should handle long strings without buffer overflow
-      expect(mockNavigate).toHaveBeenCalledWith('/us/test', true);
+      expect(mockNavigate).toHaveBeenCalledWith('/', true);
     });
   });
 
@@ -263,14 +218,11 @@ describe('CountryGuard', () => {
       render(
         <MemoryRouter initialEntries={['/invalid/reports/123/edit']}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>Should not render</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>Should not render</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
@@ -282,19 +234,16 @@ describe('CountryGuard', () => {
       render(
         <MemoryRouter initialEntries={['/xyz/household/person/1/income/employment']}>
           <Routes>
-            <Route
-              path="/:countryId/*"
-              element={
-                <CountryGuard>
-                  <div>Should not render</div>
-                </CountryGuard>
-              }
-            />
+            <Route path="/:countryId" element={<CountryGuard />}>
+
+              <Route path="*" element={<div>Should not render</div>} />
+
+            </Route>
           </Routes>
         </MemoryRouter>
       );
 
-      expect(mockNavigate).toHaveBeenCalledWith('/us/household/person/1/income/employment', true);
+      expect(mockNavigate).toHaveBeenCalledWith('/', true);
     });
   });
 });

--- a/app/src/tests/unit/routing/guards/CountryGuard.test.tsx
+++ b/app/src/tests/unit/routing/guards/CountryGuard.test.tsx
@@ -43,9 +43,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={[TEST_PATHS.UK_HOUSEHOLD]}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>UK Content</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>
@@ -60,9 +58,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={[TEST_PATHS.CA_REPORTS]}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>CA Content</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>
@@ -79,9 +75,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={[TEST_PATHS.INVALID_SIMPLE]}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>Should not render</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>
@@ -111,9 +105,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={[TEST_PATHS.SQL_PATH]}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>Should not render</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>
@@ -128,9 +120,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={[TEST_PATHS.XSS_PATH]}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>Should not render</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>
@@ -145,9 +135,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={[TEST_PATHS.TRAVERSAL_PATH]}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>Should not render</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>
@@ -162,9 +150,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={[TEST_PATHS.GARBAGE_PATH]}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>Should not render</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>
@@ -179,9 +165,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={[TEST_PATHS.UNICODE_PATH]}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>Should not render</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>
@@ -200,9 +184,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={[longPath]}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>Should not render</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>
@@ -219,9 +201,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={['/invalid/reports/123/edit']}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>Should not render</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>
@@ -235,9 +215,7 @@ describe('CountryGuard', () => {
         <MemoryRouter initialEntries={['/xyz/household/person/1/income/employment']}>
           <Routes>
             <Route path="/:countryId" element={<CountryGuard />}>
-
               <Route path="*" element={<div>Should not render</div>} />
-
             </Route>
           </Routes>
         </MemoryRouter>


### PR DESCRIPTION

  - CountryGuard now uses <Outlet /> pattern and redirects to / for invalid countries (no complex path preservation)
  - Layout only wraps calculator/app pages that need sidebar - static pages render without it
  - Cleaner separation of concerns: validation vs layout

