### PR TITLE
Fix iframe deep link URLs accumulating path segments

### DIFF
--- a/app/src/components/IframeContent.tsx
+++ b/app/src/components/IframeContent.tsx
@@ -30,6 +30,12 @@ export default function IframeContent({
     }
   }, [url]);
 
+  // Base path is /:countryId/:slug — deep link sub-paths append after this
+  const basePath = useMemo(() => {
+    const segments = location.pathname.split('/').filter(Boolean);
+    return `/${segments.slice(0, 2).join('/')}`;
+  }, [location.pathname]);
+
   // Listen for hash change messages from iframe and sync to parent URL bar
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
@@ -39,17 +45,17 @@ export default function IframeContent({
       if (event.data?.type === 'hashchange' && typeof event.data.hash === 'string') {
         const hash = event.data.hash || '';
         if (hash && !hash.startsWith('#')) {
-          // Path-based deep link: ensure slash separator
+          // Path-based deep link: replace sub-path after the base route
           const subPath = hash.startsWith('/') ? hash : `/${hash}`;
-          window.history.replaceState(null, '', `${location.pathname}${subPath}`);
+          window.history.replaceState(null, '', `${basePath}${subPath}`);
         } else {
-          window.history.replaceState(null, '', `${location.pathname}${hash}`);
+          window.history.replaceState(null, '', `${basePath}${hash}`);
         }
       }
     };
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [location.pathname, iframeOrigin]);
+  }, [basePath, iframeOrigin]);
 
   const iframeHeight = height || 'calc(100vh - var(--header-height, 58px))';
   const iframeWidth = width || '100%';


### PR DESCRIPTION
## Summary

- Fixes iframe `hashchange` handler appending sub-paths to the full `location.pathname` instead of replacing them
- Computes a stable base path (`/:countryId/:slug`) and replaces everything after it when the iframe navigates

## Reproduction

1. Navigate to `/us/state-legislative-tracker/NY/ny-s4487`
2. Close the bill → URL becomes `/us/state-legislative-tracker/NY/ny-s4487/NY` (wrong)
3. After fix → URL becomes `/us/state-legislative-tracker/NY` (correct)

## Test plan

- [ ] Navigate to a deep-linked tracker bill URL, close the bill, verify URL resets to state level
- [ ] Navigate between multiple bills, verify URL stays correct
- [ ] Verify hash-based deep links (e.g. `#key=value`) still work for other iframe apps
- [ ] Verify no regression on other iframe apps (marriage calculator, ACA calc, etc.)

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)