### PR TITLE
Add analytics to calculator app

### DIFF
--- a/app/src/main.calculator.tsx
+++ b/app/src/main.calculator.tsx
@@ -2,6 +2,8 @@
  * Entry point for Calculator app (app.policyengine.org)
  */
 import { StrictMode } from 'react';
+import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/react';
 import { createRoot } from 'react-dom/client';
 import CalculatorApp from './CalculatorApp';
 
@@ -37,5 +39,7 @@ const rootErrorHandlers = {
 createRoot(document.getElementById('root')!, rootErrorHandlers).render(
   <StrictMode>
     <CalculatorApp />
+    <Analytics />
+    <SpeedInsights />
   </StrictMode>
 );

--- a/app/src/main.website.tsx
+++ b/app/src/main.website.tsx
@@ -3,6 +3,7 @@
  */
 import { StrictMode } from 'react';
 import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/react';
 import { createRoot } from 'react-dom/client';
 import WebsiteApp from './WebsiteApp';
 
@@ -10,5 +11,6 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <WebsiteApp />
     <Analytics />
+    <SpeedInsights />
   </StrictMode>
 );

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@policyengine/design-system": "^0.1.0",
         "@vercel/analytics": "^1.6.1",
+        "@vercel/speed-insights": "^1.3.1",
         "concurrently": "^9.2.1",
       },
       "devDependencies": {
@@ -585,6 +586,8 @@
     "@vercel/nft": ["@vercel/nft@1.1.1", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^13.0.0", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.2", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-mKMGa7CEUcXU75474kOeqHbtvK1kAcu4wiahhmlUenB5JbTQB8wVlDI8CyHR3rpGo0qlzoRWqcDzI41FUoBJCA=="],
 
     "@vercel/node": ["@vercel/node@5.5.27", "", { "dependencies": { "@edge-runtime/node-utils": "2.3.0", "@edge-runtime/primitives": "4.1.0", "@edge-runtime/vm": "3.2.0", "@types/node": "20.11.0", "@vercel/build-utils": "13.2.15", "@vercel/error-utils": "2.0.3", "@vercel/nft": "1.1.1", "@vercel/static-config": "3.1.2", "async-listen": "3.0.0", "cjs-module-lexer": "1.2.3", "edge-runtime": "2.5.9", "es-module-lexer": "1.4.1", "esbuild": "0.27.0", "etag": "1.8.1", "mime-types": "2.1.35", "node-fetch": "2.6.9", "path-to-regexp": "6.1.0", "path-to-regexp-updated": "npm:path-to-regexp@6.3.0", "ts-morph": "12.0.0", "ts-node": "10.9.1", "typescript": "4.9.5", "typescript5": "npm:typescript@5.9.3", "undici": "5.28.4" } }, "sha512-nHx/zTHpjVvVGwKfoXUyPF/rKEcl8zkbbrpGN71+7YEqY27s8LPUzwZ53SEELA5PxeQzbrX6378nOC7kIPu28A=="],
+
+    "@vercel/speed-insights": ["@vercel/speed-insights@1.3.1", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ=="],
 
     "@vercel/static-config": ["@vercel/static-config@3.1.2", "", { "dependencies": { "ajv": "8.6.3", "json-schema-to-ts": "1.6.4", "ts-morph": "12.0.0" } }, "sha512-2d+TXr6K30w86a+WbMbGm2W91O0UzO5VeemZYBBUJbCjk/5FLLGIi8aV6RS2+WmaRvtcqNTn2pUA7nCOK3bGcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@policyengine/design-system": "^0.1.0",
     "@vercel/analytics": "^1.6.1",
+    "@vercel/speed-insights": "^1.3.1",
     "concurrently": "^9.2.1"
   }
 }


### PR DESCRIPTION
Fixes #650

## Summary
- Adds Vercel Analytics to the calculator app (`app.policyengine.org`)
- Adds Speed Insights to both the calculator and website apps
- Installs `@vercel/speed-insights` package

## Changes
- `app/src/main.calculator.tsx`: Added `<Analytics />` and `<SpeedInsights />` components
- `app/src/main.website.tsx`: Added `<SpeedInsights />` component (Analytics was already present)
- `package.json`: Added `@vercel/speed-insights` dependency

## Test plan
- [ ] Verify calculator builds successfully
- [ ] Verify website builds successfully
- [ ] After deployment, confirm analytics data appears in Vercel dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)