### PR TITLE
Add Claude Plugin landing page with country-specific examples

### DIFF
--- a/app/src/pages/ClaudePlugins.page.tsx
+++ b/app/src/pages/ClaudePlugins.page.tsx
@@ -235,7 +235,10 @@ const ukUseCases: UseCase[] = [
     title: 'Build interactive dashboards',
     description: 'Let stakeholders explore reform scenarios.',
     terminal: [
-      { type: 'prompt', text: 'Build a dashboard showing the impact of cutting the basic rate by 1p' },
+      {
+        type: 'prompt',
+        text: 'Build a dashboard showing the impact of cutting the basic rate by 1p',
+      },
       { type: 'output', text: 'Creating interactive app with charts...' },
       { type: 'success', text: '✓ app.py written → ready to run' },
     ],
@@ -300,7 +303,6 @@ export default function ClaudePluginsPage() {
   const heroPrompt = isUK
     ? 'What is the budgetary impact of raising the personal allowance to £13,500?'
     : 'What is the budgetary impact of doubling the standard deduction?';
-
 
   return (
     <StaticPageLayout title="Claude Plugins">


### PR DESCRIPTION
## Summary
- Moves the Claude plugin landing page from `/us/claude-plugin` to `/claude-plugin`
- The page doesn't need country context, so it belongs at the top level

## Test plan
- [ ] Visit `policyengine.org/claude-plugin` and verify the page loads
- [ ] Verify `/us/claude-plugin` no longer resolves to this page


🤖 Generated with [Claude Code](https://claude.com/claude-code)