### PR TITLE
Fix Sidebar View research link to use WEBSITE_URL

### DIFF
--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from '@tabler/icons-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Box, Button, Stack } from '@mantine/core';
+import { WEBSITE_URL } from '@/constants';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import { colors, spacing, typography } from '../designTokens';
 import SidebarDivider from './sidebar/SidebarDivider';
@@ -54,7 +55,7 @@ export default function Sidebar({ isOpen = true }: SidebarProps) {
     {
       label: 'View research',
       icon: IconBook,
-      path: `/${countryId}/research`,
+      path: `${WEBSITE_URL}/${countryId}/research`,
       external: true,
     },
   ];


### PR DESCRIPTION
Fixes #566

## Summary
- Fix "View research" link in sidebar to navigate to website instead of staying within calculator app


