### PR TITLE
Add Spring Statement calculator reverse proxy

### DIFF
--- a/app/scripts/generate-sitemap.ts
+++ b/app/scripts/generate-sitemap.ts
@@ -153,6 +153,13 @@ function generateSitemap(): string {
     priority: '0.7',
   });
 
+  // Spring Statement personal calculator (UK-only, served via Vercel rewrite)
+  entries.push({
+    url: `${BASE_URL}/uk/spring-statement`,
+    changefreq: 'weekly',
+    priority: '0.7',
+  });
+
   // Build XML
   const urlEntries = entries
     .map((e) => {

--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -288,5 +288,15 @@
     "source": "https://policyengine.github.io/snap-district-map/",
     "tags": ["us", "policy"],
     "countryId": "us"
+  },
+  {
+    "type": "rewrite",
+    "slug": "spring-statement",
+    "title": "Spring Statement 2025 personal calculator",
+    "description": "See how the Spring Statement 2025 policy changes affect your household's taxes and benefits. Covers income tax, National Insurance, Universal Credit, and more.",
+    "source": "https://spring-statement-calculator.vercel.app/",
+    "tags": ["uk", "featured", "policy"],
+    "countryId": "uk",
+    "date": "2026-03-03 12:00:00"
   }
 ]

--- a/vercel.json
+++ b/vercel.json
@@ -52,6 +52,14 @@
       "source": "/us/taxsim/:path*",
       "destination": "https://cps-dashboard-pied.vercel.app/us/taxsim/:path*"
     },
+    {
+      "source": "/uk/spring-statement",
+      "destination": "https://spring-statement-calculator.vercel.app/"
+    },
+    {
+      "source": "/uk/spring-statement/:path*",
+      "destination": "https://spring-statement-calculator.vercel.app/:path*"
+    },
     { "source": "/(.*)", "destination": "/website.html" }
   ],
   "headers": [


### PR DESCRIPTION
## Summary

Adds the Spring Statement 2025 Personal Calculator as a reverse-proxied tool at `policyengine.org/uk/spring-statement`, following the same pattern as the TAXSIM emulator (`/us/taxsim`).

- **Vercel rewrite** (`vercel.json`): Routes `/uk/spring-statement` and `/uk/spring-statement/:path*` to `https://spring-statement-calculator.vercel.app/`
- **Sitemap** (`generate-sitemap.ts`): Adds `/uk/spring-statement` entry with `priority: 0.7`, `changefreq: weekly` (matches TAXSIM)
- **SEO crawler support** (`apps.json`): Entry with `type: "rewrite"` so the Edge Middleware (`middleware.ts`) serves proper OG meta tags, Twitter Cards, and JSON-LD structured data to social crawlers and search engine bots
- **Analytics**: GA4 tracking (G-2YHG89FY0N) is embedded directly in the source app's `index.html` — fires on every page load through the reverse proxy

### How it works

1. Social crawlers/search bots hit `/uk/spring-statement`
2. Edge Middleware detects crawler UA → finds app in `apps.json` → returns OG HTML with title, description, image
3. Normal users hit `/uk/spring-statement`
4. Middleware passes through → Vercel rewrite proxies to `spring-statement-calculator.vercel.app`
5. GA4 script in the proxied HTML fires analytics under the PolicyEngine property

### Companion PR

- Source app changes: https://github.com/PolicyEngine/spring-statement-personal-calculator/pull/1

## Test plan

- [ ] Visit `policyengine.org/uk/spring-statement` — calculator loads correctly
- [ ] Check page source — GA4 script present with ID `G-2YHG89FY0N`
- [ ] Test with [opengraph.xyz](https://www.opengraph.xyz/) — OG title/description/image render
- [ ] Verify `/uk/spring-statement` appears in generated `sitemap.xml`
- [ ] Sub-paths (`/uk/spring-statement/assets/...`) proxy correctly (CSS/JS assets load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)