### PR TITLE
Add /us/taxsim rewrite to TAXSIM dashboard

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -36,6 +36,14 @@
       "source": "/slides/:path*",
       "destination": "https://policyengine-slides.vercel.app/slides/:path*"
     },
+    {
+      "source": "/us/taxsim",
+      "destination": "https://cps-dashboard-pied.vercel.app/us/taxsim"
+    },
+    {
+      "source": "/us/taxsim/:path*",
+      "destination": "https://cps-dashboard-pied.vercel.app/us/taxsim/:path*"
+    },
     { "source": "/(.*)", "destination": "/website.html" }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- Adds a Vercel rewrite so `policyengine.org/us/taxsim` serves the PolicyEngine TAXSIM dashboard
- The dashboard is deployed separately at `cps-dashboard-pied.vercel.app` from the [policyengine-taxsim](https://github.com/PolicyEngine/policyengine-taxsim) repo
- Includes landing page, documentation, and CPS comparison dashboard
- Same pattern as `/slides` rewrite

## Test plan
- [ ] After merge, verify `policyengine.org/us/taxsim` loads the TAXSIM landing page
- [ ] Verify navigation between landing, docs, and dashboard works
- [ ] Verify assets (JS/CSS/fonts) load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)