### PR TITLE
Fix unbalanced brackets in Reproduce in Python output

### DIFF
--- a/app/src/tests/unit/utils/reproducibilityCode.test.ts
+++ b/app/src/tests/unit/utils/reproducibilityCode.test.ts
@@ -503,6 +503,109 @@ describe('reproducibilityCode', () => {
       });
     });
 
+    describe('syntax validation', () => {
+      /**
+       * Checks that brackets and parentheses are balanced in generated Python.
+       * Counts (), {}, and [] pairs — any mismatch means invalid syntax.
+       */
+      function assertBalancedBrackets(code: string) {
+        let parens = 0;
+        let braces = 0;
+        let squares = 0;
+        for (const ch of code) {
+          if (ch === '(') {
+            parens++;
+          }
+          if (ch === ')') {
+            parens--;
+          }
+          if (ch === '{') {
+            braces++;
+          }
+          if (ch === '}') {
+            braces--;
+          }
+          if (ch === '[') {
+            squares++;
+          }
+          if (ch === ']') {
+            squares--;
+          }
+          // Should never go negative (closing before opening)
+          expect(parens).toBeGreaterThanOrEqual(0);
+          expect(braces).toBeGreaterThanOrEqual(0);
+          expect(squares).toBeGreaterThanOrEqual(0);
+        }
+        expect(parens).toBe(0);
+        expect(braces).toBe(0);
+        expect(squares).toBe(0);
+      }
+
+      test('given reform-only policy then generated code has balanced brackets', () => {
+        // When
+        const code = getReproducibilityCodeBlock(
+          'household',
+          TEST_COUNTRIES.US,
+          REFORM_ONLY_POLICY,
+          TEST_REGIONS.US_NATIONAL,
+          TEST_YEARS.DEFAULT,
+          null,
+          SIMPLE_HOUSEHOLD_INPUT,
+          false
+        ).join('\n');
+
+        // Then
+        assertBalancedBrackets(code);
+      });
+
+      test('given baseline-and-reform policy then generated code has balanced brackets', () => {
+        // When
+        const code = getReproducibilityCodeBlock(
+          'policy',
+          TEST_COUNTRIES.US,
+          BASELINE_AND_REFORM_POLICY,
+          TEST_REGIONS.US_NATIONAL,
+          TEST_YEARS.DEFAULT,
+          null
+        ).join('\n');
+
+        // Then
+        assertBalancedBrackets(code);
+      });
+
+      test('given household with earning variation then generated code has balanced brackets', () => {
+        // When
+        const code = getReproducibilityCodeBlock(
+          'household',
+          TEST_COUNTRIES.US,
+          REFORM_ONLY_POLICY,
+          TEST_REGIONS.US_NATIONAL,
+          TEST_YEARS.DEFAULT,
+          null,
+          SIMPLE_HOUSEHOLD_INPUT,
+          true
+        ).join('\n');
+
+        // Then
+        assertBalancedBrackets(code);
+      });
+
+      test('given place region with reform then generated code has balanced brackets', () => {
+        // When
+        const code = getReproducibilityCodeBlock(
+          'policy',
+          TEST_COUNTRIES.US,
+          REFORM_ONLY_POLICY,
+          TEST_REGIONS.NJ_PLACE,
+          TEST_YEARS.DEFAULT,
+          null
+        ).join('\n');
+
+        // Then
+        assertBalancedBrackets(code);
+      });
+    });
+
     describe('infinity handling', () => {
       test('given policy with Infinity then adds numpy import', () => {
         // When

--- a/app/src/utils/reproducibilityCode.ts
+++ b/app/src/utils/reproducibilityCode.ts
@@ -157,7 +157,7 @@ function getBaselineCode(
   let jsonStr = JSON.stringify(policy.baseline.data, null, 2);
   jsonStr = sanitizeStringToPython(jsonStr);
   const lines = [''].concat(jsonStr.split('\n'));
-  lines[1] = `baseline = Reform.from_dict({${lines[1]}`;
+  lines[1] = `baseline = Reform.from_dict(${lines[1]}`;
   lines[lines.length - 1] = `${lines[lines.length - 1]}, country_id="${countryId}")`;
   return lines;
 }
@@ -175,7 +175,7 @@ function getReformCode(
   let jsonStr = JSON.stringify(policy.reform.data, null, 2);
   jsonStr = sanitizeStringToPython(jsonStr);
   const lines = [''].concat(jsonStr.split('\n'));
-  lines[1] = `reform = Reform.from_dict({${lines[1]}`;
+  lines[1] = `reform = Reform.from_dict(${lines[1]}`;
   lines[lines.length - 1] = `${lines[lines.length - 1]}, country_id="${countryId}")`;
   return lines;
 }


### PR DESCRIPTION
Fixes #787

## Summary
- Remove extra opening `{` in `getBaselineCode` and `getReformCode` that caused `Reform.from_dict({{` to produce one more `{` than `}`, making invalid Python for any non-empty policy
- Add bracket-balance validation tests covering reform-only, baseline+reform, earning variation, and place-region scenarios

## Test plan
- [x] All 36 existing + new tests pass
- [x] Lint passes clean
- [ ] Manually verify Reproduce in Python tab with a reform policy shows balanced brackets

🤖 Generated with [Claude Code](https://claude.com/claude-code)