### PR TITLE
Apply getNiceTicks to all charts and add to design system

### DIFF
--- a/app/src/pages/report-output/distributional-impact/DistributionalImpactIncomeAverageSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/DistributionalImpactIncomeAverageSubPage.tsx
@@ -20,7 +20,12 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { absoluteChangeMessage } from '@/utils/chartMessages';
-import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  downloadCsv,
+  getClampedChartHeight,
+  getNiceTicks,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { currencySymbol, formatCurrency, ordinal, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
@@ -100,6 +105,10 @@ export default function DistributionalImpactIncomeAverageSubPage({ output }: Pro
     hoverText: hoverMessage(x, yArray[i]),
   }));
 
+  const values = chartData.map((d) => d.value);
+  const yDomain: [number, number] = [Math.min(0, ...values), Math.max(0, ...values)];
+  const yTicks = getNiceTicks(yDomain);
+
   const prefix = currencySymbol(countryId);
 
   // Description text
@@ -125,6 +134,8 @@ export default function DistributionalImpactIncomeAverageSubPage({ output }: Pro
               />
             </XAxis>
             <YAxis
+              ticks={yTicks}
+              domain={[yTicks[0], yTicks[yTicks.length - 1]]}
               tick={RECHARTS_FONT_STYLE}
               tickLine={false}
               tickFormatter={(v: number) => `${prefix}${v.toLocaleString()}`}

--- a/app/src/pages/report-output/distributional-impact/DistributionalImpactIncomeRelativeSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/DistributionalImpactIncomeRelativeSubPage.tsx
@@ -20,7 +20,12 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { relativeChangeMessage } from '@/utils/chartMessages';
-import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  downloadCsv,
+  getClampedChartHeight,
+  getNiceTicks,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { formatPercent, ordinal, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
@@ -95,6 +100,10 @@ export default function DistributionalImpactIncomeRelativeSubPage({ output }: Pr
     hoverText: hoverMessage(x, yArray[i]),
   }));
 
