### PR TITLE
Fix 404 on first click for rewrite-proxied apps

### DIFF
--- a/app/src/components/blog/BlogPostCard.tsx
+++ b/app/src/components/blog/BlogPostCard.tsx
@@ -26,8 +26,13 @@ export function BlogPostCard({ item, countryId }: BlogPostCardProps) {
     .slice(0, 3)
     .map((tag) => topicLabels[tag] || locationLabels[tag] || tag);
 
+  // Apps may be served via Vercel rewrites (reverse proxy), so use a plain
+  // <a> to force a full server request instead of client-side routing.
+  const Wrapper = item.isApp ? 'a' : Link;
+  const wrapperProps = item.isApp ? { href: link } : { to: link };
+
   return (
-    <Link to={link} className="tw:no-underline tw:text-inherit tw:group">
+    <Wrapper {...(wrapperProps as any)} className="tw:no-underline tw:text-inherit tw:group">
       <div
         className={cn(
           'tw:flex tw:flex-col tw:h-full',
@@ -86,6 +91,6 @@ export function BlogPostCard({ item, countryId }: BlogPostCardProps) {
           </p>
         </div>
       </div>
-    </Link>
+    </Wrapper>
   );
 }


### PR DESCRIPTION
## Summary

- Apps served via Vercel rewrites (e.g. `/us/watca`, `/us/taxsim`) show a 404 on first click from the research page because React Router's `<Link>` intercepts the navigation client-side, and there's no matching React route
- Use a plain `<a>` tag for app cards so the browser makes a full server request that hits the Vercel rewrite rule
- On refresh the rewrite worked fine — this only affected SPA navigation

## Test plan

- [ ] Navigate to `/us/research`, click the WATCA calculator card — should load without 404
- [ ] Click a regular blog post card — should still use client-side navigation
- [ ] Verify `/us/taxsim` also works from research page links

🤖 Generated with [Claude Code](https://claude.com/claude-code)