### PR TITLE
Fix earnings variation dot position for multi-earner households

### DIFF
--- a/app/src/pages/report-output/earnings-variation/BaselineAndReformChart.tsx
+++ b/app/src/pages/report-output/earnings-variation/BaselineAndReformChart.tsx
@@ -121,11 +121,12 @@ export default function BaselineAndReformChart({
     return <div>No variation data available</div>;
   }
 
-  // Get current earnings for marker
+  // Get current earnings for marker (first person only, matching axes sweep)
+  const firstPersonName = Object.keys(baseline.householdData?.people || {})[0];
   const currentEarnings = getValueFromHousehold(
     'employment_income',
     year,
-    null,
+    firstPersonName,
     baseline,
     metadata
   ) as number;

--- a/app/src/pages/report-output/earnings-variation/BaselineOnlyChart.tsx
+++ b/app/src/pages/report-output/earnings-variation/BaselineOnlyChart.tsx
@@ -89,11 +89,12 @@ export default function BaselineOnlyChart({
     metadata
   ) as number;
 
-  // Get current earnings to show marker position
+  // Get current earnings to show marker position (first person only, matching axes sweep)
+  const firstPersonName = Object.keys(baseline.householdData?.people || {})[0];
   const currentEarnings = getValueFromHousehold(
     'employment_income',
     year,
-    null,
+    firstPersonName,
     baseline,
     metadata
   ) as number;


### PR DESCRIPTION
## Summary

Fixes #785

- The reference dot on the "Varying your earnings" chart was placed at the **total household employment income** (sum of all earners), while the line's X-axis represents **only the first person's employment income** (the variable swept by the axes)
- For multi-earner households (e.g., couple where both partners earn $46k), the dot appeared at $92k instead of $46k, misaligned from the line
- Now uses the first person's employment income for the dot's X-position, consistent with how `MarginalTaxRatesSubPage` already handles this

## Test plan

- [ ] Open [this shared report](https://app.policyengine.org/us/report-output/sur-mmduf79in4rx?share=eyJ1c2VyUmVwb3J0Ijp7InJlcG9ydElkIjoiOTI1IiwiY291bnRyeUlkIjoidXMiLCJsYWJlbCI6IkNvdXBsZSB3aXRoIDIgY2hpbGRyZW4iLCJpc0NyZWF0ZWQiOnRydWUsImlkIjoic3VyLW1tZHVmNzlpbjRyeCJ9LCJ1c2VyU2ltdWxhdGlvbnMiOlt7InNpbXVsYXRpb25JZCI6IjEwMDkiLCJjb3VudHJ5SWQiOiJ1cyIsImxhYmVsIjoiQ291cGxlIHdpdGggMiBjaGlsZHJlbiBiYXNlbGluZSBzaW11bGF0aW9uIiwiaXNDcmVhdGVkIjp0cnVlLCJpZCI6InN1cy1tbWR1ZjRxNGx5cHoifV0sInVzZXJQb2xpY2llcyI6W10sInVzZXJIb3VzZWhvbGRzIjpbeyJob3VzZWhvbGRJZCI6NTcxNTEsImNvdW50cnlJZCI6InVzIiwibGFiZWwiOiJDb3VwbGUgd2l0aCAyIGtpZHMiLCJ0eXBlIjoiaG91c2Vob2xkIiwiaWQiOiJzdWgtbW1kdWYwYzgzcWdoIiwiaXNDcmVhdGVkIjp0cnVlfV0sInVzZXJHZW9ncmFwaGllcyI6W119) (couple in Virginia, both partners earn $46k, 2 children)
- [ ] Navigate to Comparative analysis → Earnings variation
- [ ] Verify the dot sits at ~$46k (first earner) on the X-axis, not ~$92k (both earners summed)
- [ ] Verify the dot sits on the line for `household_net_income`
- [ ] Test with a single-earner household to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)