### PR TITLE
Add ads transparency dashboard route

### DIFF
--- a/app/src/WebsiteRouter.tsx
+++ b/app/src/WebsiteRouter.tsx
@@ -5,6 +5,7 @@
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 import AppLayout from './components/AppLayout';
 import StaticLayout from './components/StaticLayout';
+import AdsDashboardPage from './pages/AdsDashboard.page';
 import AIGrowthResearchPage from './pages/AIGrowthResearch.page';
 import AppPage from './pages/AppPage';
 import BlogPage from './pages/Blog.page';
@@ -105,6 +106,10 @@ const router = createBrowserRouter(
         {
           path: 'ai-inequality',
           element: <AIGrowthResearchPage />,
+        },
+        {
+          path: 'ads-dashboard',
+          element: <AdsDashboardPage />,
         },
         // Embed routes - minimal layout for iframe embedding
         {

--- a/app/src/pages/AdsDashboard.page.tsx
+++ b/app/src/pages/AdsDashboard.page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Ads transparency dashboard - iframe embed of the standalone Vercel app
+ */
+export default function AdsDashboardPage() {
+  return (
+    <iframe
+      src="https://policyengine-ads-dashboard.vercel.app"
+      style={{
+        width: '100%',
+        height: '100vh',
+        border: 'none',
+      }}
+      title="PolicyEngine Ads Transparency Dashboard"
+    />
+  );
+}

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
-- bump: minor
+- bump: patch
   changes:
     added:
-      - Embed AI Growth Research site at /{countryId}/ai-inequality
+      - Ads transparency dashboard at /{countryId}/ads-dashboard


### PR DESCRIPTION
## Summary
- Adds `/ads-dashboard` route that embeds the standalone ads transparency dashboard
- Dashboard shows Google Ads Grant performance data (spend, impressions, clicks, conversions)
- Live at https://policyengine-ads-dashboard.vercel.app

## Test plan
- [ ] Visit /us/ads-dashboard and verify iframe loads
- [ ] Check dashboard displays correctly within the app frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)