### PR TITLE
Pass country param to model embed URL

### DIFF
--- a/app/src/pages/Model.page.tsx
+++ b/app/src/pages/Model.page.tsx
@@ -2,8 +2,11 @@
  * Embeds the PolicyEngine Model overview from Vercel.
  * Inherits policyengine.org header/footer via StaticLayout.
  */
+import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+
 export default function ModelPage() {
-  const embedUrl = 'https://policyengine-model.vercel.app?embed';
+  const countryId = useCurrentCountry();
+  const embedUrl = `https://policyengine-model.vercel.app?embed&country=${countryId}`;
 
   return (
     <iframe


### PR DESCRIPTION
## Summary
- The embedded model overview site now receives the current country from the router via `useCurrentCountry()`
- Enables country-specific content (UK data pipeline, programs list, etc.)
- Replaces #645 which had merge conflicts

## Test plan
- [ ] Visit `/us/model` and verify embed loads with `?embed&country=us`
- [ ] Visit `/uk/model` and verify embed loads with `?embed&country=uk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)