### PR TITLE
Updated type of the Title card body to accept both string and tags

### DIFF
--- a/app/src/components/shared/static/TextCardWithHeader.tsx
+++ b/app/src/components/shared/static/TextCardWithHeader.tsx
@@ -3,7 +3,7 @@ import { colors } from '../../../designTokens';
 
 interface Section {
   heading?: string;
-  body: string | string[];
+  body: string | string[] | React.ReactNode | React.ReactNode[];
 }
 
 interface TitleCardWithHeaderProps {


### PR DESCRIPTION
Fixes #219. 

Description: Updated the body of the title card to accept string or html tag type along with list of string or list of react nodes.