### PR TITLE
Replace Plotly HexagonalMap with pure SVG

### DIFF
--- a/app/src/tests/unit/utils/visualization/colorScales.test.ts
+++ b/app/src/tests/unit/utils/visualization/colorScales.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest';
+import { interpolateColor } from '@/utils/visualization/colorScales';
+
+describe('interpolateColor', () => {
+  test('given value at minimum then returns first color', () => {
+    // Given
+    const scaleColors = ['#000000', '#808080', '#ffffff'];
+
+    // When
+    const result = interpolateColor(0, 0, 100, scaleColors);
+
+    // Then
+    expect(result).toBe('#000000');
+  });
+
+  test('given value at maximum then returns last color', () => {
+    // Given
+    const scaleColors = ['#000000', '#808080', '#ffffff'];
+
+    // When
+    const result = interpolateColor(100, 0, 100, scaleColors);
+
+    // Then
+    expect(result).toBe('#ffffff');
+  });
+
+  test('given value at midpoint of two colors then returns middle color', () => {
+    // Given
+    const scaleColors = ['#000000', '#ffffff'];
+
+    // When
+    const result = interpolateColor(50, 0, 100, scaleColors);
+
+    // Then — should be roughly #808080
+    expect(result).toMatch(/^#[0-9a-f]{6}$/i);
+    // Parse and check it's approximately midway
+    const r = parseInt(result.slice(1, 3), 16);
+    expect(r).toBeGreaterThan(110);
+    expect(r).toBeLessThan(145);
+  });
+
+  test('given value below minimum then clamps to first color', () => {
+    // Given
+    const scaleColors = ['#ff0000', '#00ff00'];
+
+    // When
+    const result = interpolateColor(-10, 0, 100, scaleColors);
+
+    // Then
+    expect(result).toBe('#ff0000');
+  });
+
+  test('given value above maximum then clamps to last color', () => {
+    // Given
+    const scaleColors = ['#ff0000', '#00ff00'];
+
+    // When
+    const result = interpolateColor(150, 0, 100, scaleColors);
+
+    // Then
+    expect(result).toBe('#00ff00');
+  });
+
+  test('given min equals max then returns first color', () => {
+    // Given
+    const scaleColors = ['#ff0000', '#00ff00'];
+
+    // When
+    const result = interpolateColor(50, 50, 50, scaleColors);
+
+    // Then
+    expect(result).toBe('#ff0000');
+  });
+
+  test('given five-color scale at quarter position then interpolates between first two', () => {
+    // Given — 5 colors spans 4 segments, so 0.25 of range hits boundary of segment 0 and 1
+    const scaleColors = ['#000000', '#404040', '#808080', '#c0c0c0', '#ffffff'];
+
+    // When — value at 25% of range (boundary between segment 0 and 1)
+    const result = interpolateColor(25, 0, 100, scaleColors);
+
+    // Then — should be exactly second color
+    expect(result).toBe('#404040');
+  });
+});

--- a/app/src/types/visualization/HexMapConfig.ts
+++ b/app/src/types/visualization/HexMapConfig.ts
@@ -1,5 +1,3 @@
-import type { Layout } from 'plotly.js';
-
 /**
  * Color scale configuration for hexagonal maps
  */
@@ -42,9 +40,6 @@ export interface HexMapConfig {
    * Scale factor for coordinates to control spacing between hexagons.
    * Values < 1 bring hexagons closer together, values > 1 spread them apart.
    * Default is 1 (no scaling).
-   *
-   * @example
-   * coordinateScale: 0.5 // Hexagons will be twice as close together
    */
   coordinateScale?: number;
 
@@ -56,7 +51,4 @@ export interface HexMapConfig {
 
   /** Function to format hover text values */
   formatValue?: (value: number) => string;
-
-  /** Additional layout overrides */
-  layoutOverrides?: Partial<Layout>;
 }

--- a/app/src/utils/visualization/colorScales.ts
+++ b/app/src/utils/visualization/colorScales.ts
@@ -71,3 +71,57 @@ export function getColorScale(name?: string): string[] {
   }
   return DIVERGING_GRAY_TEAL.colors; // Default to teal (primary brand color)
 }
+
+/**
+ * Interpolate a color from a multi-stop color scale based on a value within a range.
+ *
+ * @param value - The value to map to a color
+ * @param min - Minimum of the range
+ * @param max - Maximum of the range
+ * @param scaleColors - Array of hex color strings defining the scale stops
+ * @returns Hex color string (e.g., '#3a7f5c')
+ */
+export function interpolateColor(
+  value: number,
+  min: number,
+  max: number,
+  scaleColors: string[]
+): string {
+  if (scaleColors.length === 0) {
+    return '#000000';
+  }
+  if (scaleColors.length === 1 || min >= max) {
+    return scaleColors[0];
+  }
+
+  // Clamp to [0, 1]
+  const t = Math.max(0, Math.min(1, (value - min) / (max - min)));
+
+  // Map t to a position across (scaleColors.length - 1) segments
+  const segments = scaleColors.length - 1;
+  const segPos = t * segments;
+  const segIndex = Math.min(Math.floor(segPos), segments - 1);
+  const segT = segPos - segIndex;
+
+  const c0 = parseHex(scaleColors[segIndex]);
+  const c1 = parseHex(scaleColors[segIndex + 1]);
+
+  const r = Math.round(c0.r + (c1.r - c0.r) * segT);
+  const g = Math.round(c0.g + (c1.g - c0.g) * segT);
+  const b = Math.round(c0.b + (c1.b - c0.b) * segT);
+
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+function parseHex(color: string): { r: number; g: number; b: number } {
+  const c = color.replace('#', '');
+  return {
+    r: parseInt(c.slice(0, 2), 16),
+    g: parseInt(c.slice(2, 4), 16),
+    b: parseInt(c.slice(4, 6), 16),
+  };
+}
+
+function hex(n: number): string {
+  return n.toString(16).padStart(2, '0');
+}


### PR DESCRIPTION
## Summary

- Replaces the Plotly scatter-with-hexagon-markers implementation of `HexagonalMap` with a pure SVG implementation using `<polygon>` elements
- Adds `interpolateColor()` utility to `colorScales.ts` for mapping numeric values to multi-stop color scales
- Removes `layoutOverrides` (Plotly-specific) from `HexMapConfig` interface and the `plotly.js` `Layout` type import
- Color bar rendered as SVG `<linearGradient>` with tick labels
- Hover tooltips via mouse events on polygons with CSS-positioned overlay div

Part of the effort to fully remove `react-plotly.js` (#668, #669).

## Test plan

- [x] 14 component tests verify SVG rendering: polygon count, fill colors, color bar presence/absence, tooltip on hover, custom config
- [x] 7 unit tests for `interpolateColor`: boundary values, clamping, midpoint, multi-stop scales
- [x] Full test suite passes (2855 tests)
- [x] Typecheck clean
- [x] Lint clean
- [ ] Visual check on UK constituency hex map page

🤖 Generated with [Claude Code](https://claude.com/claude-code)