### PR TITLE
Simplify chart data construction and description text

### DIFF
--- a/app/src/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.tsx
@@ -85,21 +85,13 @@ export default function WinnersLosersIncomeDecileSubPage({ output }: Props) {
   // Transform data for Recharts
   const decileData = decileNumbers.map((decile) => ({
     name: decile.toString(),
-    'Gain more than 5%': deciles['Gain more than 5%'][decile - 1],
-    'Gain less than 5%': deciles['Gain less than 5%'][decile - 1],
-    'No change': deciles['No change'][decile - 1],
-    'Lose less than 5%': deciles['Lose less than 5%'][decile - 1],
-    'Lose more than 5%': deciles['Lose more than 5%'][decile - 1],
+    ...Object.fromEntries(CATEGORIES.map((cat) => [cat, deciles[cat][decile - 1]])),
   }));
 
   const allData = [
     {
       name: 'All',
-      'Gain more than 5%': all['Gain more than 5%'],
-      'Gain less than 5%': all['Gain less than 5%'],
-      'No change': all['No change'],
-      'Lose less than 5%': all['Lose less than 5%'],
-      'Lose more than 5%': all['Lose more than 5%'],
+      ...Object.fromEntries(CATEGORIES.map((cat) => [cat, all[cat]])),
     },
   ];
 
@@ -128,34 +120,15 @@ export default function WinnersLosersIncomeDecileSubPage({ output }: Props) {
 
   // CSV export handler
   const handleDownloadCsv = () => {
-    const header = [
-      'Decile',
-      'Gain more than 5%',
-      'Gain less than 5%',
-      'No change',
-      'Lose less than 5%',
-      'Lose more than 5%',
-    ];
-    const data = [
-      header,
-      ...decileNumbers.map((decile) => [
-        decile.toString(),
-        deciles['Gain more than 5%'][decile - 1].toString(),
-        deciles['Gain less than 5%'][decile - 1].toString(),
-        deciles['No change'][decile - 1].toString(),
-        deciles['Lose less than 5%'][decile - 1].toString(),
-        deciles['Lose more than 5%'][decile - 1].toString(),
+    const header = ['Decile', ...CATEGORIES];
+    const rows = [
+      ...decileNumbers.map((d) => [
+        d.toString(),
+        ...CATEGORIES.map((cat) => deciles[cat][d - 1].toString()),
       ]),
-      [
-        'All',
-        all['Gain more than 5%'].toString(),
-        all['Gain less than 5%'].toString(),
-        all['No change'].toString(),
-        all['Lose less than 5%'].toString(),
-        all['Lose more than 5%'].toString(),
-      ],
+      ['All', ...CATEGORIES.map((cat) => all[cat].toString())],
     ];
-    downloadCsv(data, 'winners-losers-income-decile.csv');
+    downloadCsv([header, ...rows], 'winners-losers-income-decile.csv');
   };
 
   // Description text

--- a/app/src/pages/report-output/distributional-impact/WinnersLosersWealthDecileSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/WinnersLosersWealthDecileSubPage.tsx
@@ -91,21 +91,13 @@ export default function WinnersLosersWealthDecileSubPage({ output }: Props) {
   // Transform data for Recharts
   const decileData = decileNumbers.map((decile) => ({
     name: decile.toString(),
-    'Gain more than 5%': (deciles as any)['Gain more than 5%']?.[decile - 1] || 0,
-    'Gain less than 5%': (deciles as any)['Gain less than 5%']?.[decile - 1] || 0,
-    'No change': (deciles as any)['No change']?.[decile - 1] || 0,
-    'Lose less than 5%': (deciles as any)['Lose less than 5%']?.[decile - 1] || 0,
-    'Lose more than 5%': (deciles as any)['Lose more than 5%']?.[decile - 1] || 0,
+    ...Object.fromEntries(CATEGORIES.map((cat) => [cat, (deciles as any)[cat]?.[decile - 1] || 0])),
   }));
 
   const allData = [
     {
       name: 'All',
-      'Gain more than 5%': all['Gain more than 5%'],
-      'Gain less than 5%': all['Gain less than 5%'],
-      'No change': all['No change'],
-      'Lose less than 5%': all['Lose less than 5%'],
-      'Lose more than 5%': all['Lose more than 5%'],
+      ...Object.fromEntries(CATEGORIES.map((cat) => [cat, all[cat]])),
     },
   ];
 

--- a/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByAgeSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByAgeSubPage.tsx
@@ -135,19 +135,12 @@ export default function DeepPovertyImpactByAgeSubPage({ output }: Props) {
   const yTicks = getNiceTicks(yDomain);
 
   // Description text
-  const getDescription = () => {
-    const term1 = 'The deep poverty rate is ';
-    const term2 = `the population share in ${
-      countryId === 'uk' ? 'resource units' : 'households'
-    } with `;
-    const term3 = 'net income (after taxes and transfers) below half their poverty threshold.';
-    const more = term1 + term2 + term3;
-
-    if (countryId === 'uk') {
-      return `PolicyEngine reports the impact to absolute poverty before housing costs. ${more}`;
-    }
-    return `PolicyEngine reports the impact to the Supplemental Poverty Measure. ${more}`;
-  };
+  const povertyMeasure =
+    countryId === 'uk'
+      ? 'absolute poverty before housing costs'
+      : 'the Supplemental Poverty Measure';
+  const unitTerm = countryId === 'uk' ? 'resource units' : 'households';
+  const description = `PolicyEngine reports the impact to ${povertyMeasure}. The deep poverty rate is the population share in ${unitTerm} with net income (after taxes and transfers) below half their poverty threshold.`;
 
   return (
     <ChartContainer title={getChartTitle()} onDownloadCsv={handleDownloadCsv}>
@@ -180,7 +173,7 @@ export default function DeepPovertyImpactByAgeSubPage({ output }: Props) {
         <ChartWatermark />
 
         <Text size="sm" c="dimmed">
-          {getDescription()}
+          {description}
         </Text>
       </Stack>
     </ChartContainer>

--- a/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByGenderSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByGenderSubPage.tsx
@@ -142,19 +142,12 @@ export default function DeepPovertyImpactByGenderSubPage({ output }: Props) {
   const yTicks = getNiceTicks(yDomain);
 
   // Description text
-  const getDescription = () => {
-    const term1 = 'The deep poverty rate is ';
-    const term2 = `the population share in ${
-      countryId === 'uk' ? 'resource units' : 'households'
-    } with `;
-    const term3 = 'net income (after taxes and transfers) below half their poverty threshold.';
-    const more = term1 + term2 + term3;
-
-    if (countryId === 'uk') {
-      return `PolicyEngine reports the impact to absolute poverty before housing costs. ${more}`;
-    }
-    return `PolicyEngine reports the impact to the Supplemental Poverty Measure. ${more}`;
-  };
+  const povertyMeasure =
+    countryId === 'uk'
+      ? 'absolute poverty before housing costs'
+      : 'the Supplemental Poverty Measure';
+  const unitTerm = countryId === 'uk' ? 'resource units' : 'households';
+  const description = `PolicyEngine reports the impact to ${povertyMeasure}. The deep poverty rate is the population share in ${unitTerm} with net income (after taxes and transfers) below half their poverty threshold.`;
 
   return (
     <ChartContainer title={getChartTitle()} onDownloadCsv={handleDownloadCsv}>
@@ -187,7 +180,7 @@ export default function DeepPovertyImpactByGenderSubPage({ output }: Props) {
         <ChartWatermark />
 
         <Text size="sm" c="dimmed">
-          {getDescription()}
+          {description}
         </Text>
       </Stack>
     </ChartContainer>

--- a/app/src/pages/report-output/poverty-impact/PovertyImpactByAgeSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/PovertyImpactByAgeSubPage.tsx
@@ -134,19 +134,12 @@ export default function PovertyImpactByAgeSubPage({ output }: Props) {
   const yTicks = getNiceTicks(yDomain);
 
   // Description text
-  const getDescription = () => {
-    const term1 = 'The poverty rate is ';
-    const term2 = `the population share in ${
-      countryId === 'uk' ? 'resource units' : 'households'
-    } with `;
-    const term3 = 'net income (after taxes and transfers) below their poverty threshold.';
-    const more = term1 + term2 + term3;
-
-    if (countryId === 'uk') {
-      return `PolicyEngine reports the impact to absolute poverty before housing costs. ${more}`;
-    }
-    return `PolicyEngine reports the impact to the Supplemental Poverty Measure. ${more}`;
-  };
+  const povertyMeasure =
+    countryId === 'uk'
+      ? 'absolute poverty before housing costs'
+      : 'the Supplemental Poverty Measure';
+  const unitTerm = countryId === 'uk' ? 'resource units' : 'households';
+  const description = `PolicyEngine reports the impact to ${povertyMeasure}. The poverty rate is the population share in ${unitTerm} with net income (after taxes and transfers) below their poverty threshold.`;
 
   return (
     <ChartContainer title={getChartTitle()} onDownloadCsv={handleDownloadCsv}>
@@ -179,7 +172,7 @@ export default function PovertyImpactByAgeSubPage({ output }: Props) {
         <ChartWatermark />
 
         <Text size="sm" c="dimmed">
-          {getDescription()}
+          {description}
         </Text>
       </Stack>
     </ChartContainer>

--- a/app/src/pages/report-output/poverty-impact/PovertyImpactByGenderSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/PovertyImpactByGenderSubPage.tsx
@@ -142,19 +142,12 @@ export default function PovertyImpactByGenderSubPage({ output }: Props) {
   const yTicks = getNiceTicks(yDomain);
 
   // Description text
-  const getDescription = () => {
-    const term1 = 'The poverty rate is ';
-    const term2 = `the population share in ${
-      countryId === 'uk' ? 'resource units' : 'households'
-    } with `;
-    const term3 = 'net income (after taxes and transfers) below their poverty threshold.';
-    const more = term1 + term2 + term3;
-
-    if (countryId === 'uk') {
-      return `PolicyEngine reports the impact to absolute poverty before housing costs. ${more}`;
-    }
-    return `PolicyEngine reports the impact to the Supplemental Poverty Measure. ${more}`;
-  };
+  const povertyMeasure =
+    countryId === 'uk'
+      ? 'absolute poverty before housing costs'
+      : 'the Supplemental Poverty Measure';
+  const unitTerm = countryId === 'uk' ? 'resource units' : 'households';
+  const description = `PolicyEngine reports the impact to ${povertyMeasure}. The poverty rate is the population share in ${unitTerm} with net income (after taxes and transfers) below their poverty threshold.`;
 
   return (
     <ChartContainer title={getChartTitle()} onDownloadCsv={handleDownloadCsv}>
@@ -187,7 +180,7 @@ export default function PovertyImpactByGenderSubPage({ output }: Props) {
         <ChartWatermark />
 
         <Text size="sm" c="dimmed">
-          {getDescription()}
+          {description}
         </Text>
       </Stack>
     </ChartContainer>

--- a/app/src/pages/report-output/poverty-impact/PovertyImpactByRaceSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/PovertyImpactByRaceSubPage.tsx
@@ -136,19 +136,12 @@ export default function PovertyImpactByRaceSubPage({ output }: Props) {
   const yTicks = getNiceTicks(yDomain);
 
   // Description text
-  const getDescription = () => {
-    const term1 = 'The poverty rate is ';
-    const term2 = `the population share in ${
-      countryId === 'uk' ? 'resource units' : 'households'
-    } with `;
-    const term3 = 'net income (after taxes and transfers) below their poverty threshold.';
-    const more = term1 + term2 + term3;
-
-    if (countryId === 'uk') {
-      return `PolicyEngine reports the impact to absolute poverty before housing costs. ${more}`;
-    }
-    return `PolicyEngine reports the impact to the Supplemental Poverty Measure. ${more}`;
-  };
+  const povertyMeasure =
+    countryId === 'uk'
+      ? 'absolute poverty before housing costs'
+      : 'the Supplemental Poverty Measure';
+  const unitTerm = countryId === 'uk' ? 'resource units' : 'households';
+  const description = `PolicyEngine reports the impact to ${povertyMeasure}. The poverty rate is the population share in ${unitTerm} with net income (after taxes and transfers) below their poverty threshold.`;
 
   return (
     <ChartContainer title={getChartTitle()} onDownloadCsv={handleDownloadCsv}>
@@ -181,7 +174,7 @@ export default function PovertyImpactByRaceSubPage({ output }: Props) {
         <ChartWatermark />
 
         <Text size="sm" c="dimmed">
-          {getDescription()}
+          {description}
         </Text>
       </Stack>
     </ChartContainer>


### PR DESCRIPTION
## Summary
- DRY up winners/losers data transforms and CSV export using `Object.fromEntries` with `CATEGORIES` array (removes 5 repeated key-value pairs per transform)
- Replace `getDescription()` functions with inline template literals in all 5 poverty/deep poverty chart pages

Follow-up to #686 (chart polish).

## Test plan
- [x] Lint passes
- [x] Prettier applied
- [ ] Visual verification on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)