### PR TITLE
MTR chart incorrectly summing across people instead of using first person

### DIFF
--- a/app/src/pages/report-output/marginal-tax-rates/MarginalTaxRatesSubPage.tsx
+++ b/app/src/pages/report-output/marginal-tax-rates/MarginalTaxRatesSubPage.tsx
@@ -134,17 +134,42 @@ export default function MarginalTaxRatesSubPage({
   }
 
   // Get MTR data (401-point arrays)
+  // Use first person's MTR (matches V1 behavior) - MTR should not be aggregated across people
+  const firstPersonName = Object.keys(baselineVariation.householdData?.people || {})[0];
+
+  console.log('[MTR DEBUG] First person name:', firstPersonName);
+  console.log(
+    '[MTR DEBUG] People in household:',
+    Object.keys(baselineVariation.householdData?.people || {})
+  );
 
   const baselineMTR = getValueFromHousehold(
     'marginal_tax_rate',
     CURRENT_YEAR,
-    null,
+    firstPersonName,
     baselineVariation,
     metadata
   );
+
+  console.log(
+    '[MTR DEBUG] Baseline MTR type:',
+    typeof baselineMTR,
+    'isArray:',
+    Array.isArray(baselineMTR)
+  );
+  console.log(
+    '[MTR DEBUG] Baseline MTR sample values:',
+    Array.isArray(baselineMTR) ? baselineMTR.slice(0, 5) : baselineMTR
+  );
   const reformMTR =
     reform && reformVariation
-      ? getValueFromHousehold('marginal_tax_rate', CURRENT_YEAR, null, reformVariation, metadata)
+      ? getValueFromHousehold(
+          'marginal_tax_rate',
+          CURRENT_YEAR,
+          firstPersonName,
+          reformVariation,
+          metadata
+        )
       : null;
 
   if (!Array.isArray(baselineMTR)) {
@@ -161,20 +186,22 @@ export default function MarginalTaxRatesSubPage({
   const baselineMTRClipped = clipMTR(baselineMTR);
   const reformMTRClipped = reformMTR ? clipMTR(reformMTR as number[]) : null;
 
-  // Get current earnings for marker
+  // Get current earnings for marker (first person only)
+  const firstPersonNameBaseline = Object.keys(baseline.householdData?.people || {})[0];
+
   const currentEarnings = getValueFromHousehold(
     'employment_income',
     CURRENT_YEAR,
-    null,
+    firstPersonNameBaseline,
     baseline,
     metadata
   ) as number;
 
-  // Get current MTR
+  // Get current MTR (first person only)
   const currentMTR = getValueFromHousehold(
     'marginal_tax_rate',
     CURRENT_YEAR,
-    null,
+    firstPersonNameBaseline,
     baseline,
     metadata
   ) as number;


### PR DESCRIPTION
  Bug: Marginal Tax Rates chart showed doubled values (e.g., 135% instead of ~69%) for multi-adult households.

  Root Cause: MarginalTaxRatesSubPage.tsx called getValueFromHousehold() with entityName=null, causing it to sum MTR across all people. MTR should not be aggregated - each
  person has their own rate.

  Fix: Changed all MTR calculations to use first person's name (dynamically determined) instead of null, matching V1 behavior.

  Verification: Tested with household 56391 (2 adults, 2 children, MT). V2 now shows 69.6% vs V1's 69.3% (acceptable rounding difference), down from buggy 135%.

  Impact: No other charts affected - earnings variation already excludes MTR, other variables sum correctly across people.