### PR TITLE
Fix autumn budget 2025 app URL slug

### DIFF
--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "iframe",
-    "slug": "uk-autumn-budget-2025",
+    "slug": "autumn-budget-2025",
     "title": "UK Autumn Budget 2025 analysis dashboard",
     "description": "Interactive tool to explore revenue and distributional impacts of UK Autumn Budget 2025 policies across income deciles, constituencies, and household types",
     "source": "https://uk-autumn-budget-dashboard.vercel.app/",


### PR DESCRIPTION
## Summary
- Remove 'uk-' prefix from the autumn budget 2025 app slug
- Fixes URL from `/uk/uk-autumn-budget-2025` to `/uk/autumn-budget-2025`

## Test plan
- [ ] Verify `/uk/autumn-budget-2025` loads the autumn budget dashboard
- [ ] Verify the app still appears in the research/apps listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)