### PR TITLE
docs: Update Vercel project references in test comments

### DIFF
--- a/app/src/tests/unit/config/vercel.test.ts
+++ b/app/src/tests/unit/config/vercel.test.ts
@@ -72,8 +72,8 @@ describe('vercel.json configuration', () => {
   });
 
   test('given monorepo setup then root vercel.json exists for website project', () => {
-    // Given - Monorepo uses root vercel.json for policyengine-website project
-    // The policyengine-calculator project uses vercel.calculator.json
+    // Given - Monorepo uses root vercel.json for policyengine-app-v2 project (serves policyengine.org)
+    // The policyengine-calculator project uses calculator/vercel.json (serves app.policyengine.org)
     const rootVercelJsonPath = path.resolve(__dirname, '../../../../../vercel.json');
 
     // When


### PR DESCRIPTION
Fixes #531

## Summary
- Updates the test file comments to reference the correct Vercel project names
- `policyengine-app-v2` (serves policyengine.org) replaces `policyengine-website` references
- Corrects the path reference from `vercel.calculator.json` to `calculator/vercel.json`

Separately, the deprecated `policyengine-website` project was deleted from Vercel. `policyengine-app-v2` is now the only project managing the static portion of the site.

## Test plan
- [ ] Verify tests still pass: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)