### PR TITLE
Fix district map logo position to bottom-right

### DIFF
--- a/app/src/components/visualization/choropleth/USDistrictChoroplethMap.tsx
+++ b/app/src/components/visualization/choropleth/USDistrictChoroplethMap.tsx
@@ -494,7 +494,13 @@ export function USDistrictChoroplethMap({
         </div>
       )}
       {/* PolicyEngine logo watermark */}
-      <div style={{ padding: `${spacing.xs}px ${spacing.sm}px` }}>
+      <div
+        style={{
+          position: 'absolute',
+          bottom: spacing.xs,
+          right: spacing.sm,
+        }}
+      >
         <ChartWatermark />
       </div>
     </Box>


### PR DESCRIPTION
Moves the PolicyEngine watermark on US district choropleth maps from the default flow position to the bottom-right corner using absolute positioning.