### PR TITLE
Add slides embed page

### DIFF
--- a/app/src/WebsiteRouter.tsx
+++ b/app/src/WebsiteRouter.tsx
@@ -19,6 +19,7 @@ import HomePage from './pages/Home.page';
 import ModelPage from './pages/Model.page';
 import PrivacyPage from './pages/Privacy.page';
 import ResearchPage from './pages/Research.page';
+import SlidesPage from './pages/Slides.page';
 import SupportersPage from './pages/Supporters.page';
 import TeamPage from './pages/Team.page';
 import TermsPage from './pages/Terms.page';
@@ -110,6 +111,10 @@ const router = createBrowserRouter(
             {
               path: 'ai-inequality',
               element: <AIGrowthResearchPage />,
+            },
+            {
+              path: 'slides',
+              element: <SlidesPage />,
             },
             {
               path: 'model',

--- a/app/src/pages/Slides.page.tsx
+++ b/app/src/pages/Slides.page.tsx
@@ -1,0 +1,19 @@
+/**
+ * Embeds the PolicyEngine slides app from Vercel
+ * Presentations and slide decks from PolicyEngine.
+ */
+export default function SlidesPage() {
+  const embedUrl = 'https://policyengine-slides-iota.vercel.app';
+
+  return (
+    <iframe
+      src={embedUrl}
+      title="Presentations | PolicyEngine"
+      style={{
+        width: '100%',
+        height: 'calc(100vh - 120px)',
+        border: 'none',
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a new route at `/:countryId/slides` that embeds the [policyengine-slides Vercel app](https://policyengine-slides-iota.vercel.app) in an iframe
- Follows the same embed pattern used by the AI inequality page (`AIGrowthResearch.page.tsx`)
- New page file: `app/src/pages/Slides.page.tsx`

## Test plan
- [ ] Visit `/:countryId/slides` (e.g., `/us/slides`) and verify the slides app loads in the iframe
- [ ] Verify the page renders within the StaticLayout (header/footer visible)
- [ ] Confirm lint passes with `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)