### PR TITLE
fix: Update push workflow for monorepo structure

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -20,25 +20,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: app/package-lock.json
-      
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
       - name: Install dependencies
-        run: cd app && npm ci
-      
-      - name: Build
-        run: cd app && npm run build-with-types
+        run: npm ci
+
+      - name: Build design system
+        run: npm run design-system:build
+
+      - name: Build app
+        working-directory: ./app
+        run: npm run build-with-types
         env:
           BASE_URL: /${{ github.event.repository.name }}/
-      
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- Run `npm ci` from root instead of app/ to enable npm workspaces
- Build design-system before app build
- Update Node.js to v24 (matching pr.yaml)
- Use root package-lock.json for caching

Fixes the Push workflow failure after #494 merge.