### PR TITLE
Fix waterfall chart rendering, add PE watermark to maps

### DIFF
--- a/app/src/components/visualization/HexagonalMap.tsx
+++ b/app/src/components/visualization/HexagonalMap.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Box } from '@mantine/core';
+import { ChartWatermark } from '@/components/charts';
 import { colors, spacing } from '@/designTokens';
 import type { HexMapConfig } from '@/types/visualization/HexMapConfig';
 import type { HexMapDataPoint } from '@/types/visualization/HexMapDataPoint';
@@ -210,6 +211,10 @@ export function HexagonalMap({ data, config = {} }: HexagonalMapProps) {
           {tooltip.text}
         </div>
       )}
+      {/* PolicyEngine logo watermark */}
+      <div style={{ padding: `${spacing.xs}px ${spacing.sm}px` }}>
+        <ChartWatermark />
+      </div>
     </Box>
   );
 }

--- a/app/src/components/visualization/choropleth/USDistrictChoroplethMap.tsx
+++ b/app/src/components/visualization/choropleth/USDistrictChoroplethMap.tsx
@@ -26,6 +26,7 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { ComposableMap, Geographies, Geography, ZoomableGroup } from 'react-simple-maps';
 import { Box, Center, Loader, Stack, Text } from '@mantine/core';
+import { ChartWatermark } from '@/components/charts';
 import { colors, spacing } from '@/designTokens';
 import type { GeoJSONFeatureCollection, USDistrictChoroplethMapProps } from './types';
 import {
@@ -492,6 +493,10 @@ export function USDistrictChoroplethMap({
           <div style={{ color: colors.gray[600] }}>{tooltip.value}</div>
         </div>
       )}
+      {/* PolicyEngine logo watermark */}
+      <div style={{ padding: `${spacing.xs}px ${spacing.sm}px` }}>
+        <ChartWatermark />
+      </div>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Fixed waterfall chart bar positioning: replaced `invisible`/`visible` stacked bar model with explicit `barBottom`/`barTop` position model, added explicit Y-axis domain computation, and suppressed tooltip on transparent base bars
- Added PolicyEngine logo watermark to HexagonalMap and USDistrictChoroplethMap (the two SVG-based map components that were missing it)

## Context
The waterfall charts (BudgetaryImpactSubPage + BudgetaryImpactByProgramSubPage) were migrated from Plotly to Recharts in PR #671 but the stacked bar waterfall pattern had rendering issues:
1. Y-axis domain didn't account for negative bar positions, causing clipping
2. Hovering over the transparent base bar area showed empty tooltips
3. The data model mixed Recharts stacking concerns with domain logic

The hex map (PR #672) and choropleth (PR #674) were migrated to SVG but were missing the PE logo watermark that all Recharts charts have.

## Test plan
- [x] All 2848 tests pass
- [x] Lint clean
- [x] Verify waterfall renders correctly with positive, negative, and mixed impacts
- [x] Verify watermark appears on hex map and choropleth

🤖 Generated with [Claude Code](https://claude.com/claude-code)