### PR TITLE
Add GA4 tracking tag

### DIFF
--- a/app/calculator.html
+++ b/app/calculator.html
@@ -1,6 +1,15 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2YHG89FY0N"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-2YHG89FY0N');
+    </script>
+
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta

--- a/app/website.html
+++ b/app/website.html
@@ -1,6 +1,15 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2YHG89FY0N"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-2YHG89FY0N');
+    </script>
+
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta


### PR DESCRIPTION
## Summary

- Adds Google Analytics 4 tag (`G-2YHG89FY0N`) to `app/website.html` and `app/calculator.html`
- Enables visitor tracking across policyengine.org and app.policyengine.org
- Unblocks Google Ads conversion tracking for the $10K/mo Ad Grants account

## Changes

6-line snippet added to the `<head>` of both HTML entry points. No dependencies, no build changes.

## Test plan

- [ ] Deploy to preview, open site, check browser DevTools Network tab for requests to `googletagmanager.com`
- [ ] Verify GA4 Realtime report shows the visit
- [ ] Confirm no impact on page load performance (script is `async`)

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)