### PR TITLE
fix: remove debug console.log from PolicyParameterSelectorValueSetter

### DIFF
--- a/app/src/pathways/report/components/PolicyParameterSelectorValueSetter.tsx
+++ b/app/src/pathways/report/components/PolicyParameterSelectorValueSetter.tsx
@@ -77,10 +77,6 @@ export default function PolicyParameterSelectorValueSetter({
     const newValues = paramCollection.getIntervals();
     existingParam.values = newValues;
 
-    console.log('[PolicyParameterSelectorValueSetter] Updated policy:', updatedPolicy);
-    console.log('[PolicyParameterSelectorValueSetter] Parameter:', param.parameter);
-    console.log('[PolicyParameterSelectorValueSetter] New intervals:', newValues);
-
     // Notify parent of policy update
     onPolicyUpdate(updatedPolicy);
 


### PR DESCRIPTION
## Summary

Remove 3 debug console.log statements from PolicyParameterSelectorValueSetter that were logging policy updates during parameter setting.

Part of ongoing code cleanup to reduce debug logging in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)