### PR TITLE
Remove trailing spaces from button labels

### DIFF
--- a/app/src/pathways/report/views/ReportSetupView.tsx
+++ b/app/src/pathways/report/views/ReportSetupView.tsx
@@ -111,7 +111,7 @@ export default function ReportSetupView({
     // Allow setting up simulation1 if selected and not configured
     if (selectedCard === 'simulation1' && !simulation1Configured) {
       return {
-        label: 'Configure baseline simulation ',
+        label: 'Configure baseline simulation',
         onClick: handleNext,
         isDisabled: false,
       };
@@ -119,7 +119,7 @@ export default function ReportSetupView({
     // Allow setting up simulation2 if selected and not configured
     else if (selectedCard === 'simulation2' && !simulation2Configured) {
       return {
-        label: 'Configure comparison simulation ',
+        label: 'Configure comparison simulation',
         onClick: handleNext,
         isDisabled: !isPopulationDataLoaded, // Disable if data not loaded
       };
@@ -127,14 +127,14 @@ export default function ReportSetupView({
     // Allow proceeding if requirements met
     else if (canProceed) {
       return {
-        label: 'Review report ',
+        label: 'Review report',
         onClick: handleNext,
         isDisabled: false,
       };
     }
     // Disable if requirements not met - show uppermost option (baseline)
     return {
-      label: 'Configure baseline simulation ',
+      label: 'Configure baseline simulation',
       onClick: handleNext,
       isDisabled: true,
     };

--- a/app/src/pathways/report/views/ReportSimulationExistingView.tsx
+++ b/app/src/pathways/report/views/ReportSimulationExistingView.tsx
@@ -178,7 +178,7 @@ export default function ReportSimulationExistingView({
   });
 
   const primaryAction = {
-    label: 'Next ',
+    label: 'Next',
     onClick: handleSubmit,
     isDisabled: !canProceed(),
   };

--- a/app/src/pathways/report/views/policy/PolicyExistingView.tsx
+++ b/app/src/pathways/report/views/policy/PolicyExistingView.tsx
@@ -195,7 +195,7 @@ export default function PolicyExistingView({
   });
 
   const primaryAction = {
-    label: 'Next ',
+    label: 'Next',
     onClick: handleSubmit,
     isDisabled: !canProceed(),
   };

--- a/app/src/pathways/report/views/population/GeographicConfirmationView.tsx
+++ b/app/src/pathways/report/views/population/GeographicConfirmationView.tsx
@@ -108,7 +108,7 @@ export default function GeographicConfirmationView({
   };
 
   const primaryAction = {
-    label: 'Create household collection ',
+    label: 'Create household collection',
     onClick: handleSubmit,
     isLoading: isPending,
   };

--- a/app/src/pathways/report/views/population/HouseholdBuilderView.tsx
+++ b/app/src/pathways/report/views/population/HouseholdBuilderView.tsx
@@ -547,7 +547,7 @@ export default function HouseholdBuilderView({
   const canProceed = validation.isValid;
 
   const primaryAction = {
-    label: 'Create household ',
+    label: 'Create household',
     onClick: handleSubmit,
     isLoading: isPending,
     isDisabled: !canProceed,

--- a/app/src/pathways/report/views/population/PopulationExistingView.tsx
+++ b/app/src/pathways/report/views/population/PopulationExistingView.tsx
@@ -326,7 +326,7 @@ export default function PopulationExistingView({
   const cardListItems = [...householdCardItems, ...geographicCardItems];
 
   const primaryAction = {
-    label: 'Next ',
+    label: 'Next',
     onClick: handleSubmit,
     isDisabled: !canProceed(),
   };

--- a/app/src/pathways/report/views/population/PopulationScopeView.tsx
+++ b/app/src/pathways/report/views/population/PopulationScopeView.tsx
@@ -89,7 +89,7 @@ export default function PopulationScopeView({
   );
 
   const primaryAction = {
-    label: 'Select scope ',
+    label: 'Select scope',
     onClick: submissionHandler,
   };
 

--- a/app/src/pathways/report/views/simulation/SimulationPolicySetupView.tsx
+++ b/app/src/pathways/report/views/simulation/SimulationPolicySetupView.tsx
@@ -87,7 +87,7 @@ export default function SimulationPolicySetupView({
   ];
 
   const primaryAction = {
-    label: 'Next ',
+    label: 'Next',
     onClick: handleClickSubmit,
     isDisabled: !selectedAction,
   };

--- a/app/src/pathways/report/views/simulation/SimulationPopulationSetupView.tsx
+++ b/app/src/pathways/report/views/simulation/SimulationPopulationSetupView.tsx
@@ -133,7 +133,7 @@ export default function SimulationPopulationSetupView({
   const viewSubtitle = getPopulationSelectionSubtitle(shouldLockToOtherPopulation);
 
   const primaryAction = {
-    label: 'Next ',
+    label: 'Next',
     onClick: handleClickSubmit,
     isDisabled: shouldLockToOtherPopulation ? false : !selectedAction,
   };

--- a/app/src/pathways/report/views/simulation/SimulationSetupView.tsx
+++ b/app/src/pathways/report/views/simulation/SimulationSetupView.tsx
@@ -153,26 +153,26 @@ export default function SimulationSetupView({
   const getPrimaryAction = () => {
     if (selectedCard === 'population' && !isPopulationConfigured(population)) {
       return {
-        label: 'Configure household(s) ',
+        label: 'Configure household(s)',
         onClick: handleNext,
         isDisabled: false,
       };
     } else if (selectedCard === 'policy' && !isPolicyConfigured(policy)) {
       return {
-        label: 'Configure policy ',
+        label: 'Configure policy',
         onClick: handleNext,
         isDisabled: false,
       };
     } else if (canProceed) {
       return {
-        label: 'Next ',
+        label: 'Next',
         onClick: handleNext,
         isDisabled: false,
       };
     }
     // Default disabled state - show uppermost option (household(s))
     return {
-      label: 'Configure household(s) ',
+      label: 'Configure household(s)',
       onClick: handleNext,
       isDisabled: true,
     };


### PR DESCRIPTION
## Summary
- Removes trailing spaces from 16 button labels across 10 view components
- Affected labels include "Next", "Configure baseline simulation", "Configure comparison simulation", "Review report", "Create household", "Select scope", etc.
- These trailing spaces caused minor visual inconsistencies in the UI

## Files changed
- `ReportSetupView.tsx` - 4 labels
- `ReportSimulationExistingView.tsx` - 1 label  
- `PolicyExistingView.tsx` - 1 label
- `GeographicConfirmationView.tsx` - 1 label
- `HouseholdBuilderView.tsx` - 1 label
- `PopulationExistingView.tsx` - 1 label
- `PopulationScopeView.tsx` - 1 label
- `SimulationPolicySetupView.tsx` - 1 label
- `SimulationPopulationSetupView.tsx` - 1 label
- `SimulationSetupView.tsx` - 4 labels

## Test plan
- [x] All button labels should display correctly without trailing spaces
- [x] No functional changes, purely text cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)