### PR TITLE
Move ads dashboard into StaticLayout with PE header

### DIFF
--- a/app/src/WebsiteRouter.tsx
+++ b/app/src/WebsiteRouter.tsx
@@ -96,6 +96,10 @@ const router = createBrowserRouter(
               path: 'brand/assets',
               element: <BrandAssetsPage />,
             },
+            {
+              path: 'ads-dashboard',
+              element: <AdsDashboardPage />,
+            },
           ],
         },
         // Full-page embeds - no layout wrapper
@@ -106,10 +110,6 @@ const router = createBrowserRouter(
         {
           path: 'ai-inequality',
           element: <AIGrowthResearchPage />,
-        },
-        {
-          path: 'ads-dashboard',
-          element: <AdsDashboardPage />,
         },
         // Embed routes - minimal layout for iframe embedding
         {

--- a/app/src/pages/AdsDashboard.page.tsx
+++ b/app/src/pages/AdsDashboard.page.tsx
@@ -4,11 +4,12 @@
 export default function AdsDashboardPage() {
   return (
     <iframe
-      src="https://policyengine-ads-dashboard.vercel.app"
+      src="https://policyengine-ads-dashboard.vercel.app?embedded=true"
       style={{
         width: '100%',
-        height: '100vh',
+        height: 'calc(100vh - 64px)', // Account for PE header
         border: 'none',
+        display: 'block',
       }}
       title="PolicyEngine Ads Transparency Dashboard"
     />

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
-    added:
-      - Ads transparency dashboard at /{countryId}/ads-dashboard
+    changed:
+      - Move ads dashboard route into StaticLayout (shows PE header)


### PR DESCRIPTION
## Summary
- Moves /ads-dashboard route into StaticLayout so it shows the standard PolicyEngine header
- Dashboard iframe uses `?embedded=true` param to hide its own redundant header
- Adjusted iframe height to account for PE header (64px)

## Test plan
- [ ] Visit /us/ads-dashboard
- [ ] Verify PE header appears at top
- [ ] Verify dashboard content appears below without its own header
- [ ] No whitespace/buffer issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)