### PR TITLE
test: add vercel.json config validation tests

### DIFF
--- a/app/src/tests/unit/config/vercel.test.ts
+++ b/app/src/tests/unit/config/vercel.test.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, expect, test } from 'vitest';
+
+/**
+ * These tests validate that vercel.json is configured correctly for SPA routing.
+ *
+ * The vercel.json file must have a rewrite rule that sends all requests to the
+ * root index.html, allowing React Router to handle client-side routing.
+ *
+ * Without this configuration, direct URL access or page refreshes on sub-routes
+ * (e.g., /us/research/some-article) will return 404 errors because Vercel
+ * looks for a matching file instead of serving the SPA.
+ */
+describe('vercel.json configuration', () => {
+  const vercelJsonPath = path.resolve(__dirname, '../../../../vercel.json');
+
+  test('given vercel.json exists then file is present', () => {
+    // When
+    const exists = fs.existsSync(vercelJsonPath);
+
+    // Then
+    expect(exists).toBe(true);
+  });
+
+  test('given vercel.json then contains valid JSON', () => {
+    // Given
+    const content = fs.readFileSync(vercelJsonPath, 'utf-8');
+
+    // When
+    const parseJson = () => JSON.parse(content);
+
+    // Then
+    expect(parseJson).not.toThrow();
+  });
+
+  test('given vercel.json then has rewrites array', () => {
+    // Given
+    const content = fs.readFileSync(vercelJsonPath, 'utf-8');
+    const config = JSON.parse(content);
+
+    // Then
+    expect(config).toHaveProperty('rewrites');
+    expect(Array.isArray(config.rewrites)).toBe(true);
+    expect(config.rewrites.length).toBeGreaterThan(0);
+  });
+
+  test('given vercel.json rewrites then has SPA fallback rule', () => {
+    // Given
+    const content = fs.readFileSync(vercelJsonPath, 'utf-8');
+    const config = JSON.parse(content);
+
+    // When - Find the catch-all SPA routing rule
+    const spaRewrite = config.rewrites.find(
+      (rule: { source: string; destination: string }) =>
+        rule.source === '/(.*)' && rule.destination === '/'
+    );
+
+    // Then - Must have the SPA fallback rule
+    expect(spaRewrite).toBeDefined();
+    expect(spaRewrite.source).toBe('/(.*)');
+    expect(spaRewrite.destination).toBe('/');
+  });
+
+  test('given vercel.json then does NOT have routes array (use rewrites for SPA)', () => {
+    // Given
+    const content = fs.readFileSync(vercelJsonPath, 'utf-8');
+    const config = JSON.parse(content);
+
+    // Then - routes array breaks SPA routing when combined with rewrites
+    expect(config.routes).toBeUndefined();
+  });
+
+  test('given root vercel.json then does NOT exist (app/vercel.json is canonical)', () => {
+    // Given - Root vercel.json caused 404 errors by overriding app/vercel.json
+    const rootVercelJsonPath = path.resolve(__dirname, '../../../../../vercel.json');
+
+    // When
+    const exists = fs.existsSync(rootVercelJsonPath);
+
+    // Then
+    expect(exists).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Add tests that validate `app/vercel.json` is correctly configured for SPA routing.

## What broke and why

When implementing social preview support (OG tags), I added a root `vercel.json` to configure API functions. This broke the entire site with 404 errors on all routes because:

1. **Root vercel.json overrides app/vercel.json** - Vercel uses the config file closest to the project root, so my new root config took precedence over the working `app/vercel.json`

2. **Wrong routing config** - I tried various approaches (`rewrites`, `routes` with `handle: filesystem`) but none worked correctly because:
   - The original working config used `{ "source": "/(.*)", "destination": "/" }` in `app/vercel.json`
   - My root config used different patterns and paths that didn't match the outputDirectory setup

3. **SPA routing requires specific config** - For React Router to handle client-side routes, all requests must be rewritten to serve `index.html`. Without this, direct URL access (e.g., refreshing `/uk/research/some-article`) returns 404 because Vercel looks for a literal file at that path.

## Timeline of the incident

| Commit/PR | Description | Impact |
|-----------|-------------|--------|
| [1113ee30](https://github.com/PolicyEngine/policyengine-app-v2/commit/1113ee30) | Added root `vercel.json` to enable API functions | 🔴 Broke all routes with 404 |
| [0db14439](https://github.com/PolicyEngine/policyengine-app-v2/commit/0db14439) | Attempted fix: changed rewrite to serve index.html | 🔴 Still broken |
| [#437](https://github.com/PolicyEngine/policyengine-app-v2/pull/437) | Attempted fix: switched to `routes` with filesystem handler | 🔴 Still broken |
| [#438](https://github.com/PolicyEngine/policyengine-app-v2/pull/438) | **Fix**: Removed root vercel.json, restored app/vercel.json | ✅ Site working |

## What these tests catch

These tests would have **immediately failed** when the root `vercel.json` was added:

```
✗ given root vercel.json then does NOT exist (app/vercel.json is canonical)
```

And would have caught incorrect rewrite configurations:

```
✗ given vercel.json rewrites then has SPA fallback rule
  Expected: { source: "/(.*)", destination: "/" }
```

## Tests added
1. Verifies `app/vercel.json` exists
2. Verifies it contains valid JSON
3. Verifies it has `rewrites` array
4. Verifies it has the SPA fallback rule `{ source: "/(.*)", destination: "/" }`
5. Verifies no `routes` array (which breaks SPA routing when combined with rewrites)
6. Verifies no root `vercel.json` exists (which caused 404 errors)

## Test plan
- [x] Tests pass locally
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)