### PR TITLE
feat: Apple-inspired homepage animations and feature grid

### DIFF
--- a/app/src/WebsiteApp.tsx
+++ b/app/src/WebsiteApp.tsx
@@ -4,6 +4,7 @@
  */
 import '@mantine/core/styles.css';
 import '@mantine/dates/styles.css';
+import '@/styles/stylesheets/animations.css';
 
 import { QueryNormalizerProvider } from '@normy/react-query';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/app/src/components/home/ActionCards.tsx
+++ b/app/src/components/home/ActionCards.tsx
@@ -1,35 +1,97 @@
-import { Card, Center, Container, Text } from '@mantine/core';
-import { CALCULATOR_URL } from '@/constants';
+import { Box, Container, Group, Stack, Text } from '@mantine/core';
+import { CALCULATOR_URL, WEBSITE_URL } from '@/constants';
 import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import { useScrollReveal } from '@/hooks/useScrollReveal';
 
+/**
+ * CTA section at the bottom of the hero.
+ * Primary button links to the reports (simulation) flow.
+ * Secondary link goes to the research page.
+ */
 export default function ActionCards() {
   const countryId = useCurrentCountry();
+  const [ref, visible] = useScrollReveal<HTMLDivElement>(0.3);
 
   return (
     <Container size="xl" pb={spacing['4xl']}>
-      <Center>
-        <Card
-          component="a"
-          href={`${CALCULATOR_URL}/${countryId}/reports`}
-          shadow="sm"
-          p={spacing.xl}
-          radius={spacing.radius.md}
-          withBorder
-          style={{
-            backgroundColor: 'transparent',
-            cursor: 'pointer',
-            borderColor: colors.primary[500],
-            borderWidth: 1.5,
-            fontFamily: typography.fontFamily.primary,
-            textDecoration: 'none',
-          }}
-        >
-          <Text fw={typography.fontWeight.semibold} c={colors.primary[500]} size="xl">
+      <Stack ref={ref} align="center" gap={spacing.lg}>
+        <Group gap={spacing.md} justify="center" wrap="wrap">
+          {/* Primary CTA */}
+          <Box
+            component="a"
+            href={`${CALCULATOR_URL}/${countryId}/reports`}
+            className={`reveal${visible ? ' visible' : ''} reveal-delay-1`}
+            style={{
+              display: 'inline-block',
+              backgroundColor: colors.primary[600],
+              color: colors.white,
+              borderRadius: spacing.radius.md,
+              padding: `${spacing.md} ${spacing['2xl']}`,
+              fontFamily: typography.fontFamily.primary,
+              fontWeight: typography.fontWeight.semibold,
+              fontSize: typography.fontSize.base,
+              textDecoration: 'none',
+              transition: 'background-color 0.2s ease, transform 0.15s ease, box-shadow 0.15s ease',
+              boxShadow: `0 4px 14px -2px ${colors.primary[300]}`,
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLElement).style.backgroundColor = colors.primary[700];
+              (e.currentTarget as HTMLElement).style.transform = 'translateY(-2px)';
+              (e.currentTarget as HTMLElement).style.boxShadow =
+                `0 8px 20px -4px ${colors.primary[300]}`;
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLElement).style.backgroundColor = colors.primary[600];
+              (e.currentTarget as HTMLElement).style.transform = 'translateY(0)';
+              (e.currentTarget as HTMLElement).style.boxShadow =
+                `0 4px 14px -2px ${colors.primary[300]}`;
+            }}
+          >
             Enter PolicyEngine
