### PR TITLE
Migrate waterfall charts from Plotly to Recharts

### DIFF
--- a/app/src/pages/report-output/budgetary-impact/BudgetaryImpactByProgramSubPage.tsx
+++ b/app/src/pages/report-output/budgetary-impact/BudgetaryImpactByProgramSubPage.tsx
@@ -1,22 +1,27 @@
-import type { Layout } from 'plotly.js';
-import Plot from 'react-plotly.js';
 import { useSelector } from 'react-redux';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Label,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 import { Stack, Text } from '@mantine/core';
 import { useMediaQuery, useViewportSize } from '@mantine/hooks';
 import type { SocietyWideReportOutput } from '@/api/societyWideCalculation';
 import { ChartContainer } from '@/components/ChartContainer';
+import { ChartWatermark, TOOLTIP_STYLE } from '@/components/charts';
 import { colors } from '@/designTokens/colors';
 import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { absoluteChangeMessage } from '@/utils/chartMessages';
-import {
-  DEFAULT_CHART_CONFIG,
-  downloadCsv,
-  getChartLogoImage,
-  getClampedChartHeight,
-} from '@/utils/chartUtils';
-import { currencySymbol, formatCurrencyAbbr, localeCode } from '@/utils/formatters';
+import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import { currencySymbol, formatCurrencyAbbr } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
 interface Props {
@@ -27,6 +32,51 @@ interface ProgramBudgetItem {
   baseline: number;
   difference: number;
   reform: number;
+}
+
+interface WaterfallDatum {
+  name: string;
+  invisible: number;
+  visible: number;
+  value: number;
+  label: string;
+  hoverText: string;
+  isTotal: boolean;
+  fill: string;
+}
+
+function WaterfallTooltip({ active, payload }: any) {
+  if (!active || !payload?.[0]) {
+    return null;
+  }
+  const data = payload[0].payload as WaterfallDatum;
+  return (
+    <div style={{ ...TOOLTIP_STYLE, maxWidth: 300 }}>
+      <p style={{ fontWeight: 600, margin: 0 }}>{data.name}</p>
+      <p style={{ margin: '4px 0 0', fontSize: 13, whiteSpace: 'pre-wrap' }}>{data.hoverText}</p>
+    </div>
+  );
+}
+
+function WaterfallBarLabel({ x, y, width, height, index, data }: any) {
+  const entry: WaterfallDatum | undefined = data?.[index];
+  if (!entry || x === undefined || y === undefined || width === undefined) {
+    return null;
+  }
+  const labelY = y + height / 2;
+  return (
+    <text
+      x={x + width / 2}
+      y={labelY}
+      textAnchor="middle"
+      dominantBaseline="central"
+      fontSize={12}
+      fill="#fff"
+      fontWeight={500}
+    >
+      {entry.label}
+    </text>
+  );
 }
 
 export default function BudgetaryImpactByProgramSubPage({ output }: Props) {
@@ -54,13 +104,13 @@ export default function BudgetaryImpactByProgramSubPage({ output }: Props) {
 
   // Filter programs with non-zero difference and get labels
   const programs: Array<{ key: string; label: string; value: number }> = [];
-  Object.entries(detailedBudget).forEach(([programKey, values]) => {
-    if (values.difference !== 0) {
+  Object.entries(detailedBudget).forEach(([programKey, programValues]) => {
+    if (programValues.difference !== 0) {
       const programLabel = variables[programKey]?.label || programKey;
       programs.push({
         key: programKey,
         label: programLabel,
-        value: values.difference / 1e9, // Convert to billions
+        value: programValues.difference / 1e9, // Convert to billions
       });
     }
   });
@@ -133,79 +183,86 @@ export default function BudgetaryImpactByProgramSubPage({ output }: Props) {
     return `This reform would ${signTerm} ${term2}${regionPhrase}`;
   };
 
-  // Chart configuration
-  const chartData = [
-    {
-      x: labelsWithTotal,
-      y: valuesWithTotal,
-      type: 'waterfall' as const,
-      orientation: 'v' as const,
-      // 'relative' for all but the last, which is 'total'
-      measure:
-        valuesWithTotal.length > 1
-          ? Array(valuesWithTotal.length - 1)
-              .fill('relative')
-              .concat(['total'])
-          : undefined,
-      text: valuesWithTotal.map((value) => formatCur(value * 1e9)) as any,
-      textposition: 'inside' as const,
-      increasing: { marker: { color: colors.primary[500] } },
-      decreasing: { marker: { color: colors.gray[600] } },
-      totals: {
-        marker: {
-          color: budgetaryImpact < 0 ? colors.gray[600] : colors.primary[500],
-        },
-      },
-      connector: {
-        line: {
-          color: colors.gray[400],
-          width: 2,
-          dash: 'dot' as const,
-        },
-      },
-      customdata: labelsWithTotal.map((x, i) =>
-        hoverMessage(x, valuesWithTotal[i]).replaceAll('\n', '<br>')
-      ) as any,
-      hovertemplate: '<b>%{x}</b><br><br>%{customdata}<extra></extra>',
-    },
-  ];
+  // Build waterfall chart data
+  const chartData: WaterfallDatum[] = [];
+  let runningTotal = 0;
 
-  const layout = {
-    xaxis: {
-      title: { text: 'Program' },
-      fixedrange: true,
-    },
-    yaxis: {
-      title: { text: 'Budgetary impact (bn)' },
-      tickprefix: currencySymbol(countryId),
-      tickformat: ',.1f',
-      fixedrange: true,
-    },
-    uniformtext: {
-      mode: 'hide' as const,
-      minsize: mobile ? 4 : 8,
-    },
-    margin: {
-      t: 0,
-      b: 80,
-      l: 60,
-      r: 20,
-    },
-    images: [getChartLogoImage()],
-  } as Partial<Layout>;
+  for (let i = 0; i < valuesWithTotal.length; i++) {
+    const isTotal = i === valuesWithTotal.length - 1;
+    const value = valuesWithTotal[i];
+    const isPositive = value >= 0;
+
+    let invisible: number;
+    if (isTotal) {
+      invisible = isPositive ? 0 : value;
+    } else {
+      invisible = isPositive ? runningTotal : runningTotal + value;
+    }
+
+    const fill = isTotal
+      ? budgetaryImpact < 0
+        ? colors.gray[600]
+        : colors.primary[500]
+      : isPositive
+        ? colors.primary[500]
+        : colors.gray[600];
+
+    chartData.push({
+      name: labelsWithTotal[i],
+      invisible,
+      visible: Math.abs(value),
+      value,
+      label: formatCur(value * 1e9),
+      hoverText: hoverMessage(labelsWithTotal[i], value),
+      isTotal,
+      fill,
+    });
+
+    if (!isTotal) {
+      runningTotal += value;
+    }
+  }
+
+  const symbol = currencySymbol(countryId);
 
   return (
     <ChartContainer title={getChartTitle()} onDownloadCsv={handleDownloadCsv}>
       <Stack gap={spacing.sm}>
-        <Plot
-          data={chartData}
-          layout={layout}
-          config={{
-            ...DEFAULT_CHART_CONFIG,
-            locale: localeCode(countryId),
-          }}
-          style={{ width: '100%', height: chartHeight }}
-        />
+        <ResponsiveContainer width="100%" height={chartHeight}>
+          <BarChart data={chartData} margin={{ top: 20, right: 20, bottom: 30, left: 20 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="name" tick={RECHARTS_FONT_STYLE} />
+            <YAxis
+              tick={RECHARTS_FONT_STYLE}
+              tickFormatter={(v: number) => `${symbol}${v.toFixed(1)}`}
+            >
+              <Label
+                value="Budgetary impact (bn)"
+                angle={-90}
+                position="insideLeft"
+                style={{ textAnchor: 'middle', ...RECHARTS_FONT_STYLE }}
+              />
+            </YAxis>
+            <Tooltip content={<WaterfallTooltip />} />
+            <Bar
+              dataKey="invisible"
+              stackId="waterfall"
+              fill="transparent"
+              isAnimationActive={false}
+            />
+            <Bar
+              dataKey="visible"
+              stackId="waterfall"
+              isAnimationActive={false}
+              label={<WaterfallBarLabel data={chartData} />}
+            >
+              {chartData.map((entry, index) => (
+                <Cell key={index} fill={entry.fill} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+        <ChartWatermark />
       </Stack>
     </ChartContainer>
   );

--- a/app/src/tests/unit/pages/report-output/budgetary-impact/BudgetaryImpactSubPage.test.tsx
+++ b/app/src/tests/unit/pages/report-output/budgetary-impact/BudgetaryImpactSubPage.test.tsx
@@ -10,8 +10,18 @@ import {
   MOCK_ZERO_IMPACT,
 } from '@/tests/fixtures/pages/report-output/budgetary-impact/BudgetaryImpactSubPageMocks';
 
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
+// Mock Recharts to avoid rendering SVG in tests
+vi.mock('recharts', () => ({
+  Bar: vi.fn(() => null),
+  BarChart: vi.fn(({ children }) => children),
+  CartesianGrid: vi.fn(() => null),
+  Cell: vi.fn(() => null),
+  Label: vi.fn(() => null),
+  ResponsiveContainer: vi.fn(({ children }) => children),
+  Tooltip: vi.fn(() => null),
+  XAxis: vi.fn(() => null),
+  YAxis: vi.fn(() => null),
+}));
 
 // Mock hooks
 vi.mock('@/hooks/useCurrentCountry', () => ({
@@ -24,6 +34,8 @@ vi.mock('@/utils/chartUtils', () => ({
   downloadCsv: vi.fn(),
   getChartLogoImage: vi.fn(() => ({})),
   getClampedChartHeight: vi.fn(() => 500),
+  RECHARTS_FONT_STYLE: { fontFamily: 'Inter', fontSize: 12 },
+  RECHARTS_WATERMARK: { src: '/test.png', width: 80, opacity: 0.8 },
 }));
 
 describe('BudgetaryImpactSubPage', () => {


### PR DESCRIPTION
## Summary

- Replaced Plotly waterfall chart type with Recharts stacked bars in `BudgetaryImpactSubPage` and `BudgetaryImpactByProgramSubPage`
- Uses invisible base bar + visible segment to simulate waterfall behavior
- Positive bars in teal, negative in gray, total bar colored by net impact sign
- Same shared components (ChartWatermark, TOOLTIP_STYLE) as other migrated charts

## Test plan

- [x] All 2848 tests pass
- [x] Typecheck clean
- [x] Lint clean
- [ ] Visual verification on Vercel preview

Part of #668, #669 (removing Plotly dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)