### PR TITLE
Remove dead Plotly test mocks from 15 test files

### DIFF
--- a/app/src/tests/CLAUDE.md
+++ b/app/src/tests/CLAUDE.md
@@ -152,11 +152,13 @@
      };
      ```
 
-7. **Always mock Plotly**: Add to test file or setup
+7. **Mock LazyPlot when testing blog components**: Plotly is lazy-loaded via `LazyPlot`. Mock it in blog/notebook tests:
 
    ```typescript
-   vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
+   vi.mock('@/components/blog/LazyPlot', () => ({ LazyPlot: vi.fn(() => null) }));
    ```
+
+   Note: Chart components use Recharts (not Plotly), so no Plotly mock is needed for chart tests.
 
 8. **Mock conventions**:
    - Use `vi` not `jest`

--- a/app/src/tests/fixtures/components/blog/MarkdownFormatterMocks.ts
+++ b/app/src/tests/fixtures/components/blog/MarkdownFormatterMocks.ts
@@ -1,8 +1,8 @@
 /**
  * Test fixtures for MarkdownFormatter component tests
  *
- * Note: Plotly mock must be defined inline in test files due to vi.mock hoisting.
- * Use: vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
+ * Note: LazyPlot is mocked in test files to avoid loading Plotly in tests.
+ * Use: vi.mock('@/components/blog/LazyPlot', () => ({ LazyPlot: vi.fn(() => null) }));
  */
 
 /**

--- a/app/src/tests/fixtures/pages/reportOutputMocks.tsx
+++ b/app/src/tests/fixtures/pages/reportOutputMocks.tsx
@@ -144,9 +144,6 @@ export const createMockNotFoundSubPage = () =>
  * Setup function for all mocks
  */
 export function setupReportOutputMocks(vi: any) {
-  // Mock Plotly
-  vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
-
   // Mock subpage components
   vi.mock('@/pages/report-output/OverviewSubPage', () => ({
     default: createMockOverviewSubPage(),

--- a/app/src/tests/unit/components/report/IndividualTable.test.tsx
+++ b/app/src/tests/unit/components/report/IndividualTable.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@test-utils';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import IndividualTable from '@/components/report/IndividualTable';
 import {
   BASELINE_LABEL,
@@ -13,9 +13,6 @@ import {
   REFORM_LABEL,
   TABLE_HEADER_VARIABLE,
 } from '@/tests/fixtures/components/report/IndividualTable';
-
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
 
 describe('IndividualTable', () => {
   describe('Single simulation mode', () => {

--- a/app/src/tests/unit/components/report/ReportErrorFallback/ReportErrorFallback.test.tsx
+++ b/app/src/tests/unit/components/report/ReportErrorFallback/ReportErrorFallback.test.tsx
@@ -2,9 +2,6 @@ import { render, screen } from '@test-utils';
 import { describe, expect, test } from 'vitest';
 import { ReportErrorFallback } from '@/components/report/ReportErrorFallback';
 
-// Mock Plotly to avoid errors
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
-
 const createTestError = (message: string): Error => {
   const error = new Error(message);
   error.stack = `Error: ${message}\n    at TestComponent (test.tsx:10:5)`;

--- a/app/src/tests/unit/components/report/ReportOutputTypeCell.test.tsx
+++ b/app/src/tests/unit/components/report/ReportOutputTypeCell.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { screen, render as testRender } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { MantineProvider } from '@mantine/core';
 import { ReportOutputTypeCell } from '@/components/report/ReportOutputTypeCell';
 import { calculationKeys } from '@/libs/queryKeys';
@@ -15,9 +15,6 @@ import {
   createMockErrorStatus,
   createMockPendingStatus,
 } from '@/tests/fixtures/hooks/useCalcStatusSubscriptionMocks';
-
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
 
 describe('ReportOutputTypeCell', () => {
   let queryClient: QueryClient;

--- a/app/src/tests/unit/hooks/useUserReports.test.tsx
+++ b/app/src/tests/unit/hooks/useUserReports.test.tsx
@@ -49,9 +49,6 @@ import {
   TEST_SIMULATION_ID_2,
 } from '@/tests/fixtures/hooks/useUserReportsMocks';
 
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
-
 // Mock the normalizer
 vi.mock('@normy/react-query', () => ({
   useQueryNormalizer: () => createNormalizedCacheMock(),

--- a/app/src/tests/unit/pages/Reports.page.test.tsx
+++ b/app/src/tests/unit/pages/Reports.page.test.tsx
@@ -12,9 +12,6 @@ import {
   mockMixedStatusHookReturn,
 } from '@/tests/fixtures/pages/reportsMocks';
 
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
-
 // Mock the hooks
 vi.mock('@/hooks/useUserReports', () => ({
   useUserReports: vi.fn(),

--- a/app/src/tests/unit/pages/report-output/LocalAuthoritySubPage.test.tsx
+++ b/app/src/tests/unit/pages/report-output/LocalAuthoritySubPage.test.tsx
@@ -1,13 +1,10 @@
 import { render, screen } from '@test-utils';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { LocalAuthoritySubPage } from '@/pages/report-output/LocalAuthoritySubPage';
 import {
   MOCK_UK_REPORT_OUTPUT_NO_LA_FIELD,
   MOCK_UK_REPORT_OUTPUT_WITH_LA,
 } from '@/tests/fixtures/pages/local-authority/localAuthorityComponentMocks';
-
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
 
 describe('LocalAuthoritySubPage', () => {
   test('given UK report with local authority data then renders tabs', () => {

--- a/app/src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
@@ -3,9 +3,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import SocietyWideOverview from '@/pages/report-output/SocietyWideOverview';
 import { createMockSocietyWideOutput } from '@/tests/fixtures/pages/reportOutputMocks';
 
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
-
 // Mock useCurrentCountry hook
 vi.mock('@/hooks/useCurrentCountry', () => ({
   useCurrentCountry: vi.fn(() => 'us'),

--- a/app/src/tests/unit/pages/report-output/SocietyWideReportOutput.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideReportOutput.test.tsx
@@ -23,10 +23,6 @@ import {
 vi.mock('@/hooks/useCalculationStatus');
 vi.mock('@/hooks/useReportProgressDisplay');
 vi.mock('@/hooks/useStartCalculationOnLoad');
-
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
-
 // Mock subpage components with inline mocks to avoid hoisting issues
 vi.mock('@/pages/report-output/LoadingPage', () => ({
   default: vi.fn(({ message }: { message?: string; progress?: number }) => (

--- a/app/src/tests/unit/pages/report-output/congressional-district/AbsoluteChangeByDistrict.test.tsx
+++ b/app/src/tests/unit/pages/report-output/congressional-district/AbsoluteChangeByDistrict.test.tsx
@@ -8,9 +8,6 @@ import {
   MOCK_US_REPORT_OUTPUT_NO_DISTRICT,
 } from '@/tests/fixtures/pages/congressional-district/congressionalDistrictComponentMocks';
 
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
-
 // Mock react-redux to provide region data from metadata
 vi.mock('react-redux', async () => {
   const actual = await vi.importActual('react-redux');

--- a/app/src/tests/unit/pages/report-output/congressional-district/RelativeChangeByDistrict.test.tsx
+++ b/app/src/tests/unit/pages/report-output/congressional-district/RelativeChangeByDistrict.test.tsx
@@ -8,9 +8,6 @@ import {
   MOCK_US_REPORT_OUTPUT_NO_DISTRICT,
 } from '@/tests/fixtures/pages/congressional-district/congressionalDistrictComponentMocks';
 
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
-
 // Mock react-redux to provide region data from metadata
 vi.mock('react-redux', async () => {
   const actual = await vi.importActual('react-redux');

--- a/app/src/tests/unit/pages/report-output/constituency/AbsoluteChangeByConstituency.test.tsx
+++ b/app/src/tests/unit/pages/report-output/constituency/AbsoluteChangeByConstituency.test.tsx
@@ -1,13 +1,10 @@
 import { render, screen } from '@test-utils';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { AbsoluteChangeByConstituency } from '@/pages/report-output/constituency/AbsoluteChangeByConstituency';
 import {
   MOCK_UK_REPORT_OUTPUT,
   MOCK_UK_REPORT_OUTPUT_NO_CONSTITUENCY,
 } from '@/tests/fixtures/pages/constituency/constituencyComponentMocks';
-
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
 
 describe('AbsoluteChangeByConstituency', () => {
   test('given constituency data then renders component', () => {

--- a/app/src/tests/unit/pages/report-output/constituency/RelativeChangeByConstituency.test.tsx
+++ b/app/src/tests/unit/pages/report-output/constituency/RelativeChangeByConstituency.test.tsx
@@ -1,13 +1,10 @@
 import { render, screen } from '@test-utils';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { RelativeChangeByConstituency } from '@/pages/report-output/constituency/RelativeChangeByConstituency';
 import {
   MOCK_UK_REPORT_OUTPUT,
   MOCK_UK_REPORT_OUTPUT_NO_CONSTITUENCY,
 } from '@/tests/fixtures/pages/constituency/constituencyComponentMocks';
-
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
 
 describe('RelativeChangeByConstituency', () => {
   test('given constituency data then renders component', () => {

--- a/app/src/tests/unit/pages/report-output/local-authority/AbsoluteChangeByLocalAuthority.test.tsx
+++ b/app/src/tests/unit/pages/report-output/local-authority/AbsoluteChangeByLocalAuthority.test.tsx
@@ -1,13 +1,10 @@
 import { render, screen } from '@test-utils';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { AbsoluteChangeByLocalAuthority } from '@/pages/report-output/local-authority/AbsoluteChangeByLocalAuthority';
 import {
   MOCK_UK_REPORT_OUTPUT_NO_LA_DATA,
   MOCK_UK_REPORT_OUTPUT_WITH_LA,
 } from '@/tests/fixtures/pages/local-authority/localAuthorityComponentMocks';
-
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
 
 describe('AbsoluteChangeByLocalAuthority', () => {
   test('given local authority data then renders component', () => {

--- a/app/src/tests/unit/pages/report-output/local-authority/RelativeChangeByLocalAuthority.test.tsx
+++ b/app/src/tests/unit/pages/report-output/local-authority/RelativeChangeByLocalAuthority.test.tsx
@@ -1,13 +1,10 @@
 import { render, screen } from '@test-utils';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { RelativeChangeByLocalAuthority } from '@/pages/report-output/local-authority/RelativeChangeByLocalAuthority';
 import {
   MOCK_UK_REPORT_OUTPUT_NO_LA_DATA,
   MOCK_UK_REPORT_OUTPUT_WITH_LA,
 } from '@/tests/fixtures/pages/local-authority/localAuthorityComponentMocks';
-
-// Mock Plotly
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
 
 describe('RelativeChangeByLocalAuthority', () => {
   test('given local authority data then renders component', () => {

--- a/app/src/tests/unit/pathways/report/views/ReportSimulationSelectionView.test.tsx
+++ b/app/src/tests/unit/pathways/report/views/ReportSimulationSelectionView.test.tsx
@@ -40,9 +40,6 @@ vi.mock('@/hooks/useUserHousehold', () => ({
 vi.mock('@/hooks/useUserPolicy', () => ({
   useUserPolicies: vi.fn(() => ({ data: [], isLoading: false })),
 }));
-
-vi.mock('react-plotly.js', () => ({ default: vi.fn(() => null) }));
-
 describe('ReportSimulationSelectionView', () => {
   beforeEach(() => {
     resetAllMocks();


### PR DESCRIPTION
## Summary
- Removed vestigial `vi.mock('react-plotly.js')` from 15 test files where no production code imports Plotly anymore
- Removed unused `vi` imports from 7 files where the only usage was the Plotly mock
- Updated `MarkdownFormatterMocks.ts` comment to reference `LazyPlot` instead of `react-plotly.js`
- Updated `reportOutputMocks.tsx` setup function to remove Plotly mock
- Updated test conventions (`CLAUDE.md`) to document the new `LazyPlot` mock pattern

## Context
PRs #671-674 migrated all chart components off `react-plotly.js`. The only remaining Plotly usage is the `LazyPlot` wrapper in `app/src/components/blog/LazyPlot.tsx` which lazy-loads Plotly for blog/notebook content. These test mocks were dead code that caused lint errors (unused `vi` imports).

## Test plan
- [x] All 2848 tests pass
- [x] Lint clean (0 errors, 0 warnings)
- [x] TypeScript compiles clean
- [x] No `react-plotly.js` references remain outside `LazyPlot.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)