### PR TITLE
Crash in policy creation

### DIFF
--- a/app/src/components/policyParameterSelectorFrame/ValueSetter.tsx
+++ b/app/src/components/policyParameterSelectorFrame/ValueSetter.tsx
@@ -533,13 +533,9 @@ export function ValueInputBox(props: ValueInputBoxProps) {
   };
 
   // Convert decimal value (0-1) to percentage display value (0-100)
-  const displayValue = isPercentage
-    ? value !== undefined
-      ? value * 100
-      : 0
-    : value !== undefined
-      ? value
-      : 0;
+  // Defensive: ensure value is a number, not an object/array/string
+  const numericValue = typeof value === 'number' ? value : 0;
+  const displayValue = isPercentage ? numericValue * 100 : numericValue;
 
   if (isBool) {
     return (


### PR DESCRIPTION
Fixes #383 

Thorough verification required.

RCA (Root Cause Analysis)

  Crash: TypeError: (char || "").match is not a function

  Location: ValueSetter.tsx - in the ValueInputBox component when rendering NumberInput (which uses react-number-format's NumericFormat component internally)

  Root Cause:
  Some parameters (specifically HMRC IncomeTax parameters) have non-numeric values (likely objects, arrays, or other complex types) in their metadata. When a user clicks on
  these parameters in the policy parameter selector, the ValueInputBox component tries to pass these non-numeric values directly to Mantine's NumberInput component.

  The NumberInput uses react-number-format's NumericFormat internally, which expects string or number values. When it receives a non-numeric value, it attempts to call
  .match() on it (for parsing/formatting), which fails because .match() only exists on strings.

  Trigger:
  Clicking on specific parameter leaves in the policy parameter selector tree (HMRC IncomeTax and a few other params) during isolated policy creation flow.

  Fix:
  Added type guard in ValueSetter.tsx line 536-538 to ensure the value passed to NumberInput is always a number:
  const numericValue = typeof value === 'number' ? value : 0;
  const displayValue = isPercentage ? numericValue * 100 : numericValue;

  This prevents non-numeric values from reaching the NumberInput/NumericFormat component.