### PR TITLE
feat: Add adds/subtracts to variable metadata types and adapter

### DIFF
--- a/app/src/adapters/MetadataAdapter.ts
+++ b/app/src/adapters/MetadataAdapter.ts
@@ -38,6 +38,8 @@ export class MetadataAdapter {
       created_at: v2.created_at,
       // Use API label if available, otherwise auto-generate from name (sentence case)
       label: v2.label || v2.name.replace(/_/g, ' ').replace(/^./, (c: string) => c.toUpperCase()),
+      adds: v2.adds ?? undefined,
+      subtracts: v2.subtracts ?? undefined,
     };
   }
 

--- a/app/src/tests/fixtures/api/v2/apiV2Mocks.ts
+++ b/app/src/tests/fixtures/api/v2/apiV2Mocks.ts
@@ -41,6 +41,8 @@ export function createMockVariable(
     data_type: 'float',
     possible_values: null,
     default_value: 0,
+    adds: null,
+    subtracts: null,
     tax_benefit_model_version_id: TEST_VERSIONS.US_VERSION_ID,
     created_at: '2024-01-01T00:00:00Z',
     ...overrides,

--- a/app/src/tests/unit/adapters/MetadataAdapter.test.ts
+++ b/app/src/tests/unit/adapters/MetadataAdapter.test.ts
@@ -81,6 +81,82 @@ describe('MetadataAdapter', () => {
     });
   });
 
+  describe('variableFromV2 adds/subtracts', () => {
+    it('given V2 variable with null adds then converts to undefined', () => {
+      // Given
+      const v2Variable = createMockVariable({ adds: null });
+
+      // When
+      const result = MetadataAdapter.variableFromV2(v2Variable);
+
+      // Then
+      expect(result.adds).toBeUndefined();
+    });
+
+    it('given V2 variable with null subtracts then converts to undefined', () => {
+      // Given
+      const v2Variable = createMockVariable({ subtracts: null });
+
+      // When
+      const result = MetadataAdapter.variableFromV2(v2Variable);
+
+      // Then
+      expect(result.subtracts).toBeUndefined();
+    });
+
+    it('given V2 variable with adds array then preserves array', () => {
+      // Given
+      const ADDS_COMPONENTS = ['employment_income', 'self_employment_income', 'pension_income'];
+      const v2Variable = createMockVariable({ adds: ADDS_COMPONENTS });
+
+      // When
+      const result = MetadataAdapter.variableFromV2(v2Variable);
+
+      // Then
+      expect(result.adds).toEqual(ADDS_COMPONENTS);
+    });
+
+    it('given V2 variable with subtracts array then preserves array', () => {
+      // Given
+      const SUBTRACTS_COMPONENTS = ['tax_deduction', 'personal_allowance'];
+      const v2Variable = createMockVariable({ subtracts: SUBTRACTS_COMPONENTS });
+
+      // When
+      const result = MetadataAdapter.variableFromV2(v2Variable);
+
+      // Then
+      expect(result.subtracts).toEqual(SUBTRACTS_COMPONENTS);
+    });
+
+    it('given V2 variable with both adds and subtracts then preserves both', () => {
+      // Given
+      const ADDS_COMPONENTS = ['gross_income', 'capital_gains'];
+      const SUBTRACTS_COMPONENTS = ['standard_deduction'];
+      const v2Variable = createMockVariable({
+        adds: ADDS_COMPONENTS,
+        subtracts: SUBTRACTS_COMPONENTS,
+      });
+
+      // When
+      const result = MetadataAdapter.variableFromV2(v2Variable);
+
+      // Then
+      expect(result.adds).toEqual(ADDS_COMPONENTS);
+      expect(result.subtracts).toEqual(SUBTRACTS_COMPONENTS);
+    });
+
+    it('given V2 variable with empty adds array then preserves empty array', () => {
+      // Given
+      const v2Variable = createMockVariable({ adds: [] });
+
+      // When
+      const result = MetadataAdapter.variableFromV2(v2Variable);
+
+      // Then
+      expect(result.adds).toEqual([]);
+    });
+  });
+
   describe('variablesFromV2', () => {
     it('given array of V2 variables then converts to keyed record', () => {
       // Given

--- a/app/src/types/metadata.ts
+++ b/app/src/types/metadata.ts
@@ -14,6 +14,8 @@ export interface V2VariableMetadata {
   data_type: string;
   possible_values: string[] | null;
   default_value: string | number | boolean | null;
+  adds: string[] | null;
+  subtracts: string[] | null;
   tax_benefit_model_version_id: string;
   created_at: string;
 }
@@ -100,9 +102,8 @@ export interface VariableMetadata {
   label?: string;
 
   // Variable arithmetic (for breakdown calculations)
-  // WARNING: These fields are NOT populated from V2 API - see note above
-  adds?: string | string[];
-  subtracts?: string | string[];
+  adds?: string[];
+  subtracts?: string[];
 }
 
 /**


### PR DESCRIPTION
Fixes #780

## Summary

- Adds `adds: string[] | null` and `subtracts: string[] | null` to `V2VariableMetadata` type
- Adds optional `adds?: string[]` and `subtracts?: string[]` to `VariableMetadata` type
- Maps fields in `MetadataAdapter.variableFromV2()` with null → undefined conversion
- Updates `createMockVariable` factory with `adds: null, subtracts: null` defaults
- Adds 6 adapter tests covering null, array, combined, and empty cases

## Test plan

- [x] `given V2 variable with null adds then converts to undefined`
- [x] `given V2 variable with null subtracts then converts to undefined`
- [x] `given V2 variable with adds array then preserves array`
- [x] `given V2 variable with subtracts array then preserves array`
- [x] `given V2 variable with both adds and subtracts then preserves both`
- [x] `given V2 variable with empty adds array then preserves empty array`

🤖 Generated with [Claude Code](https://claude.com/claude-code)