### PR TITLE
Update TAXSIM rewrite to renamed Vercel project

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -46,11 +46,11 @@
     },
     {
       "source": "/us/taxsim",
-      "destination": "https://cps-dashboard-pied.vercel.app/us/taxsim"
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim"
     },
     {
       "source": "/us/taxsim/:path*",
-      "destination": "https://cps-dashboard-pied.vercel.app/us/taxsim/:path*"
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/:path*"
     },
     {
       "source": "/uk/spring-statement-2026",


### PR DESCRIPTION
## Summary
- Updates Vercel rewrite destination from `cps-dashboard-pied.vercel.app` to `policyengine-taxsim-policy-engine.vercel.app`
- The Vercel project was renamed from `cps-dashboard` to `policyengine-taxsim`
- Old alias still works so no downtime

## Test plan
- [x] Verified `policyengine-taxsim-policy-engine.vercel.app/us/taxsim` returns 200
- [x] Old `cps-dashboard-pied.vercel.app` still works as fallback
