### PR TITLE
Randomize starting slot for logo carousel rotation

### DIFF
--- a/app/src/components/home/OrgLogos.tsx
+++ b/app/src/components/home/OrgLogos.tsx
@@ -51,7 +51,8 @@ export default function OrgLogos() {
     const initial = shuffledOrgs.slice(0, NUM_VISIBLE).map((_, i) => i);
     setSlotIndices(initial);
     nextLogoRef.current = NUM_VISIBLE;
-    lastSlotRef.current = -1;
+    // Randomize starting position so the first slot to rotate isn't predictable
+    lastSlotRef.current = Math.floor(Math.random() * NUM_VISIBLE);
   }, [shuffledOrgs]);
 
   // Cycle slots using golden ratio step for visually scattered but deterministic pattern


### PR DESCRIPTION
## Summary
- Randomize the starting position for logo carousel rotation so the first slot to change isn't always the center (where 10 Downing Street logo is placed)

Previously the golden ratio stepping always started at `-1`, making the first slot to rotate be `(-1 + 4) % 7 = 3` (the center slot). Now the starting position is randomized.

## Test plan
- [ ] Verify logo rotation starts at different positions on page reload
- [ ] Verify 10 Downing Street logo still appears centered on initial load

🤖 Generated with [Claude Code](https://claude.com/claude-code)