### PR TITLE
fix: remove unused Run Again and Share buttons from report output page

### DIFF
--- a/app/src/pages/report-output/ReportOutputLayout.tsx
+++ b/app/src/pages/report-output/ReportOutputLayout.tsx
@@ -3,21 +3,9 @@ import {
   IconChevronLeft,
   IconClock,
   IconPencil,
-  IconRefresh,
-  IconShare,
   IconStack2,
 } from '@tabler/icons-react';
-import {
-  ActionIcon,
-  Anchor,
-  Box,
-  Button,
-  Container,
-  Group,
-  Stack,
-  Text,
-  Title,
-} from '@mantine/core';
+import { ActionIcon, Anchor, Box, Container, Group, Stack, Text, Title } from '@mantine/core';
 import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import { getComparativeAnalysisTree } from './comparativeAnalysisTree';
@@ -32,8 +20,6 @@ interface ReportOutputLayoutProps {
   tabs: Array<{ value: string; label: string }>;
   activeTab: string;
   onTabChange: (tabValue: string) => void;
-  onRunAgain?: () => void;
-  onShare?: () => void;
   onEditName?: () => void;
   showSidebar?: boolean;
   outputType?: 'household' | 'societyWide';
@@ -61,8 +47,6 @@ export default function ReportOutputLayout({
   tabs,
   activeTab,
   onTabChange,
-  onRunAgain,
-  onShare,
   onEditName,
   showSidebar = false,
   outputType = 'societyWide',
@@ -88,50 +72,25 @@ export default function ReportOutputLayout({
 
         {/* Header Section */}
         <Box>
-          {/* Title row with actions */}
-          <Group justify="space-between" align="flex-start" mb={spacing.xs}>
-            <Group gap={spacing.xs} align="center">
-              <Title
-                order={1}
-                variant="colored"
-                fw={typography.fontWeight.semibold}
-                fz={typography.fontSize['3xl']}
-              >
-                {reportLabel || reportId}
-              </Title>
-              <ActionIcon
-                variant="subtle"
-                color="gray"
-                size="lg"
-                aria-label="Edit report name"
-                onClick={onEditName}
-              >
-                <IconPencil size={18} />
-              </ActionIcon>
-            </Group>
-
-            <Group gap={spacing.sm}>
-              <Button
-                variant="filled"
-                leftSection={<IconRefresh size={18} />}
-                bg={colors.warning}
-                c={colors.black}
-                styles={{
-                  root: {
-                    '&:hover': {
-                      backgroundColor: colors.warning,
-                      filter: 'brightness(0.95)',
-                    },
-                  },
-                }}
-                onClick={onRunAgain}
-              >
-                Run Again
-              </Button>
-              <Button variant="default" leftSection={<IconShare size={18} />} onClick={onShare}>
-                Share
-              </Button>
-            </Group>
+          {/* Title row with edit action */}
+          <Group gap={spacing.xs} align="center" mb={spacing.xs}>
+            <Title
+              order={1}
+              variant="colored"
+              fw={typography.fontWeight.semibold}
+              fz={typography.fontSize['3xl']}
+            >
+              {reportLabel || reportId}
+            </Title>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size="lg"
+              aria-label="Edit report name"
+              onClick={onEditName}
+            >
+              <IconPencil size={18} />
+            </ActionIcon>
           </Group>
 
           {/* Timestamp and View All */}


### PR DESCRIPTION
## Summary

- Removed the "Run Again" button from the report output header
- Removed the "Share" button from the report output header
- Simplified the header layout now that the action buttons are gone
- Removed unused icon imports (IconRefresh, IconShare)
- Removed unused `onRunAgain` and `onShare` props from the component interface

Note: The "Back" navigation and "View All" link were marked as "may include" in the issue, so keeping those for now unless separate direction is given.

Fixes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)