-          </Text>
-        </Card>
-      </Center>
+          </Box>
+
+          {/* Secondary CTA */}
+          <Box
+            component="a"
+            href={`${WEBSITE_URL}/${countryId}/research`}
+            className={`reveal${visible ? ' visible' : ''} reveal-delay-2`}
+            style={{
+              display: 'inline-block',
+              backgroundColor: 'transparent',
+              color: colors.primary[700],
+              borderRadius: spacing.radius.md,
+              padding: `${spacing.md} ${spacing['2xl']}`,
+              fontFamily: typography.fontFamily.primary,
+              fontWeight: typography.fontWeight.medium,
+              fontSize: typography.fontSize.base,
+              textDecoration: 'none',
+              border: `1.5px solid ${colors.primary[300]}`,
+              transition: 'border-color 0.2s ease, background-color 0.2s ease',
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLElement).style.borderColor = colors.primary[500];
+              (e.currentTarget as HTMLElement).style.backgroundColor = colors.primary[50];
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLElement).style.borderColor = colors.primary[300];
+              (e.currentTarget as HTMLElement).style.backgroundColor = 'transparent';
+            }}
+          >
+            Read our research
+          </Box>
+        </Group>
+
+        {/* Trust line */}
+        <Text
+          className={`reveal${visible ? ' visible' : ''} reveal-delay-3`}
+          size="xs"
+          c={colors.gray[400]}
+          style={{ fontFamily: typography.fontFamily.primary }}
+        >
+          Free forever · Open source · No account required
+        </Text>
+      </Stack>
     </Container>
   );
 }

