### PR TITLE
Fix negative currency formatting: -$31 not $-31

### DIFF
--- a/app/src/tests/fixtures/utils/chartValueUtilsMocks.ts
+++ b/app/src/tests/fixtures/utils/chartValueUtilsMocks.ts
@@ -48,7 +48,7 @@ export const EXPECTED_FORMATS = {
   NULL: 'N/A',
   UNDEFINED: 'N/A',
   ZERO: '$0.00',
-  NEGATIVE: '$-100.50',
+  NEGATIVE: '-$100.50',
 } as const;
 
 // Sample data arrays for axis formatting

--- a/app/src/tests/unit/utils/chartValueUtils.test.ts
+++ b/app/src/tests/unit/utils/chartValueUtils.test.ts
@@ -26,7 +26,11 @@ import {
   UNITS,
   ZERO_VALUE,
 } from '@/tests/fixtures/utils/chartValueUtilsMocks';
-import { formatParameterValue, getPlotlyAxisFormat } from '@/utils/chartValueUtils';
+import {
+  formatParameterValue,
+  getPlotlyAxisFormat,
+  getRechartsTickFormatter,
+} from '@/utils/chartValueUtils';
 
 describe('chartValueUtils', () => {
   describe('formatParameterValue', () => {
@@ -316,6 +320,48 @@ describe('chartValueUtils', () => {
       it('should handle single value', () => {
         const result = getPlotlyAxisFormat(UNITS.NUMERIC, [42]);
         expect(result.range).toEqual([42, 42]);
+      });
+    });
+  });
+
+  describe('negative currency formatting', () => {
+    describe('formatParameterValue', () => {
+      it('should place negative sign before USD symbol', () => {
+        expect(formatParameterValue(-31, UNITS.USD, { decimalPlaces: 0 })).toBe('-$31');
+      });
+
+      it('should place negative sign before GBP symbol', () => {
+        expect(formatParameterValue(-500, UNITS.GBP, { decimalPlaces: 0 })).toBe('-£500');
+      });
+
+      it('should format positive USD normally', () => {
+        expect(formatParameterValue(31, UNITS.USD, { decimalPlaces: 0 })).toBe('$31');
+      });
+
+      it('should format zero USD without negative sign', () => {
+        expect(formatParameterValue(0, UNITS.USD, { decimalPlaces: 0 })).toBe('$0');
+      });
+    });
+
+    describe('getRechartsTickFormatter', () => {
+      it('should place negative sign before USD symbol', () => {
+        const formatter = getRechartsTickFormatter(UNITS.USD, { decimalPlaces: 0 });
+        expect(formatter(-31)).toBe('-$31');
+      });
+
+      it('should place negative sign before GBP symbol', () => {
+        const formatter = getRechartsTickFormatter(UNITS.GBP, { decimalPlaces: 0 });
+        expect(formatter(-500)).toBe('-£500');
+      });
+
+      it('should place negative sign before USD symbol in compact mode', () => {
+        const formatter = getRechartsTickFormatter(UNITS.USD, { compact: true });
+        expect(formatter(-1500)).toBe('-$1.5K');
+      });
+
+      it('should format positive USD normally in compact mode', () => {
+        const formatter = getRechartsTickFormatter(UNITS.USD, { compact: true });
+        expect(formatter(1500)).toBe('$1.5K');
       });
     });
   });

--- a/app/src/tests/unit/utils/policyTableHelpers.test.ts
+++ b/app/src/tests/unit/utils/policyTableHelpers.test.ts
@@ -158,20 +158,28 @@ describe('policyTableHelpers', () => {
     });
 
     describe('Negative numbers', () => {
-      test('given negative integer with currency then formats with one decimal place', () => {
+      test('given negative integer with currency then formats with sign before symbol', () => {
         // Given / When
         const result = formatParameterValue(-1000, 'currency-USD');
 
         // Then
-        expect(result).toBe('$-1,000.0');
+        expect(result).toBe('-$1,000.0');
       });
 
-      test('given negative decimal with currency then formats correctly', () => {
+      test('given negative decimal with currency then formats with sign before symbol', () => {
         // Given / When
         const result = formatParameterValue(-1234.5, 'currency-USD');
 
         // Then
-        expect(result).toBe('$-1,234.5');
+        expect(result).toBe('-$1,234.5');
+      });
+
+      test('given negative GBP value then formats with sign before symbol', () => {
+        // Given / When
+        const result = formatParameterValue(-500, 'currency-GBP');
+
+        // Then
+        expect(result).toBe('-£500.0');
       });
 
       test('given negative percentage then formats with one decimal place', () => {

--- a/app/src/utils/chartValueUtils.ts
+++ b/app/src/utils/chartValueUtils.ts
@@ -52,19 +52,19 @@ export function formatParameterValue(
   const gbpUnits = ['currency-GBP', 'currency_GBP', 'GBP'];
 
   if (currencyUnits.includes(unit || '')) {
-    const symbol = includeSymbol ? '$' : '';
-    return `${symbol}${Number(value).toLocaleString('en-US', {
+    return Number(value).toLocaleString('en-US', {
+      ...(includeSymbol && { style: 'currency', currency: 'USD' }),
       minimumFractionDigits: decimalPlaces,
       maximumFractionDigits: decimalPlaces,
-    })}`;
+    });
   }
 
   if (gbpUnits.includes(unit || '')) {
-    const symbol = includeSymbol ? '£' : '';
-    return `${symbol}${Number(value).toLocaleString('en-GB', {
+    return Number(value).toLocaleString('en-GB', {
+      ...(includeSymbol && { style: 'currency', currency: 'GBP' }),
       minimumFractionDigits: decimalPlaces,
       maximumFractionDigits: decimalPlaces,
-    })}`;
+    });
   }
 
   // Default numeric formatting
@@ -185,18 +185,36 @@ export function getRechartsTickFormatter(
   if (currencyUnits.includes(unit)) {
     return (value: number) => {
       if (compact) {
-        return `$${compactNumber(value)}`;
+        return value.toLocaleString('en-US', {
+          style: 'currency',
+          currency: 'USD',
+          notation: 'compact',
+          maximumFractionDigits: decimalPlaces,
+        });
       }
-      return `$${value.toLocaleString('en-US', { maximumFractionDigits: decimalPlaces })}`;
+      return value.toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: decimalPlaces,
+      });
     };
   }
 
   if (gbpUnits.includes(unit)) {
     return (value: number) => {
       if (compact) {
-        return `£${compactNumber(value)}`;
+        return value.toLocaleString('en-GB', {
+          style: 'currency',
+          currency: 'GBP',
+          notation: 'compact',
+          maximumFractionDigits: decimalPlaces,
+        });
       }
-      return `£${value.toLocaleString('en-GB', { maximumFractionDigits: decimalPlaces })}`;
+      return value.toLocaleString('en-GB', {
+        style: 'currency',
+        currency: 'GBP',
+        maximumFractionDigits: decimalPlaces,
+      });
     };
   }
 
@@ -206,24 +224,6 @@ export function getRechartsTickFormatter(
 
   // Default numeric
   return (value: number) => value.toLocaleString('en-US', { maximumFractionDigits: decimalPlaces });
-}
-
-/**
- * Compact number display for large values (1K, 1M, 1B)
- */
-function compactNumber(value: number): string {
-  const abs = Math.abs(value);
-  const sign = value < 0 ? '-' : '';
-  if (abs >= 1_000_000_000) {
-    return `${sign}${(abs / 1_000_000_000).toFixed(1)}B`;
-  }
-  if (abs >= 1_000_000) {
-    return `${sign}${(abs / 1_000_000).toFixed(1)}M`;
-  }
-  if (abs >= 1_000) {
-    return `${sign}${(abs / 1_000).toFixed(1)}K`;
-  }
-  return `${sign}${abs.toFixed(0)}`;
 }
 
 /**

--- a/app/src/utils/policyTableHelpers.ts
+++ b/app/src/utils/policyTableHelpers.ts
@@ -81,16 +81,20 @@ export function formatParameterValue(value: any, unit?: string): string {
       return `${percentValue.toFixed(DECIMAL_PRECISION)}%`;
     }
     if (unit === 'currency-USD') {
-      return `$${value.toLocaleString('en-US', {
+      return value.toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
         minimumFractionDigits: DECIMAL_PRECISION,
         maximumFractionDigits: DECIMAL_PRECISION,
-      })}`;
+      });
     }
     if (unit === 'currency-GBP') {
-      return `£${value.toLocaleString('en-GB', {
+      return value.toLocaleString('en-GB', {
+        style: 'currency',
+        currency: 'GBP',
         minimumFractionDigits: DECIMAL_PRECISION,
         maximumFractionDigits: DECIMAL_PRECISION,
-      })}`;
+      });
     }
     return value.toLocaleString('en-US', {
       minimumFractionDigits: DECIMAL_PRECISION,


### PR DESCRIPTION
## Summary
- Place the negative sign before the currency symbol in all manual currency formatters (`formatParameterValue`, `getRechartsTickFormatter`, `policyTableHelpers`)
- Fixes choropleth map color bar labels showing "$-31" instead of "-$31", and all other chart labels/tooltips with the same pattern
- The `Intl.NumberFormat`-based `formatCurrency` in `formatters.ts` was already correct

## Test plan
- [x] 8 new tests for negative USD/GBP formatting in `chartValueUtils.test.ts` and `policyTableHelpers.test.ts`
- [x] All 2884 existing tests pass
- [x] Lint passes clean
- [ ] Visual verification on district map report page

🤖 Generated with [Claude Code](https://claude.com/claude-code)