### PR TITLE
Consolidate all fonts to Inter + JetBrains Mono

### DIFF
--- a/app/src/components/blog/MarkdownFormatter.tsx
+++ b/app/src/components/blog/MarkdownFormatter.tsx
@@ -32,11 +32,11 @@ import {
 import { LazyPlot } from './LazyPlot';
 import { useDisplayCategory } from './useDisplayCategory';
 
-// Import Google Fonts for Roboto Serif
+// Import Google Fonts for code blocks (Roboto Mono)
 const fontLinkElement = document.createElement('link');
 fontLinkElement.rel = 'stylesheet';
 fontLinkElement.href =
-  'https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600;700&family=Roboto+Mono:wght@400;500;700&display=swap';
+  'https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500;700&display=swap';
 if (!document.head.querySelector(`link[href="${fontLinkElement.href}"]`)) {
   document.head.appendChild(fontLinkElement);
 }

--- a/app/src/styles/stylesheets/RichTextBlock.css
+++ b/app/src/styles/stylesheets/RichTextBlock.css
@@ -3,12 +3,11 @@
 
 .rich-text-block p {
   font-family:
-    Roboto,
+    Inter,
     -apple-system,
     BlinkMacSystemFont,
     'Segoe UI',
-    Helvetica,
-    Arial,
+    Roboto,
     sans-serif;
   font-size: 16px;
   line-height: 1.625;

--- a/packages/design-system/src/__tests__/typography.test.ts
+++ b/packages/design-system/src/__tests__/typography.test.ts
@@ -3,30 +3,29 @@ import { typography, FONT_UI, FONT_CHART, FONT_PROSE, FONT_MONO } from '../token
 
 describe('typography', () => {
   describe('font families', () => {
-    it('should have primary font as Inter', () => {
+    it('should use Inter for all non-mono font families', () => {
       expect(typography.fontFamily.primary).toContain('Inter');
-    });
-
-    it('should have chart font as Inter (same as primary)', () => {
+      expect(typography.fontFamily.secondary).toContain('Inter');
+      expect(typography.fontFamily.body).toContain('Inter');
       expect(typography.fontFamily.chart).toContain('Inter');
+      expect(typography.fontFamily.prose).toContain('Inter');
     });
 
-    it('should have prose font as Roboto Serif for long-form content', () => {
-      expect(typography.fontFamily.prose).toContain('Roboto Serif');
+    it('should have all non-mono families resolve to the same value', () => {
+      const inter = typography.fontFamily.primary;
+      expect(typography.fontFamily.secondary).toBe(inter);
+      expect(typography.fontFamily.body).toBe(inter);
+      expect(typography.fontFamily.chart).toBe(inter);
+      expect(typography.fontFamily.prose).toBe(inter);
     });
 
     it('should have monospace font', () => {
       expect(typography.fontFamily.mono).toContain('JetBrains Mono');
     });
 
-    it('should include fallback fonts for all families', () => {
-      // All font families should have system fallbacks
+    it('should include fallback fonts', () => {
       expect(typography.fontFamily.primary).toContain('sans-serif');
-      expect(typography.fontFamily.secondary).toContain('sans-serif');
-      expect(typography.fontFamily.body).toContain('sans-serif');
       expect(typography.fontFamily.mono).toContain('monospace');
-      expect(typography.fontFamily.chart).toContain('sans-serif');
-      expect(typography.fontFamily.prose).toContain('serif');
     });
   });
 
@@ -35,14 +34,14 @@ describe('typography', () => {
       expect(FONT_UI).toBe(typography.fontFamily.primary);
     });
 
-    it('should export FONT_CHART as Inter for charts', () => {
+    it('should export FONT_CHART as Inter', () => {
       expect(FONT_CHART).toBe(typography.fontFamily.chart);
       expect(FONT_CHART).toContain('Inter');
     });
 
-    it('should export FONT_PROSE for long-form content', () => {
-      expect(FONT_PROSE).toBe(typography.fontFamily.prose);
-      expect(FONT_PROSE).toContain('Roboto Serif');
+    it('should export FONT_PROSE as Inter (same as primary)', () => {
+      expect(FONT_PROSE).toBe(typography.fontFamily.primary);
+      expect(FONT_PROSE).toContain('Inter');
     });
 
     it('should export FONT_MONO for code', () => {
@@ -105,6 +104,12 @@ describe('typography', () => {
       expect(typography.textStyles['sm-medium']).toBeDefined();
       expect(typography.textStyles['sm-semibold']).toBeDefined();
       expect(typography.textStyles['body-regular']).toBeDefined();
+    });
+
+    it('should use Inter for all text styles', () => {
+      Object.values(typography.textStyles).forEach((style) => {
+        expect(style.fontFamily).toBe('Inter');
+      });
     });
 
     it('should have complete text style definitions', () => {

--- a/packages/design-system/src/tokens/typography.ts
+++ b/packages/design-system/src/tokens/typography.ts
@@ -1,18 +1,24 @@
 /**
  * PolicyEngine typography system
  * Source of truth for fonts, sizes, and text styles
+ *
+ * Two font families only: Inter (everything) + JetBrains Mono (code).
+ * Legacy aliases (secondary, body, chart, prose) all resolve to the
+ * primary Inter stack for backward compatibility.
  */
+
+const INTER = 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
 
 export const typography = {
   fontFamily: {
-    primary: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-    secondary: 'Public Sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-    body: 'Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    primary: INTER,
+    // Legacy aliases — all resolve to Inter
+    secondary: INTER,
+    body: INTER,
+    chart: INTER,
+    prose: INTER,
+    // Code
     mono: 'JetBrains Mono, "Fira Code", Consolas, monospace',
-    // Chart labels and axes — same as primary UI font
-    chart: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-    // Long-form written content (blog posts, research articles)
-    prose: 'Roboto Serif, Georgia, "Times New Roman", serif',
   },
 
   fontWeight: {
@@ -49,7 +55,7 @@ export const typography = {
     '24': '24px',
   },
 
-  // Pre-defined text styles
+  // Pre-defined text styles — all use Inter
   textStyles: {
     'sm-medium': {
       fontFamily: 'Inter',
@@ -64,19 +70,19 @@ export const typography = {
       lineHeight: '20px',
     },
     'md-normal': {
-      fontFamily: 'Public Sans',
+      fontFamily: 'Inter',
       fontSize: '16px',
       fontWeight: 400,
       lineHeight: '24px',
     },
     'body-regular': {
-      fontFamily: 'Roboto',
+      fontFamily: 'Inter',
       fontSize: '14px',
       fontWeight: 400,
       lineHeight: '22px',
     },
     'h5-regular': {
-      fontFamily: 'Roboto',
+      fontFamily: 'Inter',
       fontSize: '16px',
       fontWeight: 400,
       lineHeight: '24px',


### PR DESCRIPTION
## Summary
- Remove Roboto, Roboto Serif, and Public Sans from the design system
- All font family tokens (`primary`, `secondary`, `body`, `chart`, `prose`) now resolve to the same Inter stack
- Legacy aliases kept for backward compatibility — no code changes needed in consumers
- Stop loading Roboto Serif Google Font in blog renderer
- Update RichTextBlock.css from Roboto to Inter
- All text styles updated to Inter

## Rationale
Inter is our standard font. Roboto and Public Sans were v1 leftovers that got carried into the design system mechanically. The brand page already declared Inter as the only UI font. This makes it official: **two font families total — Inter + JetBrains Mono**.

## Test plan
- [x] All 73 design system tests pass
- [x] Build succeeds — CSS variables all output Inter
- [x] App lint passes
- [ ] Visual check: blog posts render in Inter instead of Roboto Serif
- [ ] Visual check: rich text blocks render in Inter instead of Roboto

🤖 Generated with [Claude Code](https://claude.com/claude-code)