### PR TITLE
fix: use routes with filesystem handler for proper SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,8 +8,9 @@
       "runtime": "@vercel/node@3"
     }
   },
-  "rewrites": [
-    { "source": "/api/(.*)", "destination": "/app/api/$1" },
-    { "source": "/(.*)", "destination": "/index.html" }
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/app/api/$1" },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- **CRITICAL FIX**: Production site was broken due to incorrect rewrites configuration
- Changes `rewrites` to `routes` with `"handle": "filesystem"` 
- This tells Vercel to first try serving actual files, then fallback to index.html for SPA routing

## Problem
The previous configuration broke direct URL access and page refreshes, showing 404 NOT_FOUND.

## Solution
Using Vercel's routes with filesystem handler ensures:
1. Static files (JS, CSS, images) are served directly
2. API routes go to serverless functions  
3. All other routes fallback to index.html for client-side routing

## Test plan
- [ ] Direct URL access to `/uk/research/uk-income-tax-ni-reforms-2025` works
- [ ] Page refresh on any route returns the app
- [ ] API endpoint `/api/og` still works
- [ ] Static assets load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)