### PR TITLE
Add CSS custom properties export to design system

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -31,7 +31,8 @@
       "import": "./dist/charts/index.js",
       "types": "./dist/charts/index.d.ts"
     },
-    "./tokens.json": "./dist/tokens.json"
+    "./tokens.json": "./dist/tokens.json",
+    "./tokens.css": "./dist/tokens.css"
   },
   "files": [
     "dist",
@@ -40,12 +41,13 @@
     "!src/__tests__"
   ],
   "scripts": {
-    "build": "tsc && npm run generate-json",
+    "build": "tsc && npm run generate-json && npm run generate-css",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.tsx",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "generate-json": "tsx scripts/generate-json.ts",
+    "generate-css": "tsx scripts/generate-css.ts",
     "test": "vitest run"
   },
   "peerDependencies": {

--- a/packages/design-system/scripts/generate-css.ts
+++ b/packages/design-system/scripts/generate-css.ts
@@ -1,0 +1,117 @@
+/**
+ * Generate CSS custom properties from design tokens
+ * Outputs tokens.css with all --pe-* variables
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { colors } from '../dist/tokens/colors.js';
+import { typography } from '../dist/tokens/typography.js';
+import { spacing } from '../dist/tokens/spacing.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function flattenObject(
+  obj: Record<string, unknown>,
+  prefix: string,
+): string[] {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const varName = `${prefix}-${key}`;
+    if (typeof value === 'string' || typeof value === 'number') {
+      lines.push(`  ${varName}: ${value};`);
+    } else if (typeof value === 'object' && value !== null) {
+      lines.push(
+        ...flattenObject(value as Record<string, unknown>, varName),
+      );
+    }
+  }
+  return lines;
+}
+
+const sections: string[] = [];
+
+// Colors
+sections.push('  /* Colors — primary (teal) */');
+sections.push(...flattenObject(colors.primary, '--pe-color-primary'));
+sections.push('');
+sections.push('  /* Colors — gray */');
+sections.push(...flattenObject(colors.gray, '--pe-color-gray'));
+sections.push('');
+sections.push('  /* Colors — blue */');
+sections.push(...flattenObject(colors.blue, '--pe-color-blue'));
+sections.push('');
+sections.push('  /* Colors — semantic */');
+sections.push(`  --pe-color-success: ${colors.success};`);
+sections.push(`  --pe-color-warning: ${colors.warning};`);
+sections.push(`  --pe-color-error: ${colors.error};`);
+sections.push(`  --pe-color-info: ${colors.info};`);
+sections.push('');
+sections.push('  /* Colors — background */');
+sections.push(...flattenObject(colors.background, '--pe-color-bg'));
+sections.push('');
+sections.push('  /* Colors — text */');
+sections.push(...flattenObject(colors.text, '--pe-color-text'));
+sections.push('');
+sections.push('  /* Colors — border */');
+sections.push(...flattenObject(colors.border, '--pe-color-border'));
+sections.push('');
+
+// Typography
+sections.push('  /* Typography — font families */');
+for (const [key, value] of Object.entries(typography.fontFamily)) {
+  sections.push(`  --pe-font-family-${key}: ${value};`);
+}
+sections.push('');
+sections.push('  /* Typography — font sizes */');
+for (const [key, value] of Object.entries(typography.fontSize)) {
+  sections.push(`  --pe-font-size-${key}: ${value};`);
+}
+sections.push('');
+sections.push('  /* Typography — font weights */');
+for (const [key, value] of Object.entries(typography.fontWeight)) {
+  sections.push(`  --pe-font-weight-${key}: ${value};`);
+}
+sections.push('');
+sections.push('  /* Typography — line heights */');
+for (const [key, value] of Object.entries(typography.lineHeight)) {
+  sections.push(`  --pe-line-height-${key}: ${value};`);
+}
+sections.push('');
+
+// Spacing
+sections.push('  /* Spacing — base scale */');
+const spacingBase = { xs: spacing.xs, sm: spacing.sm, md: spacing.md, lg: spacing.lg, xl: spacing.xl, '2xl': spacing['2xl'], '3xl': spacing['3xl'], '4xl': spacing['4xl'], '5xl': spacing['5xl'] };
+for (const [key, value] of Object.entries(spacingBase)) {
+  sections.push(`  --pe-space-${key}: ${value};`);
+}
+sections.push('');
+sections.push('  /* Spacing — border radius */');
+for (const [key, value] of Object.entries(spacing.radius)) {
+  sections.push(`  --pe-radius-${key}: ${value};`);
+}
+
+const css = `/**
+ * PolicyEngine Design Tokens — CSS Custom Properties
+ * Generated from @policyengine/design-system
+ * Source of truth: packages/design-system/src/tokens/
+ *
+ * Usage:
+ *   <link rel="stylesheet" href="https://unpkg.com/@policyengine/design-system/dist/tokens.css">
+ *   or: @import '@policyengine/design-system/tokens.css';
+ *   or: npm install @policyengine/design-system && import '@policyengine/design-system/dist/tokens.css';
+ */
+:root {
+${sections.join('\n')}
+}
+`;
+
+const outputDir = path.join(__dirname, '..', 'dist');
+const outputFile = path.join(outputDir, 'tokens.css');
+
+fs.mkdirSync(outputDir, { recursive: true });
+fs.writeFileSync(outputFile, css);
+
+console.log(`✅ Generated CSS tokens: ${outputFile}`);


### PR DESCRIPTION
## Summary
- Adds `generate-css.ts` script that produces `tokens.css` with `--pe-*` CSS custom properties for all design tokens
- Adds `./tokens.css` export to the package, so standalone tools can `import '@policyengine/design-system/tokens.css'` or link via unpkg CDN
- Adds `generate-css` to the build pipeline alongside existing `generate-json`

This enables standalone interactive tools (marriage calculator, givecalc, etc.) to import PolicyEngine design tokens as plain CSS instead of hand-copying hex values.

## Usage

```html
<!-- CDN -->
<link rel="stylesheet" href="https://unpkg.com/@policyengine/design-system/dist/tokens.css">
```

```css
/* npm import */
@import '@policyengine/design-system/tokens.css';

.button { background: var(--pe-color-primary-500); }
```

## Test plan
- [x] `npm run build` succeeds and generates `dist/tokens.css`
- [x] CSS contains all color, typography, spacing, and radius tokens
- [ ] Verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)