### PR TITLE
Add permanent redirect from /blog to /research

### DIFF
--- a/app/src/WebsiteRouter.tsx
+++ b/app/src/WebsiteRouter.tsx
@@ -2,7 +2,7 @@
  * Router for the Website (policyengine.org)
  * Contains homepage, blog, team, and embedded apps
  */
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, Navigate, RouterProvider, useParams } from 'react-router-dom';
 import AppLayout from './components/AppLayout';
 import StaticLayout from './components/StaticLayout';
 import AdsDashboardPage from './pages/AdsDashboard.page';
@@ -25,6 +25,12 @@ import YearInReviewPage from './pages/YearInReview.page';
 import { CountryAppGuard } from './routing/guards/CountryAppGuard';
 import { CountryGuardSimple } from './routing/guards/CountryGuardSimple';
 import { RedirectToCountry } from './routing/RedirectToCountry';
+
+// Redirect component for legacy /blog/:postName URLs
+function BlogRedirect() {
+  const { postName } = useParams();
+  return <Navigate to={`../research/${postName}`} replace />;
+}
 
 const router = createBrowserRouter(
   [
@@ -139,8 +145,12 @@ const router = createBrowserRouter(
         {
           children: [
             {
+              path: 'blog',
+              element: <Navigate to="../research" replace />,
+            },
+            {
               path: 'blog/:postName',
-              element: <Navigate to="../research/:postName" replace />,
+              element: <BlogRedirect />,
             },
           ],
         },

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,18 @@
   "installCommand": "npm ci",
   "buildCommand": "npm run design-system:build && npm run build:website --workspace=policyengine-app-v2",
   "outputDirectory": "app/dist",
+  "redirects": [
+    {
+      "source": "/:countryId/blog/:slug",
+      "destination": "/:countryId/research/:slug",
+      "permanent": true
+    },
+    {
+      "source": "/:countryId/blog",
+      "destination": "/:countryId/research",
+      "permanent": true
+    }
+  ],
   "rewrites": [{ "source": "/(.*)", "destination": "/website.html" }],
   "headers": [
     {


### PR DESCRIPTION
## Summary
- Adds server-side 301 redirects in vercel.json to redirect old `/blog` URLs to `/research`
- Fixes client-side redirect which wasn't properly substituting the URL parameter

This ensures that shared links like `policyengine.org/uk/blog/policyengine-10-downing-street` will redirect to `policyengine.org/uk/research/policyengine-10-downing-street`.

## Test plan
- [ ] Visit `/uk/blog/policyengine-10-downing-street` and verify it redirects to `/uk/research/policyengine-10-downing-street`
- [ ] Visit `/us/blog` and verify it redirects to `/us/research`

🤖 Generated with [Claude Code](https://claude.com/claude-code)