### PR TITLE
Add mansion tax to Autumn Budget banner

### DIFF
--- a/app/api/posts.json
+++ b/app/api/posts.json
@@ -6,7 +6,9 @@
     "tags": [
       "uk",
       "policy",
-      "tax"
+      "tax",
+      "autumn-budget",
+      "featured"
     ],
     "authors": [
       "daphne-hansell"

--- a/app/public/data/posts.json
+++ b/app/public/data/posts.json
@@ -6,7 +6,9 @@
     "tags": [
       "uk",
       "policy",
-      "tax"
+      "tax",
+      "autumn-budget",
+      "featured"
     ],
     "authors": [
       "daphne-hansell"

--- a/app/src/api/householdCalculation.ts
+++ b/app/src/api/householdCalculation.ts
@@ -12,13 +12,7 @@ export async function fetchHouseholdCalculation(
   householdId: string,
   policyId: string
 ): Promise<HouseholdData> {
-  console.log('[fetchHouseholdCalculation] Called with:');
-  console.log('  - countryId:', countryId);
-  console.log('  - householdId:', householdId);
-  console.log('  - policyId:', policyId);
-
   const url = `${BASE_URL}/${countryId}/household/${householdId}/policy/${policyId}`;
-  console.log('[fetchHouseholdCalculation] Fetching URL:', url);
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 240000); // 4-minute timeout
@@ -32,44 +26,26 @@ export async function fetchHouseholdCalculation(
     });
 
     clearTimeout(timeoutId);
-    console.log(
-      '[fetchHouseholdCalculation] Response status:',
-      response.status,
-      response.statusText
-    );
 
     if (!response.ok) {
-      console.error(
-        '[fetchHouseholdCalculation] Failed with status:',
-        response.status,
-        response.statusText
-      );
       throw new Error(`Household calculation failed: ${response.statusText}`);
     }
 
     const data: HouseholdCalculationResponse = await response.json();
-    console.log('[fetchHouseholdCalculation] Response data:');
-    console.log('  - status:', data.status);
-    console.log('  - has result?', !!data.result);
-    console.log('  - error:', data.error);
 
     if (data.status === 'error' || !data.result) {
-      console.error('[fetchHouseholdCalculation] Calculation error:', data.error);
       throw new Error(data.error || 'Household calculation failed');
     }
 
-    console.log('[fetchHouseholdCalculation] Returning successful result');
     return data.result;
   } catch (error) {
     clearTimeout(timeoutId);
 
     // Check if it's a timeout error
     if (error instanceof Error && error.name === 'AbortError') {
-      console.error('[fetchHouseholdCalculation] Request timed out');
       throw new Error('Household calculation timed out after 50 seconds (client-side timeout)');
     }
 
-    console.error('[fetchHouseholdCalculation] Error occurred:', error);
     throw error;
   }
 }

--- a/app/src/components/shared/AutumnBudgetBanner.tsx
+++ b/app/src/components/shared/AutumnBudgetBanner.tsx
@@ -233,8 +233,8 @@ export default function AutumnBudgetBanner() {
               target="_blank"
               rel="noopener noreferrer"
               style={{
-                flex: '1 1 280px',
-                maxWidth: '320px',
+                flex: '1 1 220px',
+                maxWidth: '260px',
                 minHeight: '80px',
                 backgroundColor: 'rgba(255, 255, 255, 0.95)',
                 borderRadius: '12px',
@@ -286,8 +286,8 @@ export default function AutumnBudgetBanner() {
               target="_blank"
               rel="noopener noreferrer"
               style={{
-                flex: '1 1 280px',
-                maxWidth: '320px',
+                flex: '1 1 220px',
+                maxWidth: '260px',
                 minHeight: '80px',
                 backgroundColor: 'rgba(255, 255, 255, 0.95)',
                 borderRadius: '12px',
@@ -339,8 +339,8 @@ export default function AutumnBudgetBanner() {
               target="_blank"
               rel="noopener noreferrer"
               style={{
-                flex: '1 1 280px',
-                maxWidth: '320px',
+                flex: '1 1 220px',
+                maxWidth: '260px',
                 minHeight: '80px',
                 backgroundColor: 'rgba(255, 255, 255, 0.95)',
                 borderRadius: '12px',
@@ -381,6 +381,59 @@ export default function AutumnBudgetBanner() {
                   style={{ lineHeight: 1.4 }}
                 >
                   Analysis of alternative tax reform options
+                </Text>
+              </Box>
+            </Card>
+
+            {/* Card 4: Mansion Tax */}
+            <Card
+              component="a"
+              href="/uk/research/uk-mansion-tax-autumn-budget"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                flex: '1 1 220px',
+                maxWidth: '260px',
+                minHeight: '80px',
+                backgroundColor: 'rgba(255, 255, 255, 0.95)',
+                borderRadius: '12px',
+                padding: spacing.md,
+                cursor: 'pointer',
+                transition: 'all 0.3s ease',
+                textDecoration: 'none',
+                border: `2px solid ${colors.white}`,
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+              }}
+              styles={{
+                root: {
+                  '&:hover': {
+                    transform: 'translateY(-4px)',
+                    boxShadow: '0 12px 24px rgba(0, 0, 0, 0.2)',
+                  },
+                },
+              }}
+            >
+              <Box
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  height: '100%',
+                }}
+              >
+                <Text
+                  size={typography.fontSize.base}
+                  fw={typography.fontWeight.bold}
+                  c={colors.primary[700]}
+                  mb={spacing.xs}
+                >
+                  Mansion tax
+                </Text>
+                <Text
+                  size={typography.fontSize.xs}
+                  c={colors.gray[700]}
+                  style={{ lineHeight: 1.4 }}
+                >
+                  Constituency distribution of high-value property sales
                 </Text>
               </Box>
             </Card>

--- a/app/src/data/posts/posts.json
+++ b/app/src/data/posts/posts.json
@@ -6,7 +6,9 @@
     "tags": [
       "uk",
       "policy",
-      "tax"
+      "tax",
+      "autumn-budget",
+      "featured"
     ],
     "authors": [
       "daphne-hansell"


### PR DESCRIPTION
## Summary
- Adds mansion tax as 4th card in Pre-autumn budget analysis section of the Autumn Budget banner
- Reduces card widths from 320px to 260px to better accommodate 4 cards
- Adds 'autumn budget' tag label for display

## Test plan
- [x] Verify banner displays correctly with 4 cards
- [x] Verify mansion tax card links to correct research article
- [x] Verify cards are appropriately sized

🤖 Generated with [Claude Code](https://claude.com/claude-code)