### PR TITLE
Use Inter for chart fonts, add prose font family

### DIFF
--- a/packages/design-system/src/__tests__/charts.test.ts
+++ b/packages/design-system/src/__tests__/charts.test.ts
@@ -31,9 +31,9 @@ describe('charts', () => {
   });
 
   describe('chartLayout', () => {
-    it('should use Roboto Serif font for charts', () => {
+    it('should use Inter font for charts', () => {
       expect(chartLayout.font.family).toBe(typography.fontFamily.chart);
-      expect(chartLayout.font.family).toContain('Roboto Serif');
+      expect(chartLayout.font.family).toContain('Inter');
     });
 
     it('should have white background', () => {

--- a/packages/design-system/src/__tests__/typography.test.ts
+++ b/packages/design-system/src/__tests__/typography.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { typography, FONT_UI, FONT_CHART, FONT_MONO } from '../tokens/typography';
+import { typography, FONT_UI, FONT_CHART, FONT_PROSE, FONT_MONO } from '../tokens/typography';
 
 describe('typography', () => {
   describe('font families', () => {
@@ -7,8 +7,12 @@ describe('typography', () => {
       expect(typography.fontFamily.primary).toContain('Inter');
     });
 
-    it('should have chart font as Roboto Serif', () => {
-      expect(typography.fontFamily.chart).toContain('Roboto Serif');
+    it('should have chart font as Inter (same as primary)', () => {
+      expect(typography.fontFamily.chart).toContain('Inter');
+    });
+
+    it('should have prose font as Roboto Serif for long-form content', () => {
+      expect(typography.fontFamily.prose).toContain('Roboto Serif');
     });
 
     it('should have monospace font', () => {
@@ -21,7 +25,8 @@ describe('typography', () => {
       expect(typography.fontFamily.secondary).toContain('sans-serif');
       expect(typography.fontFamily.body).toContain('sans-serif');
       expect(typography.fontFamily.mono).toContain('monospace');
-      expect(typography.fontFamily.chart).toContain('serif');
+      expect(typography.fontFamily.chart).toContain('sans-serif');
+      expect(typography.fontFamily.prose).toContain('serif');
     });
   });
 
@@ -30,9 +35,14 @@ describe('typography', () => {
       expect(FONT_UI).toBe(typography.fontFamily.primary);
     });
 
-    it('should export FONT_CHART for Plotly charts', () => {
+    it('should export FONT_CHART as Inter for charts', () => {
       expect(FONT_CHART).toBe(typography.fontFamily.chart);
-      expect(FONT_CHART).toContain('Roboto Serif');
+      expect(FONT_CHART).toContain('Inter');
+    });
+
+    it('should export FONT_PROSE for long-form content', () => {
+      expect(FONT_PROSE).toBe(typography.fontFamily.prose);
+      expect(FONT_PROSE).toContain('Roboto Serif');
     });
 
     it('should export FONT_MONO for code', () => {

--- a/packages/design-system/src/tokens/typography.ts
+++ b/packages/design-system/src/tokens/typography.ts
@@ -9,8 +9,10 @@ export const typography = {
     secondary: 'Public Sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
     body: 'Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
     mono: 'JetBrains Mono, "Fira Code", Consolas, monospace',
-    // Chart-specific font
-    chart: 'Roboto Serif, Georgia, "Times New Roman", serif',
+    // Chart labels and axes — same as primary UI font
+    chart: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    // Long-form written content (blog posts, research articles)
+    prose: 'Roboto Serif, Georgia, "Times New Roman", serif',
   },
 
   fontWeight: {
@@ -85,6 +87,7 @@ export const typography = {
 // Convenience exports for common fonts
 export const FONT_UI = typography.fontFamily.primary;
 export const FONT_CHART = typography.fontFamily.chart;
+export const FONT_PROSE = typography.fontFamily.prose;
 export const FONT_MONO = typography.fontFamily.mono;
 
 export type Typography = typeof typography;


### PR DESCRIPTION
## Summary
- Changed `typography.fontFamily.chart` from Roboto Serif to Inter (same as primary UI font) for consistent chart labeling
- Added new `typography.fontFamily.prose` for long-form written content (blog posts, research articles) using Roboto Serif
- Added `FONT_PROSE` convenience export
- Updated all tests

## Rationale
Charts should use Inter for consistency with the rest of the UI. Roboto Serif is better suited for long-form reading (blog posts, research articles), not chart axis labels and tooltips.

## Test plan
- [x] All 73 design system tests pass (`vitest run`)
- [x] Build succeeds with updated `tokens.css` and `tokens.json`
- [x] CSS variable `--pe-font-family-chart` now outputs Inter
- [x] CSS variable `--pe-font-family-prose` outputs Roboto Serif

🤖 Generated with [Claude Code](https://claude.com/claude-code)