--- a/app/src/components/home/FeatureGrid.tsx
+++ b/app/src/components/home/FeatureGrid.tsx
@@ -1,0 +1,170 @@
+import { IconChartBar, IconCode, IconSearch } from '@tabler/icons-react';
+import { Box, Container, SimpleGrid, Stack, Text } from '@mantine/core';
+import { CALCULATOR_URL } from '@/constants';
+import { colors, spacing, typography } from '@/designTokens';
+import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import { useScrollReveal } from '@/hooks/useScrollReveal';
+
+interface Feature {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  href: string;
+  cta: string;
+}
+
+function getFeatures(countryId: string): Feature[] {
+  return [
+    {
+      icon: <IconChartBar size={28} stroke={1.5} color={colors.primary[600]} />,
+      title: 'Model policy reforms',
+      description:
+        countryId === 'uk'
+          ? 'Simulate tax and benefit changes across the UK. See distributional impacts, revenue effects, and poverty outcomes instantly.'
+          : 'Simulate tax and benefit changes across all 50 states. See distributional impacts, revenue effects, and poverty outcomes instantly.',
+      href: `${CALCULATOR_URL}/${countryId}/reports/create`,
+      cta: 'Run a simulation →',
+    },
+    {
+      icon: <IconSearch size={28} stroke={1.5} color={colors.primary[600]} />,
+      title: 'Calculate household benefits',
+      description:
+        'Enter a household profile and see every tax and benefit they are eligible for — calculated from the actual rules, not estimates.',
+      href: `${CALCULATOR_URL}/${countryId}/households/create`,
+      cta: 'Try the calculator →',
+    },
+    {
+      icon: <IconCode size={28} stroke={1.5} color={colors.primary[600]} />,
+      title: 'Build with our rules engine',
+      description:
+        'Embed accurate benefit eligibility calculations in your product via our open-source Python package or REST API.',
+      href: 'https://github.com/PolicyEngine',
+      cta: 'Explore the API →',
+    },
+  ];
+}
+
+/**
+ * Three-column feature grid with scroll-triggered card reveal.
+ * Each card stagger-animates in using the .feature-card CSS class.
+ */
+export default function FeatureGrid() {
+  const countryId = useCurrentCountry();
+  const [ref, visible] = useScrollReveal<HTMLDivElement>(0.1, '-40px');
+  const features = getFeatures(countryId);
+
+  return (
+    <Container size="xl" py={spacing['5xl']}>
+      <Stack gap={spacing['3xl']}>
+        <Box
+          className={`reveal${visible ? ' visible' : ''}`}
+          style={{ textAlign: 'center' }}
+          ref={ref}
+        >
+          <Text
+            fw={typography.fontWeight.semibold}
+            c={colors.primary[500]}
+            size="sm"
+            style={{
+              fontFamily: typography.fontFamily.primary,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              marginBottom: spacing.sm,
+            }}
+          >
+            What you can do
+          </Text>
+          <Text
+            fw={typography.fontWeight.bold}
+            c={colors.primary[900]}
+            style={{
+              fontSize: 'clamp(24px, 4vw, 40px)',
+              fontFamily: typography.fontFamily.primary,
+              letterSpacing: '-0.02em',
+            }}
+          >
+            Everything policy analysts need
+          </Text>
+        </Box>
+
+        <SimpleGrid cols={{ base: 1, sm: 3 }} spacing={spacing['2xl']}>
+          {features.map((feature, i) => (
+            <FeatureCard key={feature.title} feature={feature} index={i} visible={visible} />
+          ))}
+        </SimpleGrid>
+      </Stack>
+    </Container>
+  );
+}
+
+function FeatureCard({
+  feature,
+  index,
+  visible,
+}: {
+  feature: Feature;
+  index: number;
+  visible: boolean;
+}) {
+  return (
+    <Box
+      component="a"
+      href={feature.href}
+      className={`feature-card${visible ? ' visible' : ''}`}
+      style={{
+        transitionDelay: `${index * 0.12}s`,
+        borderRadius: spacing.radius.lg,
+        border: `1px solid ${colors.primary[100]}`,
+        backgroundColor: colors.white,
+        padding: spacing['2xl'],
+        textDecoration: 'none',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: spacing.md,
+        boxShadow: '0 2px 8px -2px rgba(0,88,76,0.08)',
+        cursor: 'pointer',
+      }}
+    >
+      <Box
+        style={{
+          width: 52,
+          height: 52,
+          borderRadius: spacing.radius.md,
+          backgroundColor: colors.primary[50],
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {feature.icon}
+      </Box>
+      <Text
+        fw={typography.fontWeight.semibold}
+        c={colors.primary[900]}
+        size="lg"
+        style={{ fontFamily: typography.fontFamily.primary }}
+      >
+        {feature.title}
+      </Text>
+      <Text
+        c={colors.gray[600]}
+        size="sm"
+        style={{
+          fontFamily: typography.fontFamily.primary,
+          lineHeight: typography.lineHeight.relaxed,
+          flexGrow: 1,
+        }}
+      >
+        {feature.description}
+      </Text>
+      <Text
+        c={colors.primary[600]}
+        size="sm"
+        fw={typography.fontWeight.medium}
+        style={{ fontFamily: typography.fontFamily.primary }}
+      >
+        {feature.cta}
+      </Text>
+    </Box>
+  );
+}

--- a/app/src/components/home/MainSection.tsx
+++ b/app/src/components/home/MainSection.tsx
@@ -1,51 +1,89 @@
-import { Container, Stack, Text, Title } from '@mantine/core';
+import { useEffect, useState } from 'react';
+import { Box, Container, Stack, Text } from '@mantine/core';
 import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 
+const HEADLINE_WORDS = ['Start', 'simulating', 'policy.'];
+
+/**
+ * Hero section with Apple-style word-by-word animated headline.
+ * Words animate in sequentially using CSS @keyframes on mount.
+ */
 export default function MainSection() {
   const countryId = useCurrentCountry();
+  const [started, setStarted] = useState(false);
+
+  // Delay animation start slightly so the page has painted
+  useEffect(() => {
+    const t = requestAnimationFrame(() => setStarted(true));
+    return () => cancelAnimationFrame(t);
+  }, []);
+
+  const sublineCountry =
+    countryId === 'uk'
+      ? 'Model policy reforms across the UK.'
+      : 'Model policy reforms across all 50 states.';
 
   return (
     <Container size="xl" py={spacing['5xl']}>
       <Stack
         align="center"
-        gap={spacing['3xl']}
-        style={{
-          margin: '0 auto',
-          maxWidth: spacing.layout.container,
-        }}
+        gap={spacing['2xl']}
+        style={{ margin: '0 auto', maxWidth: spacing.layout.container }}
       >
-        <Title
-          size={48}
-          fw={typography.fontWeight.bold}
-          ta="center"
-          c={colors.primary[800]}
+        {/* Animated headline */}
+        <h1
           style={{
+            fontSize: 'clamp(42px, 7vw, 80px)',
+            fontWeight: typography.fontWeight.bold,
             lineHeight: typography.lineHeight.tight,
             fontFamily: typography.fontFamily.primary,
+            color: colors.primary[800],
+            textAlign: 'center',
+            margin: 0,
+            letterSpacing: '-0.02em',
           }}
         >
-          Start simulating
-        </Title>
+          {HEADLINE_WORDS.map((word, i) => (
+            <span
+              key={word}
+              className={started ? 'hero-word' : ''}
+              style={{
+                animationDelay: started ? `${i * 0.14}s` : undefined,
+                marginRight: i < HEADLINE_WORDS.length - 1 ? '0.3em' : 0,
+              }}
+            >
+              {word}
+            </span>
+          ))}
+        </h1>
 
-        <Text
-          size={typography.fontSize['2xl']}
-          c="#132F46"
-          ta="center"
-          fw={typography.fontWeight.normal}
+        {/* Sub-headline — fades in after headline */}
+        <Box
+          className={started ? 'hero-word' : ''}
           style={{
-            lineHeight: typography.lineHeight.normal,
-            fontFamily: typography.fontFamily.primary,
+            animationDelay: started ? `${HEADLINE_WORDS.length * 0.14 + 0.1}s` : undefined,
+            textAlign: 'center',
           }}
         >
-          Free, open-source tax and benefit analysis.
-          <br />
-          {countryId === 'uk'
-            ? 'Model policy reforms across the UK.'
-            : 'Model policy reforms across all 50 states.'}
-          <br />
-          Power benefit access tools with accurate rules.
-        </Text>
+          <Text
+            size={typography.fontSize.xl}
+            c={colors.gray[600]}
+            ta="center"
+            fw={typography.fontWeight.normal}
+            style={{
+              lineHeight: typography.lineHeight.relaxed,
+              fontFamily: typography.fontFamily.primary,
+              maxWidth: 540,
+            }}
+          >
+            Free, open-source tax and benefit analysis.
+            <br />
+            {sublineCountry}
+            <br />
+            Power benefit access tools with accurate rules.
+          </Text>
+        </Box>
       </Stack>
     </Container>
   );

--- a/app/src/components/home/StatsBar.tsx
+++ b/app/src/components/home/StatsBar.tsx
@@ -1,0 +1,79 @@
+import { Box, Container, SimpleGrid, Text } from '@mantine/core';
+import { colors, spacing, typography } from '@/designTokens';
+import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import { useScrollReveal } from '@/hooks/useScrollReveal';
+
+interface Stat {
+  value: string;
+  label: string;
+}
+
+const US_STATS: Stat[] = [
+  { value: '50', label: 'US states modelled' },
+  { value: '1,000+', label: 'Tax and benefit rules' },
+  { value: '100M+', label: 'Households simulated' },
+  { value: 'Open source', label: 'Always free' },
+];
+
+const UK_STATS: Stat[] = [
+  { value: 'UK-wide', label: 'Coverage across England, Scotland, Wales & NI' },
+  { value: '500+', label: 'Tax and benefit rules' },
+  { value: 'Open source', label: 'Always free' },
+  { value: 'Real-time', label: 'Instant policy impact' },
+];
+
+/**
+ * Horizontal stat bar that animates in on scroll.
+ * Numbers use CSS statPop animation with staggered delays.
+ */
+export default function StatsBar() {
+  const countryId = useCurrentCountry();
+  const [ref, visible] = useScrollReveal<HTMLDivElement>(0.2);
+
+  const stats = countryId === 'uk' ? UK_STATS : US_STATS;
+
+  return (
+    <Box
+      ref={ref}
+      style={{
+        borderTop: `1px solid ${colors.primary[100]}`,
+        borderBottom: `1px solid ${colors.primary[100]}`,
+        backgroundColor: colors.primary[50],
+        padding: `${spacing['2xl']} 0`,
+      }}
+    >
+      <Container size="xl">
+        <SimpleGrid cols={{ base: 2, sm: 4 }} spacing={spacing['2xl']}>
+          {stats.map((stat, i) => (
+            <Box
+              key={stat.label}
+              className={`stat-reveal${visible ? ' visible' : ''}`}
+              style={{ textAlign: 'center', animationDelay: `${i * 0.12}s` }}
+            >
+              <Text
+                fw={typography.fontWeight.bold}
+                c={colors.primary[700]}
+                style={{
+                  fontSize: 'clamp(22px, 3vw, 36px)',
+                  fontFamily: typography.fontFamily.primary,
+                  letterSpacing: '-0.02em',
+                  lineHeight: 1.1,
+                }}
+              >
+                {stat.value}
+              </Text>
+              <Text
+                size="sm"
+                c={colors.gray[500]}
+                mt={spacing.xs}
+                style={{ fontFamily: typography.fontFamily.primary }}
+              >
+                {stat.label}
+              </Text>
+            </Box>
+          ))}
+        </SimpleGrid>
+      </Container>
+    </Box>
+  );
+}

--- a/app/src/hooks/useScrollReveal.ts
+++ b/app/src/hooks/useScrollReveal.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Returns a ref and a boolean indicating whether the element has entered
+ * the viewport. Uses IntersectionObserver — no scroll listener overhead.
+ *
+ * @param threshold - Fraction of the element visible before triggering (0–1)
+ * @param rootMargin - Margin around the root (e.g. "-80px 0px")
+ */
+export function useScrollReveal<T extends Element>(
+  threshold = 0.15,
+  rootMargin = '0px'
+): [React.RefObject<T>, boolean] {
+  const ref = useRef<T>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect(); // fire once only
+        }
+      },
+      { threshold, rootMargin }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold, rootMargin]);
+
+  return [ref, visible];
+}

