### PR TITLE
Update SALTernative to use new React frontend

### DIFF
--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -133,7 +133,7 @@
     "slug": "salternative",
     "title": "The SALTernative",
     "description": "SALT deduction and AMT calculator",
-    "source": "https://salt-amt-calculator-578039519715.us-central1.run.app/?embedded=true",
+    "source": "https://policyengine.github.io/salt-amt-calculator/",
     "tags": ["us", "policy"],
     "countryId": "us"
   },

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
-- bump: minor
+- bump: patch
   changes:
-    added:
-      - Add UK local areas dashboard to research section
+    changed:
+      - Update SALTernative app to use new React frontend on GitHub Pages


### PR DESCRIPTION
## Summary
- Switch SALTernative app from Cloud Run Streamlit app to new React frontend on GitHub Pages
- New URL: https://policyengine.github.io/salt-amt-calculator/

## Test plan
- [ ] Verify salternative loads at policyengine.org/us/salternative after deploy
- [ ] Check that the React app renders correctly in iframe

---
Generated with [Claude Code](https://claude.com/claude-code)