### PR TITLE
Lazy-load Plotly in blog components

### DIFF
--- a/app/src/components/blog/LazyPlot.tsx
+++ b/app/src/components/blog/LazyPlot.tsx
@@ -1,0 +1,26 @@
+import { lazy, Suspense } from 'react';
+import { Center, Loader } from '@mantine/core';
+import { colors } from '@/designTokens';
+
+const PlotComponent = lazy(() =>
+  import('react-plotly.js').then((mod) => ({ default: mod.default }))
+);
+
+/**
+ * Lazy-loaded Plotly chart component.
+ * Only loads the react-plotly.js bundle when rendered (typically in blog posts).
+ * This keeps Plotly (~3MB) out of the main application bundle.
+ */
+export function LazyPlot(props: React.ComponentProps<typeof PlotComponent>) {
+  return (
+    <Suspense
+      fallback={
+        <Center h={400}>
+          <Loader size="md" color={colors.primary[500]} />
+        </Center>
+      }
+    >
+      <PlotComponent {...props} />
+    </Suspense>
+  );
+}

--- a/app/src/components/blog/MarkdownFormatter.tsx
+++ b/app/src/components/blog/MarkdownFormatter.tsx
@@ -18,7 +18,6 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
-import Plot from 'react-plotly.js';
 import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
 import type { MarkdownFormatterProps } from '@/types/blog';
@@ -30,6 +29,7 @@ import {
   blogSpacing,
   blogTypography,
 } from './blogStyles';
+import { LazyPlot } from './LazyPlot';
 import { useDisplayCategory } from './useDisplayCategory';
 
 // Import Google Fonts for Roboto Serif
@@ -229,7 +229,7 @@ export function PlotlyChartCode({
         marginBottom: 20,
       }}
     >
-      <Plot
+      <LazyPlot
         data={plotlyData.data}
         layout={{
           ...plotlyData.layout,

--- a/app/src/components/blog/NotebookRenderer.tsx
+++ b/app/src/components/blog/NotebookRenderer.tsx
@@ -9,7 +9,6 @@
  */
 
 import { useMemo } from 'react';
-import Plot from 'react-plotly.js';
 import type { Notebook, NotebookCell as NotebookCellType, PlotlyData } from '@/types/blog';
 import {
   extractNotebookFootnotes,
@@ -17,6 +16,7 @@ import {
   parseJSONSafe,
 } from '@/utils/notebookUtils';
 import { blogColors, blogSpacing, blogTypography } from './blogStyles';
+import { LazyPlot } from './LazyPlot';
 import {
   FootnotesSection,
   HighlightedBlock,
@@ -284,7 +284,7 @@ function NotebookOutputPlotly({ data }: { data: PlotlyData }) {
           {title}
         </h5>
       )}
-      <Plot
+      <LazyPlot
         data={data.data}
         layout={{
           ...data.layout,

--- a/app/src/tests/unit/components/blog/MarkdownFormatter.test.tsx
+++ b/app/src/tests/unit/components/blog/MarkdownFormatter.test.tsx
@@ -9,9 +9,10 @@ import {
   MARKDOWN_SAMPLES,
 } from '@/tests/fixtures/components/blog/MarkdownFormatterMocks';
 
-// Mock Plotly to avoid rendering issues in tests
-// Note: vi.mock is hoisted, so the mock must be defined inline (not imported)
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
+// Mock LazyPlot (lazy-loaded Plotly wrapper) to avoid rendering issues in tests
+vi.mock('@/components/blog/LazyPlot', () => ({
+  LazyPlot: vi.fn(() => null),
+}));
 
 describe('MarkdownFormatter', () => {
   describe('MarkdownFormatter component', () => {


### PR DESCRIPTION
## Summary

- Adds `LazyPlot` wrapper component using `React.lazy()` to defer loading `react-plotly.js` (~3MB) until a blog post or notebook with Plotly content is actually rendered
- Replaces direct `import Plot from 'react-plotly.js'` in `MarkdownFormatter` and `NotebookRenderer` with the lazy wrapper
- Shows a loading spinner while Plotly loads
- No functional change to blog rendering — just deferred bundle loading

This keeps Plotly out of the main application bundle. Blog posts with Plotly charts will load the Plotly bundle on-demand.

Part of the effort to reduce/remove Plotly dependency (#668, #669).

## Test plan

- [x] All 13 MarkdownFormatter tests pass
- [x] Full test suite passes (2848 tests)
- [x] Typecheck clean
- [x] Lint clean
- [ ] Visual check: blog post with Plotly chart renders correctly
- [ ] Verify Plotly is not in the initial JS bundle (check network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)