### PR TITLE
Add fallback logic to correctly filter region for society-wide calculations

### DIFF
--- a/app/src/libs/calculations/CalcOrchestrator.ts
+++ b/app/src/libs/calculations/CalcOrchestrator.ts
@@ -315,8 +315,10 @@ export class CalcOrchestrator {
     } else {
       const geography = config.populations.geography1;
       // geographyId now contains the FULL prefixed value like "constituency/Sheffield Central"
+      // For region parameter, prioritize: geography.geographyId → sim1.populationId → countryId
+      // This ensures we use the stored populationId from the simulation if geography is not in config
       populationId = geography?.geographyId || sim1.populationId || config.countryId;
-      region = geography?.geographyId || config.countryId;
+      region = geography?.geographyId || sim1.populationId || config.countryId;
     }
 
     const calcType = populationType === 'household' ? 'household' : 'societyWide';


### PR DESCRIPTION
## Problem

  Economy-wide reports for US states incorrectly calculated using national data instead of region-specific data.

  Example: Montana CTC reform showed $13B (entire US) instead of $48M (Montana only).

 ## Root Cause

  In CalcOrchestrator.ts:319, the region parameter had incomplete fallback logic:

  // BEFORE (BUG):
  region = geography?.geographyId || config.countryId;

  Issue: During report calculation, if geography?.geographyId is undefined or empty (due to race conditions during async data loading or when the geography object isn't passed in config), it falls back directly to config.countryId ("us"), causing the API to calculate for the entire country instead of the specific region.

  API call: /us/economy/{reform}/over/{baseline}?region=us (should be ?region=mt)

 ## Solution

  Add sim1.populationId as fallback before config.countryId:

  // AFTER (FIX):
  region = geography?.geographyId || sim1.populationId || config.countryId;

  The simulation object always contains the correct populationId from the database, making it a reliable fallback when the geography object is unavailable or incomplete.


