### PR TITLE
Wrap ai-inequality page in StaticLayout for PE header/footer

### DIFF
--- a/app/src/WebsiteRouter.tsx
+++ b/app/src/WebsiteRouter.tsx
@@ -106,16 +106,16 @@ const router = createBrowserRouter(
               path: 'ads-dashboard',
               element: <AdsDashboardPage />,
             },
+            {
+              path: 'ai-inequality',
+              element: <AIGrowthResearchPage />,
+            },
           ],
         },
         // Full-page embeds - no layout wrapper
         {
           path: '2025-year-in-review',
           element: <YearInReviewPage />,
-        },
-        {
-          path: 'ai-inequality',
-          element: <AIGrowthResearchPage />,
         },
         // Embed routes - minimal layout for iframe embedding
         {

--- a/app/src/pages/AIGrowthResearch.page.tsx
+++ b/app/src/pages/AIGrowthResearch.page.tsx
@@ -12,7 +12,7 @@ export default function AIGrowthResearchPage() {
       title="AI and inequality | PolicyEngine"
       style={{
         width: '100%',
-        height: '100vh',
+        height: 'calc(100vh - 120px)',
         border: 'none',
       }}
     />


### PR DESCRIPTION
## Summary
- Moved the `ai-inequality` route inside `StaticLayout` so it gets the standard PolicyEngine header and footer
- Adjusted iframe height from `100vh` to `calc(100vh - 120px)` to account for the header

## Test plan
- [ ] Visit `/us/ai-inequality` and confirm PE header and footer are visible around the embedded site

🤖 Generated with [Claude Code](https://claude.com/claude-code)