+  const values = chartData.map((d) => d.value);
+  const yDomain: [number, number] = [Math.min(0, ...values), Math.max(0, ...values)];
+  const yTicks = getNiceTicks(yDomain);
+
   // Description text
   const description = (
     <Text size="sm" c="dimmed">
@@ -118,6 +127,8 @@ export default function DistributionalImpactIncomeRelativeSubPage({ output }: Pr
               />
             </XAxis>
             <YAxis
+              ticks={yTicks}
+              domain={[yTicks[0], yTicks[yTicks.length - 1]]}
               tick={RECHARTS_FONT_STYLE}
               tickLine={false}
               tickFormatter={(v: number) => `${v >= 0 ? '+' : ''}${(v * 100).toFixed(1)}%`}

--- a/app/src/pages/report-output/distributional-impact/DistributionalImpactWealthAverageSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/DistributionalImpactWealthAverageSubPage.tsx
@@ -20,7 +20,12 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { absoluteChangeMessage } from '@/utils/chartMessages';
-import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  downloadCsv,
+  getClampedChartHeight,
+  getNiceTicks,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { currencySymbol, formatCurrency, ordinal, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
@@ -100,6 +105,10 @@ export default function DistributionalImpactWealthAverageSubPage({ output }: Pro
     hoverText: hoverMessage(x, yArray[i]),
   }));
 
+  const values = chartData.map((d) => d.value);
+  const yDomain: [number, number] = [Math.min(0, ...values), Math.max(0, ...values)];
+  const yTicks = getNiceTicks(yDomain);
+
   const prefix = currencySymbol(countryId);
 
   return (
@@ -117,6 +126,8 @@ export default function DistributionalImpactWealthAverageSubPage({ output }: Pro
               />
             </XAxis>
             <YAxis
+              ticks={yTicks}
+              domain={[yTicks[0], yTicks[yTicks.length - 1]]}
               tick={RECHARTS_FONT_STYLE}
               tickLine={false}
               tickFormatter={(v: number) => `${prefix}${v.toLocaleString()}`}

--- a/app/src/pages/report-output/distributional-impact/DistributionalImpactWealthRelativeSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/DistributionalImpactWealthRelativeSubPage.tsx
@@ -20,7 +20,12 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { relativeChangeMessage } from '@/utils/chartMessages';
-import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  downloadCsv,
+  getClampedChartHeight,
+  getNiceTicks,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { formatPercent, ordinal, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
@@ -95,6 +100,10 @@ export default function DistributionalImpactWealthRelativeSubPage({ output }: Pr
     hoverText: hoverMessage(x, yArray[i]),
   }));
 
+  const values = chartData.map((d) => d.value);
+  const yDomain: [number, number] = [Math.min(0, ...values), Math.max(0, ...values)];
+  const yTicks = getNiceTicks(yDomain);
+
   return (
     <ChartContainer title={getChartTitle()} onDownloadCsv={handleDownloadCsv}>
       <Stack gap={spacing.sm}>
@@ -110,6 +119,8 @@ export default function DistributionalImpactWealthRelativeSubPage({ output }: Pr
               />
             </XAxis>
             <YAxis
+              ticks={yTicks}
+              domain={[yTicks[0], yTicks[yTicks.length - 1]]}
               tick={RECHARTS_FONT_STYLE}
               tickLine={false}
               tickFormatter={(v: number) => `${v >= 0 ? '+' : ''}${(v * 100).toFixed(1)}%`}

--- a/app/src/pages/report-output/earnings-variation/BaselineAndReformChart.tsx
+++ b/app/src/pages/report-output/earnings-variation/BaselineAndReformChart.tsx
@@ -21,7 +21,7 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import type { Household } from '@/types/ingredients/Household';
-import { getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import { getClampedChartHeight, getNiceTicks, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
 import { currencySymbol } from '@/utils/formatters';
 import { getValueFromHousehold } from '@/utils/householdValues';
 
@@ -143,6 +143,12 @@ export default function BaselineAndReformChart({
     relativeDiff: relativeDiff[i],
   }));
 
+  const xTicks = getNiceTicks([0, maxEarnings]);
+  const allBothValues = [...baselineYValues, ...reformYValues];
+  const bothYTicks = getNiceTicks([Math.min(...allBothValues), Math.max(...allBothValues)]);
+  const absDiffTicks = getNiceTicks([Math.min(...absoluteDiff), Math.max(...absoluteDiff)]);
+  const relDiffTicks = getNiceTicks([Math.min(...relativeDiff), Math.max(...relativeDiff)]);
+
   // Render different charts based on view mode
   const renderChart = () => {
     if (viewMode === 'both') {
@@ -152,6 +158,7 @@ export default function BaselineAndReformChart({
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
               dataKey="earnings"
+              ticks={xTicks}
               tick={RECHARTS_FONT_STYLE}
               tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
             >
@@ -162,7 +169,11 @@ export default function BaselineAndReformChart({
                 style={RECHARTS_FONT_STYLE}
               />
             </XAxis>
-            <YAxis tick={RECHARTS_FONT_STYLE}>
+            <YAxis
+              ticks={bothYTicks}
+              domain={[bothYTicks[0], bothYTicks[bothYTicks.length - 1]]}
+              tick={RECHARTS_FONT_STYLE}
+            >
               <Label
                 value={variable.label}
                 angle={-90}
@@ -200,6 +211,7 @@ export default function BaselineAndReformChart({
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
               dataKey="earnings"
+              ticks={xTicks}
               tick={RECHARTS_FONT_STYLE}
               tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
             >
@@ -210,7 +222,11 @@ export default function BaselineAndReformChart({
                 style={RECHARTS_FONT_STYLE}
               />
             </XAxis>
-            <YAxis tick={RECHARTS_FONT_STYLE}>
+            <YAxis
+              ticks={absDiffTicks}
+              domain={[absDiffTicks[0], absDiffTicks[absDiffTicks.length - 1]]}
+              tick={RECHARTS_FONT_STYLE}
+            >
               <Label
                 value={`Change in ${variable.label}`}
                 angle={-90}
@@ -240,6 +256,7 @@ export default function BaselineAndReformChart({
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
             dataKey="earnings"
+            ticks={xTicks}
             tick={RECHARTS_FONT_STYLE}
             tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
           >
@@ -251,6 +268,8 @@ export default function BaselineAndReformChart({
             />
           </XAxis>
           <YAxis
+            ticks={relDiffTicks}
+            domain={[relDiffTicks[0], relDiffTicks[relDiffTicks.length - 1]]}
             tick={RECHARTS_FONT_STYLE}
             tickFormatter={(v: number) => `${(v * 100).toFixed(1)}%`}
           >

--- a/app/src/pages/report-output/earnings-variation/BaselineOnlyChart.tsx
+++ b/app/src/pages/report-output/earnings-variation/BaselineOnlyChart.tsx
@@ -17,7 +17,7 @@ import { colors } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import type { Household } from '@/types/ingredients/Household';
-import { getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import { getClampedChartHeight, getNiceTicks, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
 import { currencySymbol } from '@/utils/formatters';
 import { getValueFromHousehold } from '@/utils/householdValues';
 
@@ -104,6 +104,10 @@ export default function BaselineOnlyChart({
     value: yValues[i],
   }));
 
+  const xTicks = getNiceTicks([0, maxEarnings]);
+  const yNumValues = chartData.map((d) => d.value);
+  const yTicks = getNiceTicks([Math.min(...yNumValues), Math.max(...yNumValues)]);
+
   return (
     <div style={{ width: '100%', position: 'relative' }}>
       <ResponsiveContainer width="100%" height={chartHeight}>
@@ -111,6 +115,7 @@ export default function BaselineOnlyChart({
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
             dataKey="earnings"
+            ticks={xTicks}
             tick={RECHARTS_FONT_STYLE}
             tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
           >
@@ -121,7 +126,11 @@ export default function BaselineOnlyChart({
               style={RECHARTS_FONT_STYLE}
             />
           </XAxis>
-          <YAxis tick={RECHARTS_FONT_STYLE}>
+          <YAxis
+            ticks={yTicks}
+            domain={[yTicks[0], yTicks[yTicks.length - 1]]}
+            tick={RECHARTS_FONT_STYLE}
+          >
             <Label
               value={variable.label}
               angle={-90}

--- a/app/src/pages/report-output/inequality-impact/InequalityImpactSubPage.tsx
+++ b/app/src/pages/report-output/inequality-impact/InequalityImpactSubPage.tsx
@@ -20,7 +20,12 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { relativeChangeMessage } from '@/utils/chartMessages';
-import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  downloadCsv,
+  getClampedChartHeight,
+  getNiceTicks,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { formatPercent, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
@@ -126,6 +131,10 @@ export default function InequalityImpactSubPage({ output }: Props) {
     hoverText: hoverMessage(label),
   }));
 
+  const values = chartData.map((d) => d.value);
+  const yDomain: [number, number] = [Math.min(0, ...values), Math.max(0, ...values)];
+  const yTicks = getNiceTicks(yDomain);
+
   return (
     <ChartContainer title={getChartTitle()} onDownloadCsv={handleDownloadCsv}>
       <Stack gap={spacing.sm}>
@@ -134,6 +143,8 @@ export default function InequalityImpactSubPage({ output }: Props) {
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
             <XAxis dataKey="name" tick={RECHARTS_FONT_STYLE} />
             <YAxis
+              ticks={yTicks}
+              domain={[yTicks[0], yTicks[yTicks.length - 1]]}
               tickFormatter={(v: number) => `${(v * 100).toFixed(ytickPrecision)}%`}
               tick={RECHARTS_FONT_STYLE}
             >

--- a/app/src/pages/report-output/marginal-tax-rates/MarginalTaxRatesSubPage.tsx
+++ b/app/src/pages/report-output/marginal-tax-rates/MarginalTaxRatesSubPage.tsx
@@ -27,7 +27,7 @@ import type { Household } from '@/types/ingredients/Household';
 import type { Policy } from '@/types/ingredients/Policy';
 import type { Simulation } from '@/types/ingredients/Simulation';
 import type { UserPolicy } from '@/types/ingredients/UserPolicy';
-import { getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import { getClampedChartHeight, getNiceTicks, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
 import { currencySymbol } from '@/utils/formatters';
 import { getValueFromHousehold } from '@/utils/householdValues';
 import LoadingPage from '../LoadingPage';
@@ -246,6 +246,11 @@ export default function MarginalTaxRatesSubPage({
     ...(mtrDifference && { difference: mtrDifference[i] }),
   }));
 
+  const xTicks = getNiceTicks([0, maxEarnings]);
+  const mtrTicks = getNiceTicks([-2, 2]);
+  const diffValues = mtrDifference ? mtrDifference.filter((v) => v !== undefined) : [0];
+  const diffTicks = getNiceTicks([Math.min(0, ...diffValues), Math.max(0, ...diffValues)]);
+
   const renderChart = () => {
     if (!reform || !reformMTRClipped || viewMode === 'both') {
       return (
@@ -254,6 +259,7 @@ export default function MarginalTaxRatesSubPage({
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
               dataKey="earnings"
+              ticks={xTicks}
               tick={RECHARTS_FONT_STYLE}
               tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
             >
@@ -266,6 +272,7 @@ export default function MarginalTaxRatesSubPage({
             </XAxis>
             <YAxis
               domain={[-2, 2]}
+              ticks={mtrTicks}
               tick={RECHARTS_FONT_STYLE}
               tickFormatter={(v: number) => `${(v * 100).toFixed(0)}%`}
             >
@@ -322,6 +329,7 @@ export default function MarginalTaxRatesSubPage({
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
             dataKey="earnings"
+            ticks={xTicks}
             tick={RECHARTS_FONT_STYLE}
             tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
           >
@@ -333,6 +341,8 @@ export default function MarginalTaxRatesSubPage({
             />
           </XAxis>
           <YAxis
+            ticks={diffTicks}
+            domain={[diffTicks[0], diffTicks[diffTicks.length - 1]]}
             tick={RECHARTS_FONT_STYLE}
             tickFormatter={(v: number) => `${(v * 100).toFixed(1)}%`}
           >

--- a/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByAgeSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByAgeSubPage.tsx
@@ -20,7 +20,12 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { relativeChangeMessage } from '@/utils/chartMessages';
-import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  downloadCsv,
+  getClampedChartHeight,
+  getNiceTicks,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { formatNumber, formatPercent, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
@@ -128,6 +133,10 @@ export default function DeepPovertyImpactByAgeSubPage({ output }: Props) {
     hoverText: hoverMessage(label),
   }));
 
+  const values = chartData.map((d) => d.value);
+  const yDomain: [number, number] = [Math.min(0, ...values), Math.max(0, ...values)];
+  const yTicks = getNiceTicks(yDomain);
+
   // Description text
   const getDescription = () => {
     const term1 = 'The deep poverty rate is ';
@@ -151,6 +160,8 @@ export default function DeepPovertyImpactByAgeSubPage({ output }: Props) {
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
             <XAxis dataKey="name" tick={RECHARTS_FONT_STYLE} />
             <YAxis
+              ticks={yTicks}
+              domain={[yTicks[0], yTicks[yTicks.length - 1]]}
               tickFormatter={(v: number) => `${(v * 100).toFixed(ytickPrecision)}%`}
               tick={RECHARTS_FONT_STYLE}
             >

--- a/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByGenderSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByGenderSubPage.tsx
@@ -20,7 +20,12 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { relativeChangeMessage } from '@/utils/chartMessages';
-import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  downloadCsv,
+  getClampedChartHeight,
+  getNiceTicks,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { formatNumber, formatPercent, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
@@ -135,6 +140,10 @@ export default function DeepPovertyImpactByGenderSubPage({ output }: Props) {
     hoverText: hoverMessage(label),
   }));
 
+  const values = chartData.map((d) => d.value);
+  const yDomain: [number, number] = [Math.min(0, ...values), Math.max(0, ...values)];
+  const yTicks = getNiceTicks(yDomain);
+
   // Description text
   const getDescription = () => {
     const term1 = 'The deep poverty rate is ';
@@ -158,6 +167,8 @@ export default function DeepPovertyImpactByGenderSubPage({ output }: Props) {
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
             <XAxis dataKey="name" tick={RECHARTS_FONT_STYLE} />
             <YAxis
+              ticks={yTicks}
+              domain={[yTicks[0], yTicks[yTicks.length - 1]]}
               tickFormatter={(v: number) => `${(v * 100).toFixed(ytickPrecision)}%`}
               tick={RECHARTS_FONT_STYLE}
             >

--- a/app/src/pages/report-output/poverty-impact/PovertyImpactByAgeSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/PovertyImpactByAgeSubPage.tsx
@@ -20,7 +20,12 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { relativeChangeMessage } from '@/utils/chartMessages';
-import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  downloadCsv,
+  getClampedChartHeight,
+  getNiceTicks,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { formatNumber, formatPercent, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
@@ -127,6 +132,10 @@ export default function PovertyImpactByAgeSubPage({ output }: Props) {
     hoverText: hoverMessage(label),
   }));
 
+  const values = chartData.map((d) => d.value);
+  const yDomain: [number, number] = [Math.min(0, ...values), Math.max(0, ...values)];
+  const yTicks = getNiceTicks(yDomain);
+
   // Description text
   const getDescription = () => {
     const term1 = 'The poverty rate is ';
@@ -150,6 +159,8 @@ export default function PovertyImpactByAgeSubPage({ output }: Props) {
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
             <XAxis dataKey="name" tick={RECHARTS_FONT_STYLE} />
             <YAxis
+              ticks={yTicks}
+              domain={[yTicks[0], yTicks[yTicks.length - 1]]}
               tickFormatter={(v: number) => `${(v * 100).toFixed(ytickPrecision)}%`}
               tick={RECHARTS_FONT_STYLE}
             >

--- a/app/src/pages/report-output/poverty-impact/PovertyImpactByGenderSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/PovertyImpactByGenderSubPage.tsx
@@ -20,7 +20,12 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { relativeChangeMessage } from '@/utils/chartMessages';
-import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  downloadCsv,
+  getClampedChartHeight,
+  getNiceTicks,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { formatNumber, formatPercent, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
@@ -135,6 +140,10 @@ export default function PovertyImpactByGenderSubPage({ output }: Props) {
     hoverText: hoverMessage(label),
   }));
 
+  const values = chartData.map((d) => d.value);
+  const yDomain: [number, number] = [Math.min(0, ...values), Math.max(0, ...values)];
+  const yTicks = getNiceTicks(yDomain);
+
   // Description text
   const getDescription = () => {
     const term1 = 'The poverty rate is ';
@@ -158,6 +167,8 @@ export default function PovertyImpactByGenderSubPage({ output }: Props) {
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
             <XAxis dataKey="name" tick={RECHARTS_FONT_STYLE} />
             <YAxis
+              ticks={yTicks}
+              domain={[yTicks[0], yTicks[yTicks.length - 1]]}
               tickFormatter={(v: number) => `${(v * 100).toFixed(ytickPrecision)}%`}
               tick={RECHARTS_FONT_STYLE}
             >

--- a/app/src/pages/report-output/poverty-impact/PovertyImpactByRaceSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/PovertyImpactByRaceSubPage.tsx
@@ -20,7 +20,12 @@ import { spacing } from '@/designTokens/spacing';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { RootState } from '@/store';
 import { relativeChangeMessage } from '@/utils/chartMessages';
-import { downloadCsv, getClampedChartHeight, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  downloadCsv,
+  getClampedChartHeight,
+  getNiceTicks,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { formatNumber, formatPercent, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
 
@@ -129,6 +134,10 @@ export default function PovertyImpactByRaceSubPage({ output }: Props) {
     hoverText: hoverMessage(label),
   }));
 
+  const values = chartData.map((d) => d.value);
+  const yDomain: [number, number] = [Math.min(0, ...values), Math.max(0, ...values)];
+  const yTicks = getNiceTicks(yDomain);
+
   // Description text
   const getDescription = () => {
     const term1 = 'The poverty rate is ';
@@ -152,6 +161,8 @@ export default function PovertyImpactByRaceSubPage({ output }: Props) {
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
             <XAxis dataKey="name" tick={RECHARTS_FONT_STYLE} />
             <YAxis
+              ticks={yTicks}
+              domain={[yTicks[0], yTicks[yTicks.length - 1]]}
               tickFormatter={(v: number) => `${(v * 100).toFixed(ytickPrecision)}%`}
               tick={RECHARTS_FONT_STYLE}
             >

--- a/app/src/pathways/report/components/policyParameterSelector/HistoricalValues.tsx
+++ b/app/src/pathways/report/components/policyParameterSelector/HistoricalValues.tsx
@@ -21,7 +21,7 @@ import {
   filterInfiniteValues,
   getChartBoundaryDates,
 } from '@/utils/chartDateUtils';
-import { getReformPolicyLabel, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import { getNiceTicks, getReformPolicyLabel, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
 import { formatParameterValue, getRechartsTickFormatter } from '@/utils/chartValueUtils';
 import { capitalize } from '@/utils/stringUtils';
 
@@ -179,42 +179,16 @@ export const ParameterOverTimeChart = memo((props: ParameterOverTimeChartProps) 
         maxY = Math.max(maxY, 1);
       }
 
-      // Compute nice tick step
-      const yRange = maxY - minY;
-      const targetTicks = 5;
-      const rawStep = yRange / targetTicks;
-      if (rawStep <= 0) {
+      if (minY === maxY) {
         return { maxDate, yMin: 0, yMax: 1, yTicks: [0, 1] };
       }
-      const magnitude = 10 ** Math.floor(Math.log10(rawStep));
-      const normalized = rawStep / magnitude;
-      let niceStep: number;
-      if (normalized <= 1) {
-        niceStep = 1 * magnitude;
-      } else if (normalized <= 2) {
-        niceStep = 2 * magnitude;
-      } else if (normalized <= 2.5) {
-        niceStep = 2.5 * magnitude;
-      } else if (normalized <= 5) {
-        niceStep = 5 * magnitude;
-      } else {
-        niceStep = 10 * magnitude;
-      }
 
-      // Round to nice boundaries (always include 0)
-      const niceMin = minY < 0 ? Math.floor(minY / niceStep) * niceStep : 0;
-      const niceMax = Math.ceil(maxY / niceStep) * niceStep;
-
-      // Generate tick array
-      const ticks: number[] = [];
-      for (let v = niceMin; v <= niceMax; v += niceStep) {
-        ticks.push(Math.round(v * 1e10) / 1e10);
-      }
+      const ticks = getNiceTicks([minY, maxY]);
 
       return {
         maxDate,
-        yMin: niceMin,
-        yMax: niceMax,
+        yMin: ticks[0],
+        yMax: ticks[ticks.length - 1],
         yTicks: ticks,
       };
     } catch (error) {


### PR DESCRIPTION
## Summary

- Adds human-friendly axis tick values (D3-style snapping to 1/2/2.5/5 multiples) to all 13 report chart pages plus the HistoricalValues parameter chart
- Exports `getNiceTicks` from `@policyengine/design-system` so other PE tools (e.g. marriage calculator) can import it via `import { getNiceTicks } from '@policyengine/design-system'`
- Replaces the duplicate 30-line tick computation in `HistoricalValues.tsx` with a single `getNiceTicks()` call

### Files updated (15)
- `packages/design-system/src/charts/index.ts` — new export
- `HistoricalValues.tsx` — removed duplicate, imports shared util
- 5 poverty impact pages (age, gender, race, deep poverty age/gender)
- 4 distributional impact pages (income/wealth relative/average)
- `InequalityImpactSubPage.tsx`
- `BaselineOnlyChart.tsx`, `BaselineAndReformChart.tsx`
- `MarginalTaxRatesSubPage.tsx`

## Test plan
- [x] All 232 test files pass (2875 tests)
- [x] TypeScript compiles clean
- [x] ESLint + Stylelint pass
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)