### PR TITLE
Fix waterfall chart range bars and tick labels

### DIFF
--- a/app/src/components/charts/WaterfallChart.tsx
+++ b/app/src/components/charts/WaterfallChart.tsx
@@ -45,6 +45,8 @@ export interface WaterfallChartProps {
   yAxisLabel?: string;
   /** Y-axis tick formatter */
   yTickFormatter?: (value: number) => string;
+  /** Number of Y-axis ticks (default: 5) */
+  yTickCount?: number;
   /** Fill color resolver — receives datum, returns CSS color string */
   fillColor: (datum: WaterfallDatum) => string;
   /** Optional custom tooltip content */
@@ -98,14 +100,6 @@ function WaterfallTooltip({ active, payload }: any) {
 // Main component
 // ---------------------------------------------------------------------------
 
-/**
- * Accessor that returns [barBottom, barTop] for each datum, telling Recharts
- * to render a range bar spanning exactly those Y-axis values.
- */
-function waterfallRange(d: WaterfallDatum): [number, number] {
-  return [d.barBottom, d.barTop];
-}
-
 export function WaterfallChart({
   data,
   yDomain,
@@ -114,6 +108,7 @@ export function WaterfallChart({
   yTickFormatter,
   fillColor,
   tooltipContent,
+  yTickCount = 5,
   margin = { top: 20, right: 20, bottom: 30, left: 20 },
 }: WaterfallChartProps) {
   return (
@@ -122,7 +117,12 @@ export function WaterfallChart({
         <BarChart data={data} margin={margin}>
           <CartesianGrid strokeDasharray="3 3" vertical={false} />
           <XAxis dataKey="name" tick={RECHARTS_FONT_STYLE} />
-          <YAxis domain={yDomain} tick={RECHARTS_FONT_STYLE} tickFormatter={yTickFormatter}>
+          <YAxis
+            domain={yDomain}
+            tickCount={yTickCount}
+            tick={RECHARTS_FONT_STYLE}
+            tickFormatter={yTickFormatter}
+          >
             {yAxisLabel && (
               <Label
                 value={yAxisLabel}
@@ -134,7 +134,7 @@ export function WaterfallChart({
           </YAxis>
           <Tooltip content={tooltipContent ?? <WaterfallTooltip />} />
           <Bar
-            dataKey={waterfallRange as any}
+            dataKey="waterfallRange"
             isAnimationActive={false}
             label={<WaterfallBarLabel data={data} />}
           >

--- a/app/src/components/charts/waterfallUtils.ts
+++ b/app/src/components/charts/waterfallUtils.ts
@@ -22,6 +22,12 @@ export interface WaterfallDatum {
   barBottom: number;
   /** Top of the visible bar (data-space Y value) */
   barTop: number;
+  /**
+   * Range tuple `[barBottom, barTop]` for use as a Recharts Bar dataKey.
+   * Recharts renders range bars when a **string** dataKey points to a
+   * `[low, high]` array property. Function dataKeys do NOT support ranges.
+   */
+  waterfallRange: [number, number];
   /** Original signed value */
   value: number;
   /** Pre-formatted label for display inside bar */
@@ -70,6 +76,7 @@ export function computeWaterfallData(
       name,
       barBottom,
       barTop,
+      waterfallRange: [barBottom, barTop],
       value,
       label: formatValue(value),
       isTotal,

--- a/app/src/pages/report-output/budgetary-impact/BudgetaryImpactByProgramSubPage.tsx
+++ b/app/src/pages/report-output/budgetary-impact/BudgetaryImpactByProgramSubPage.tsx
@@ -20,6 +20,7 @@ import {
   formatBillions,
   getBudgetChartTitle,
   getBudgetFillColor,
+  makeBudgetTickFormatter,
 } from './budgetChartUtils';
 
 interface Props {
@@ -119,6 +120,7 @@ export default function BudgetaryImpactByProgramSubPage({ output }: Props) {
 
   const yDomain = getWaterfallDomain(data);
   const symbol = currencySymbol(countryId);
+  const tickFormatter = makeBudgetTickFormatter(symbol, yDomain);
 
   return (
     <ChartContainer
@@ -130,7 +132,7 @@ export default function BudgetaryImpactByProgramSubPage({ output }: Props) {
         yDomain={yDomain}
         height={chartHeight}
         yAxisLabel="Budgetary impact (bn)"
-        yTickFormatter={(v: number) => `${symbol}${v.toFixed(1)}`}
+        yTickFormatter={tickFormatter}
         fillColor={(d) => getBudgetFillColor(d, budgetaryImpact)}
         tooltipContent={<BudgetWaterfallTooltip />}
       />

--- a/app/src/pages/report-output/budgetary-impact/BudgetaryImpactSubPage.tsx
+++ b/app/src/pages/report-output/budgetary-impact/BudgetaryImpactSubPage.tsx
@@ -18,6 +18,7 @@ import {
   formatBillions,
   getBudgetChartTitle,
   getBudgetFillColor,
+  makeBudgetTickFormatter,
 } from './budgetChartUtils';
 
 interface Props {
@@ -108,6 +109,7 @@ export default function BudgetaryImpactSubPage({ output }: Props) {
 
   const yDomain = getWaterfallDomain(data);
   const symbol = currencySymbol(countryId);
+  const tickFormatter = makeBudgetTickFormatter(symbol, yDomain);
 
   return (
     <ChartContainer
@@ -119,7 +121,7 @@ export default function BudgetaryImpactSubPage({ output }: Props) {
         yDomain={yDomain}
         height={chartHeight}
         yAxisLabel="Budgetary impact (bn)"
-        yTickFormatter={(v: number) => `${symbol}${v.toFixed(1)}`}
+        yTickFormatter={tickFormatter}
         fillColor={(d) => getBudgetFillColor(d, budgetaryImpact)}
         tooltipContent={<BudgetWaterfallTooltip />}
       />

--- a/app/src/pages/report-output/budgetary-impact/budgetChartUtils.tsx
+++ b/app/src/pages/report-output/budgetary-impact/budgetChartUtils.tsx
@@ -55,3 +55,20 @@ export function getBudgetChartTitle(
 export function formatBillions(value: number, countryId: CountryId): string {
   return formatCurrencyAbbr(value, countryId, { maximumFractionDigits: 1 });
 }
+
+/**
+ * Creates a Y-axis tick formatter that adapts decimal precision to the data range.
+ * For narrow ranges (< 1bn) uses 2 decimals; otherwise uses 1 decimal.
+ * Avoids "-$0.0" by treating near-zero values as 0.
+ */
+export function makeBudgetTickFormatter(
+  symbol: string,
+  yDomain: [number, number]
+): (v: number) => string {
+  const range = yDomain[1] - yDomain[0];
+  const decimals = range < 1 ? 2 : 1;
+  return (v: number) => {
+    const display = Math.abs(v) < 1e-10 ? 0 : v;
+    return `${symbol}${display.toFixed(decimals)}`;
+  };
+}

--- a/app/src/tests/unit/components/charts/waterfallUtils.test.ts
+++ b/app/src/tests/unit/components/charts/waterfallUtils.test.ts
@@ -143,6 +143,21 @@ describe('computeWaterfallData', () => {
   it('returns empty array for empty input', () => {
     expect(computeWaterfallData([], fmt)).toEqual([]);
   });
+
+  it('includes waterfallRange tuple [barBottom, barTop] for Recharts range bars', () => {
+    const items: WaterfallItem[] = [
+      { name: 'A', value: 10 },
+      { name: 'B', value: -3 },
+      { name: 'Total', value: 7, isTotal: true },
+    ];
+
+    const result = computeWaterfallData(items, fmt);
+
+    // Recharts range bars require a data property (not a function) that is [low, high]
+    expect(result[0].waterfallRange).toEqual([0, 10]);
+    expect(result[1].waterfallRange).toEqual([7, 10]);
+    expect(result[2].waterfallRange).toEqual([0, 7]);
+  });
 });
 
 describe('getWaterfallDomain', () => {


### PR DESCRIPTION
## Summary

- **Fix range bars**: Recharts only supports range bars (`[low, high]` tuples) when `dataKey` is a **string** pointing to an array property on the datum. The previous code used a function dataKey, which Recharts interprets as returning a single number — causing all bars to start from 0.
  - Added `waterfallRange: [barBottom, barTop]` property to `WaterfallDatum`
  - Changed `<Bar dataKey={waterfallRange as any}>` to `<Bar dataKey="waterfallRange">`
- **Fix tick labels**: Added `makeBudgetTickFormatter` that adapts decimal precision to the data range (2 decimals for ranges < 1bn) and clamps near-zero values to avoid "-$0.0"
- **Added test**: Verifies `waterfallRange` tuple is correctly computed on each datum

## Test plan

- [x] Unit tests pass (231 passed)
- [x] Typecheck passes
- [x] Lint passes
- [ ] Visual verification of waterfall chart rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)