### PR TITLE
Add GiveCalc banner for year-end giving

### DIFF
--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation } from 'react-router-dom';
 import { AppShell } from '@mantine/core';
 import { spacing } from '@/designTokens';
 import { cacheMonitor } from '@/utils/cacheMonitor';
+import GiveCalcBanner from './shared/GiveCalcBanner';
 import HeaderNavigation from './shared/HomeHeader';
 import LegacyBanner from './shared/LegacyBanner';
 import Sidebar from './Sidebar';
@@ -34,6 +35,7 @@ export default function Layout() {
     >
       <AppShell.Header p={0}>
         <HeaderNavigation />
+        <GiveCalcBanner />
         <LegacyBanner />
       </AppShell.Header>
 

--- a/app/src/components/StandardLayout.tsx
+++ b/app/src/components/StandardLayout.tsx
@@ -11,6 +11,7 @@
 import { AppShell } from '@mantine/core';
 import { LayoutProvider, useIsInsideLayout } from '@/contexts/LayoutContext';
 import { spacing } from '@/designTokens';
+import GiveCalcBanner from './shared/GiveCalcBanner';
 import HeaderNavigation from './shared/HomeHeader';
 import LegacyBanner from './shared/LegacyBanner';
 import Sidebar from './Sidebar';
@@ -40,6 +41,7 @@ export default function StandardLayout({ children }: StandardLayoutProps) {
       >
         <AppShell.Header p={0}>
           <HeaderNavigation />
+          <GiveCalcBanner />
           <LegacyBanner />
         </AppShell.Header>
 

--- a/app/src/components/StaticLayout.tsx
+++ b/app/src/components/StaticLayout.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from 'react-router-dom';
 import Footer from '@/components/Footer';
+import GiveCalcBanner from '@/components/shared/GiveCalcBanner';
 import HeaderNavigation from '@/components/shared/HomeHeader';
 import LegacyBanner from '@/components/shared/LegacyBanner';
 
@@ -7,6 +8,7 @@ export default function StaticLayout() {
   return (
     <>
       <HeaderNavigation />
+      <GiveCalcBanner />
       <LegacyBanner />
       <Outlet />
       <Footer />

--- a/app/src/components/shared/GiveCalcBanner.tsx
+++ b/app/src/components/shared/GiveCalcBanner.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { Alert, Anchor } from '@mantine/core';
+import { colors, spacing, typography } from '@/designTokens';
+import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+
+const BANNER_DISMISSED_KEY = 'givecalc-banner-dismissed';
+
+/**
+ * Banner promoting GiveCalc for year-end giving
+ * Only shows for US users on December 31, 2025
+ */
+export default function GiveCalcBanner() {
+  const countryId = useCurrentCountry();
+  const [visible, setVisible] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return sessionStorage.getItem(BANNER_DISMISSED_KEY) !== 'true';
+    }
+    return true;
+  });
+
+  // Only show for US users on December 31, 2025
+  const currentDate = new Date();
+  const isLastDay =
+    currentDate.getFullYear() === 2025 &&
+    currentDate.getMonth() === 11 && // December is month 11
+    currentDate.getDate() === 31;
+
+  if (countryId !== 'us' || !visible || !isLastDay) {
+    return null;
+  }
+
+  const handleClose = () => {
+    setVisible(false);
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem(BANNER_DISMISSED_KEY, 'true');
+    }
+  };
+
+  return (
+    <Alert
+      withCloseButton
+      closeButtonLabel="Dismiss banner"
+      onClose={handleClose}
+      styles={{
+        root: {
+          backgroundColor: '#fef3c7',
+          borderBottom: `1px solid #fcd34d`,
+          borderRadius: 0,
+          padding: `${spacing.sm} ${spacing.md}`,
+          fontFamily: typography.fontFamily.primary,
+        },
+        message: {
+          textAlign: 'center',
+          fontSize: '14px',
+          color: colors.gray[800],
+        },
+      }}
+    >
+      Last day to make tax-deductible donations in 2025! See how much your giving saves on taxes at{' '}
+      <Anchor
+        href="https://givecalc.org"
+        target="_blank"
+        rel="noopener noreferrer"
+        size="sm"
+        style={{
+          color: colors.primary[700],
+          fontWeight: typography.fontWeight.semibold,
+          textDecoration: 'underline',
+        }}
+      >
+        GiveCalc.org
+      </Anchor>
+    </Alert>
+  );
+}


### PR DESCRIPTION
## Summary
- Add yellow banner promoting GiveCalc.org for year-end tax-deductible donations
- Only displays for US users on December 31, 2025
- Dismissible (stored in session storage)

## Test plan
- [ ] Verify banner appears on /us pages on Dec 31
- [ ] Verify banner doesn't appear on /uk pages
- [ ] Verify dismiss functionality works
- [ ] Verify link to givecalc.org works

🤖 Generated with [Claude Code](https://claude.com/claude-code)