### PR TITLE
Revert taxsim rewrite to /us/taxsim paths

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -46,11 +46,11 @@
     },
     {
       "source": "/us/taxsim",
-      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/"
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim"
     },
     {
       "source": "/us/taxsim/:path*",
-      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/:path*"
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/:path*"
     },
     {
       "source": "/uk/spring-statement-2026",


### PR DESCRIPTION
## Summary

- Revert taxsim rewrite destinations back to `/us/taxsim/*` paths
- The taxsim dashboard restored `basePath: '/us/taxsim'` in PolicyEngine/policyengine-taxsim#738, so rewrites need to target `/us/taxsim/*` again

## Test plan

- [ ] https://www.policyengine.org/us/taxsim loads with full styling and PE header
- [ ] https://www.policyengine.org/us/taxsim/dashboard/ loads dashboard
- [ ] https://www.policyengine.org/us/taxsim/documentation/ loads docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
