### PR TITLE
Fix taxsim rewrite after basePath removal

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -46,11 +46,11 @@
     },
     {
       "source": "/us/taxsim",
-      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim"
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/"
     },
     {
       "source": "/us/taxsim/:path*",
-      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/:path*"
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/:path*"
     },
     {
       "source": "/uk/spring-statement-2026",


### PR DESCRIPTION
## Summary

- Fix Vercel rewrite for `/us/taxsim` after the taxsim dashboard removed its Next.js `basePath`
- The dashboard now serves at `/` on its standalone Vercel domain, so the rewrite destination should point to the root, not `/us/taxsim`

## Test plan

- [ ] https://www.policyengine.org/us/taxsim returns 200 (currently 404)
- [ ] https://www.policyengine.org/us/taxsim/dashboard/ loads the dashboard
- [ ] https://www.policyengine.org/us/taxsim/documentation/ loads docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
