### PR TITLE
Fix JSDoc example to use Intl currency formatting

### DIFF
--- a/app/src/components/visualization/choropleth/USDistrictChoroplethMap.tsx
+++ b/app/src/components/visualization/choropleth/USDistrictChoroplethMap.tsx
@@ -17,7 +17,7 @@
  *       colors: DIVERGING_GRAY_TEAL.colors,
  *       symmetric: true,
  *     },
- *     formatValue: (val) => `$${val.toFixed(0)}`,
+ *     formatValue: (val) => val.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }),
  *   }}
  * />
  * ```


### PR DESCRIPTION
## Summary
- Fixes the last remaining `$${val.toFixed(0)}` pattern in the choropleth component's JSDoc example to use `Intl.NumberFormat` with `style: 'currency'`

## Test plan
- [x] Documentation-only change (JSDoc comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)