### PR TITLE
Added Open Source page with placeholder content

### DIFF
--- a/app/src/pages/OpenSource.page.tsx
+++ b/app/src/pages/OpenSource.page.tsx
@@ -9,7 +9,7 @@ export default function OpenSourcePage() {
         title="Open source"
         description="PolicyEngine's commitment to open source software and transparent policy analysis"
       />
-      
+
       <TitleCardWithHeader
         title="Coming soon"
         sections={[


### PR DESCRIPTION
Fixes #136 

## Description
Introduced a new Open Source page to the V2 website. The page uses existing shared components for a consistent look and feel across the site with placeholder content from V1.

## Changes
- Created new file: **_src/pages/OpenSourcePage.tsx_**
- Added components:
   - _**PageHeader**_ to display the page title and description.
   - **_TitleCardWithHeader_** for the main content card.
   
## Screenshots
<img width="1102" height="504" alt="Screenshot 2025-10-12 at 7 16 59 PM" src="https://github.com/user-attachments/assets/f690a4ec-03d0-44d4-a3b0-54d7c82fcf84" />
