### PR TITLE
Nav links from calculator header bar now correctly go to website

### DIFF
--- a/app/src/components/homeHeader/MobileMenu.tsx
+++ b/app/src/components/homeHeader/MobileMenu.tsx
@@ -54,7 +54,8 @@ export default function MobileMenu({ opened, onOpen, onClose, navItems }: Mobile
                       td="none"
                       fw={typography.fontWeight.normal}
                       size="sm"
-                      onClick={dropdownItem.onClick}
+                      href={dropdownItem.href}
+                      onClick={dropdownItem.href ? undefined : dropdownItem.onClick}
                       style={{ fontFamily: typography.fontFamily.primary }}
                     >
                       {dropdownItem.label}
@@ -71,7 +72,8 @@ export default function MobileMenu({ opened, onOpen, onClose, navItems }: Mobile
                 td="none"
                 fw={typography.fontWeight.medium}
                 size="sm"
-                onClick={item.onClick}
+                href={item.href}
+                onClick={item.href ? undefined : item.onClick}
                 style={{ fontFamily: typography.fontFamily.primary }}
                 display="block"
               >

--- a/app/src/components/homeHeader/NavItem.tsx
+++ b/app/src/components/homeHeader/NavItem.tsx
@@ -4,12 +4,18 @@ import { colors, typography } from '@/designTokens';
 
 export interface DropdownItem {
   label: string;
-  onClick: () => void;
+  /** For internal navigation (SPA) */
+  onClick?: () => void;
+  /** For external links - renders as <a> tag */
+  href?: string;
 }
 
 export interface NavItemSetup {
   label: string;
-  onClick: () => void;
+  /** For internal navigation (SPA) */
+  onClick?: () => void;
+  /** For external links - renders as <a> tag */
+  href?: string;
   hasDropdown: boolean;
   dropdownItems?: DropdownItem[];
 }
@@ -23,7 +29,7 @@ interface NavItemProps {
  * Can be either a simple link or a dropdown menu
  */
 export default function NavItem({ setup }: NavItemProps) {
-  const { label, onClick, hasDropdown, dropdownItems } = setup;
+  const { label, onClick, href, hasDropdown, dropdownItems } = setup;
 
   if (hasDropdown && dropdownItems) {
     return (
@@ -44,11 +50,17 @@ export default function NavItem({ setup }: NavItemProps) {
           </UnstyledButton>
         </Menu.Target>
         <Menu.Dropdown>
-          {dropdownItems.map((item) => (
-            <Menu.Item key={item.label} onClick={item.onClick}>
-              {item.label}
-            </Menu.Item>
-          ))}
+          {dropdownItems.map((item) =>
+            item.href ? (
+              <Menu.Item key={item.label} component="a" href={item.href}>
+                {item.label}
+              </Menu.Item>
+            ) : (
+              <Menu.Item key={item.label} onClick={item.onClick}>
+                {item.label}
+              </Menu.Item>
+            )
+          )}
         </Menu.Dropdown>
       </Menu>
     );
@@ -62,7 +74,8 @@ export default function NavItem({ setup }: NavItemProps) {
       fw={typography.fontWeight.medium}
       size="18px"
       style={{ fontFamily: typography.fontFamily.primary }}
-      onClick={onClick}
+      href={href}
+      onClick={href ? undefined : onClick}
     >
       {label}
     </Anchor>

--- a/app/src/components/shared/HomeHeader.tsx
+++ b/app/src/components/shared/HomeHeader.tsx
@@ -1,40 +1,32 @@
-import { useNavigate } from 'react-router-dom';
 import { useDisclosure } from '@mantine/hooks';
 import HeaderContent from '@/components/homeHeader/HeaderContent';
 import { NavItemSetup } from '@/components/homeHeader/NavItem';
+import { WEBSITE_URL } from '@/constants';
 import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 
 export default function HeaderNavigation() {
   const [opened, { open, close }] = useDisclosure(false);
-  const navigate = useNavigate();
   const countryId = useCurrentCountry();
 
-  const handleNavClick = (path?: string) => {
-    if (path) {
-      navigate(path);
-      close();
-    }
-  };
-
+  // Nav items link to the website (policyengine.org), not the calculator
   const navItems: NavItemSetup[] = [
     {
       label: 'Research',
-      onClick: () => handleNavClick(`/${countryId}/research`),
+      href: `${WEBSITE_URL}/${countryId}/research`,
       hasDropdown: false,
     },
     {
       label: 'About',
-      onClick: () => {}, // No-op for dropdown parent
       hasDropdown: true,
       dropdownItems: [
-        { label: 'Team', onClick: () => handleNavClick(`/${countryId}/team`) },
-        { label: 'Supporters', onClick: () => handleNavClick(`/${countryId}/supporters`) },
+        { label: 'Team', href: `${WEBSITE_URL}/${countryId}/team` },
+        { label: 'Supporters', href: `${WEBSITE_URL}/${countryId}/supporters` },
       ],
     },
     {
       label: 'Donate',
-      onClick: () => handleNavClick(`/${countryId}/donate`),
+      href: `${WEBSITE_URL}/${countryId}/donate`,
       hasDropdown: false,
     },
   ];


### PR DESCRIPTION
## Summary
- Nav links (Research, Team, Supporters, Donate) from the calculator app now correctly navigate to the website (`policyengine.org`) instead of trying to use internal SPA routing
- Added `href` support to `NavItemSetup` interface for cross-app navigation

## Problem
When on `app.policyengine.org` (calculator), clicking Research/Team/Supporters/Donate tried to navigate to routes that don't exist in the calculator app.

## Solution
- Extended `NavItem` to support `href` prop for external/cross-app links
- Updated `HomeHeader` to use `href` with `WEBSITE_URL` constant
- Follows existing pattern used by `HeaderLogo.tsx` and `ActionCards.tsx`