### PR TITLE
Make Autumn Budget banner cards open in same tab

### DIFF
--- a/app/src/components/shared/AutumnBudgetBanner.tsx
+++ b/app/src/components/shared/AutumnBudgetBanner.tsx
@@ -234,8 +234,6 @@ export default function AutumnBudgetBanner() {
             <Card
               component="a"
               href="/uk/research/uk-two-child-limit"
-              target="_blank"
-              rel="noopener noreferrer"
               style={{
                 flex: '1 1 220px',
                 maxWidth: '260px',
@@ -289,8 +287,6 @@ export default function AutumnBudgetBanner() {
             <Card
               component="a"
               href="/uk/research/high-value-council-tax-surcharge"
-              target="_blank"
-              rel="noopener noreferrer"
               style={{
                 flex: '1 1 220px',
                 maxWidth: '260px',
@@ -344,8 +340,6 @@ export default function AutumnBudgetBanner() {
             <Card
               component="a"
               href="/uk/research/fuel-duty-freeze-2025"
-              target="_blank"
-              rel="noopener noreferrer"
               style={{
                 flex: '1 1 220px',
                 maxWidth: '260px',
@@ -399,8 +393,6 @@ export default function AutumnBudgetBanner() {
             <Card
               component="a"
               href="/uk/research/obr-november-2025-projections"
-              target="_blank"
-              rel="noopener noreferrer"
               style={{
                 flex: '1 1 220px',
                 maxWidth: '260px',

--- a/app/src/tests/unit/components/shared/AutumnBudgetBanner.test.tsx
+++ b/app/src/tests/unit/components/shared/AutumnBudgetBanner.test.tsx
@@ -107,7 +107,7 @@ describe('AutumnBudgetBanner', () => {
     expect(obrLink).toHaveAttribute('href', BANNER_LINKS.OBR_FORECAST);
   });
 
-  test('given analysis card links then open in new tab', () => {
+  test('given analysis card links then open in same tab', () => {
     // Given
     vi.setSystemTime(MOCK_DATE_AFTER_BUDGET);
 
@@ -116,8 +116,7 @@ describe('AutumnBudgetBanner', () => {
 
     // Then
     const twoChildLink = screen.getByText(BANNER_CARD_TITLES.TWO_CHILD_LIMIT).closest('a');
-    expect(twoChildLink).toHaveAttribute('target', '_blank');
-    expect(twoChildLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(twoChildLink).not.toHaveAttribute('target', '_blank');
   });
 
   test('given contact CTA then displays with correct email link', () => {


### PR DESCRIPTION
## Summary
- Remove `target="_blank"` and `rel="noopener noreferrer"` from the four analysis card links in the Autumn Budget banner
- Cards now navigate within the app instead of opening new tabs

## Test plan
- [ ] Verify banner cards link to correct pages
- [ ] Verify clicking cards stays in same tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)