### PR TITLE
Fix slides route crashing due to missing country context

### DIFF
--- a/app/src/WebsiteRouter.tsx
+++ b/app/src/WebsiteRouter.tsx
@@ -40,20 +40,14 @@ const router = createBrowserRouter(
       path: '/',
       element: <RedirectToCountry />,
     },
-    // Top-level slides route (no country slug)
+    // Top-level slides route (no country slug, no layout — fullscreen iframe)
     {
       path: '/slides',
-      element: <StaticLayout />,
-      children: [
-        {
-          index: true,
-          element: <SlidesPage />,
-        },
-        {
-          path: '*',
-          element: <SlidesPage />,
-        },
-      ],
+      element: <SlidesPage />,
+    },
+    {
+      path: '/slides/*',
+      element: <SlidesPage />,
     },
     {
       path: '/:countryId',

--- a/app/src/pages/Slides.page.tsx
+++ b/app/src/pages/Slides.page.tsx
@@ -15,7 +15,7 @@ export default function SlidesPage() {
       title="Presentations | PolicyEngine"
       style={{
         width: '100%',
-        height: 'calc(100vh - 120px)',
+        height: '100vh',
         border: 'none',
       }}
     />


### PR DESCRIPTION
## Summary
- Remove `StaticLayout` wrapper from `/slides` route since it depends on `useCurrentCountry` (requires `CountryGuardSimple`)
- Render `SlidesPage` directly as a fullscreen iframe without PE header/footer
- The slides app has its own branding so a layout wrapper is unnecessary

## Test plan
- [ ] Visit `policyengine.org/slides` — should show slide deck index
- [ ] Visit `policyengine.org/slides/abundance-dmv` — should render the deck fullscreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)