### PR TITLE
Add SPM Threshold Calculator to apps

### DIFF
--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -1,6 +1,15 @@
 [
   {
     "type": "iframe",
+    "slug": "spm-calculator",
+    "title": "SPM Threshold Calculator",
+    "description": "Calculate Supplemental Poverty Measure thresholds for any US geography, family composition, and year",
+    "source": "https://policyengine.github.io/spm-calculator/",
+    "tags": ["us", "featured", "policy", "poverty"],
+    "countryId": "us"
+  },
+  {
+    "type": "iframe",
     "slug": "uk-autumn-budget-2025",
     "title": "UK Autumn Budget 2025 analysis dashboard",
     "description": "Interactive tool to explore revenue and distributional impacts of UK Autumn Budget 2025 policies across income deciles, constituencies, and household types",

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
-- bump: minor
+- bump: patch
   changes:
     added:
-      - Blog post comparing OBR March 2025 and November 2025 economic projections with interactive chart
+      - SPM Threshold Calculator app embedding for US country pages


### PR DESCRIPTION
## Summary

Adds the SPM Threshold Calculator (https://policyengine.github.io/spm-calculator/) as an embedded iframe app for US country pages.

The calculator allows users to:
- Calculate Supplemental Poverty Measure thresholds for any family composition
- Adjust for geographic cost of living using the GEOADJ factor
- View historical thresholds (2015-2024) and forecasted thresholds (2025-2030)
- Understand the Consumer Expenditure Survey methodology with interactive explanations

**URL pattern:** `/us/spm-calculator`

## Test plan

- [ ] Verify the app loads correctly at `/us/spm-calculator`
- [ ] Confirm the iframe displays the SPM calculator UI
- [ ] Check that the PolicyEngine header bar appears above the embedded content

🤖 Generated with [Claude Code](https://claude.com/claude-code)