--- a/app/src/pages/Home.page.tsx
+++ b/app/src/pages/Home.page.tsx
@@ -1,7 +1,9 @@
 import { Box } from '@mantine/core';
 import ActionCards from '@/components/home/ActionCards';
+import FeatureGrid from '@/components/home/FeatureGrid';
 import MainSection from '@/components/home/MainSection';
 import OrgLogos from '@/components/home/OrgLogos';
+import StatsBar from '@/components/home/StatsBar';
 import DowningStreetBanner from '@/components/shared/DowningStreetBanner';
 import { colors, spacing, typography } from '@/designTokens';
 
@@ -11,16 +13,25 @@ export default function HomePage() {
       <DowningStreetBanner />
       <Box
         style={{
-          backgroundImage: `linear-gradient(180deg, ${colors.primary[50]}, #f2fcfaff, ${colors.white})`,
+          backgroundImage: `linear-gradient(180deg, ${colors.primary[50]} 0%, #f2fcfaff 40%, ${colors.white} 80%)`,
           minHeight: '100vh',
           fontFamily: typography.fontFamily.primary,
           position: 'relative',
         }}
       >
+        {/* Hero: animated headline + subtitle */}
         <Box pt={spacing['4xl']}>
           <MainSection />
           <ActionCards />
         </Box>
+
+        {/* Stats bar: numbers that animate in on scroll */}
+        <StatsBar />
+
+        {/* Feature grid: three use-case cards */}
+        <FeatureGrid />
+
+        {/* Partner logos: cycling org logos */}
         <OrgLogos />
       </Box>
     </>

--- a/app/src/styles/stylesheets/animations.css
+++ b/app/src/styles/stylesheets/animations.css
@@ -1,0 +1,102 @@
+/* PolicyEngine scroll-reveal animations
+   All animations use only transform + opacity (GPU-composited, no layout thrash).
+   Applied via JS class toggling after IntersectionObserver fires.
+*/
+
+/* Base state: hidden */
+.reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  transition:
+    opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: opacity, transform;
+}
+
+/* Visible state */
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Stagger delays for child elements */
+.reveal-delay-1 {
+  transition-delay: 0.1s;
+}
+
+.reveal-delay-2 {
+  transition-delay: 0.2s;
+}
+
+.reveal-delay-3 {
+  transition-delay: 0.3s;
+}
+
+.reveal-delay-4 {
+  transition-delay: 0.4s;
+}
+
+.reveal-delay-5 {
+  transition-delay: 0.5s;
+}
+
+/* Hero headline word-by-word animation */
+@keyframes word-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.hero-word {
+  display: inline-block;
+  opacity: 0;
+  animation: word-fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+/* Stat counter fade-in */
+@keyframes stat-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.92) translateY(12px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.stat-reveal {
+  opacity: 0;
+}
+
+.stat-reveal.visible {
+  animation: stat-pop 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+/* Feature card slide-in from bottom */
+.feature-card {
+  opacity: 0;
+  transform: translateY(32px);
+  transition:
+    opacity 0.65s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.65s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.2s ease;
+  will-change: opacity, transform;
+}
+
+.feature-card.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.feature-card:hover {
+  transform: translateY(-4px) !important;
+  box-shadow: 0 20px 40px -12px rgb(0 88 76 / 18%) !important;
+}


### PR DESCRIPTION
## Summary

Implements Apple-inspired frontend performance and animation techniques on the homepage, with **zero new JS dependencies**.

- **`useScrollReveal` hook** — reusable `IntersectionObserver` wrapper that triggers once and self-disconnects; no scroll event listeners
- **`animations.css`** — GPU-composited CSS keyframes (`transform` + `opacity` only, no layout thrash). Three animations: `word-fade-up`, `stat-pop`, `feature-card` slide-in
- **`MainSection`** — Apple-style word-by-word headline animation on mount, staggered with `animationDelay` via `requestAnimationFrame`
- **`StatsBar`** — New section with key stats (50 states, 1,000+ rules, etc.) that `statPop` in on scroll
- **`FeatureGrid`** — New three-column section surfacing the three core use cases (simulate, calculate, build) with scroll-triggered reveal and a hover-lift effect
- **`ActionCards`** — Upgraded from single plain card to primary + secondary button pair with subtle hover transitions and a trust line
- **`Home.page.tsx`** — Sections now flow: hero → CTAs → stats → features → logos

## Techniques (from the Apple playbook)

| Technique | How |
|---|---|
| No third-party animation lib | Pure CSS `@keyframes` + class toggling |
| `IntersectionObserver` | `useScrollReveal` hook — fire once, disconnect |
| GPU-only animations | Only `transform` and `opacity` are animated |
| `will-change` hints | Set on `.reveal` and `.feature-card` |
| `requestAnimationFrame` | Used in `MainSection` to delay hero animation to next paint |
| `clamp()` for responsive type | Hero headline scales with viewport |

## Test plan

- [ ] Visit `http://localhost:5173/us` — headline words animate in one by one on load
- [ ] Scroll down — stats bar numbers pop in, feature cards slide up, org logos appear
- [ ] Hover feature cards — lift effect with shadow
- [ ] Hover CTAs — primary darkens and lifts, secondary shows teal background
- [ ] Visit `/uk` — stats and copy adjust for UK country
- [ ] Check no layout shift during animations (only transform/opacity change)