### PR TITLE
Add trailing slash rewrite for /us/taxsim/

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -49,6 +49,10 @@
       "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim"
     },
     {
+      "source": "/us/taxsim/",
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/"
+    },
+    {
       "source": "/us/taxsim/:path*",
       "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/:path*"
     },


### PR DESCRIPTION
## Summary
- The `:path*` pattern in Vercel rewrites doesn't match a bare trailing slash
- `/us/taxsim/` was falling through to the SPA catch-all, returning the app-v2 shell ("App not found") instead of the taxsim dashboard
- Adds explicit `/us/taxsim/` rewrite to fix

## Test plan
- [ ] Verify `https://www.policyengine.org/us/taxsim/` loads the taxsim dashboard (not "App not found")
- [ ] Verify `https://www.policyengine.org/us/taxsim` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)