### PR TITLE
Fix banner tests after restyle

### DIFF
--- a/app/src/tests/fixtures/components/shared/FeaturedResearchBannerMocks.ts
+++ b/app/src/tests/fixtures/components/shared/FeaturedResearchBannerMocks.ts
@@ -1,9 +1,6 @@
-export const BANNER_DISMISSED_KEY = 'autumn-budget-2025-banner-dismissed';
+export const BANNER_DISMISSED_KEY = 'featured-research-banner-dismissed';
 
-export const BUDGET_DATE = new Date('2025-11-26T12:30:00Z');
-
-export const MOCK_DATE_BEFORE_BUDGET = new Date('2025-11-20T10:00:00Z');
-export const MOCK_DATE_AFTER_BUDGET = new Date('2025-11-27T10:00:00Z');
+export const MOCK_DATE = new Date('2026-03-01T10:00:00Z');
 
 export const BANNER_CARD_LINKS = {
   SPRING_STATEMENT: '/uk/spring-statement-2026',

--- a/app/src/tests/unit/components/home/OrgLogos.test.tsx
+++ b/app/src/tests/unit/components/home/OrgLogos.test.tsx
@@ -5,7 +5,7 @@ import { TEST_COUNTRY_IDS } from '@/tests/fixtures/components/homeHeader/Country
 
 // Mock the organizations module
 vi.mock('@/data/organizations', () => ({
-  getOrgsForCountrySorted: vi.fn((countryId: string) => {
+  getOrgsForCountry: vi.fn((countryId: string) => {
     if (countryId === 'us') {
       return [
         {
@@ -18,36 +18,6 @@ vi.mock('@/data/organizations', () => ({
           name: 'US Organization 2',
           logo: '/us-logo2.png',
           link: 'https://us-org2.example.com',
-          countries: ['us'],
-        },
-        {
-          name: 'US Organization 3',
-          logo: '/us-logo3.png',
-          link: 'https://us-org3.example.com',
-          countries: ['us'],
-        },
-        {
-          name: 'US Organization 4',
-          logo: '/us-logo4.png',
-          link: 'https://us-org4.example.com',
-          countries: ['us'],
-        },
-        {
-          name: 'US Organization 5',
-          logo: '/us-logo5.png',
-          link: 'https://us-org5.example.com',
-          countries: ['us'],
-        },
-        {
-          name: 'US Organization 6',
-          logo: '/us-logo6.png',
-          link: 'https://us-org6.example.com',
-          countries: ['us'],
-        },
-        {
-          name: 'US Organization 7',
-          logo: '/us-logo7.png',
-          link: 'https://us-org7.example.com',
           countries: ['us'],
         },
       ];
@@ -66,36 +36,6 @@ vi.mock('@/data/organizations', () => ({
           link: 'https://uk-org2.example.com',
           countries: ['uk'],
         },
-        {
-          name: 'UK Organization 3',
-          logo: '/uk-logo3.png',
-          link: 'https://uk-org3.example.com',
-          countries: ['uk'],
-        },
-        {
-          name: 'UK Organization 4',
-          logo: '/uk-logo4.png',
-          link: 'https://uk-org4.example.com',
-          countries: ['uk'],
-        },
-        {
-          name: 'UK Organization 5',
-          logo: '/uk-logo5.png',
-          link: 'https://uk-org5.example.com',
-          countries: ['uk'],
-        },
-        {
-          name: 'UK Organization 6',
-          logo: '/uk-logo6.png',
-          link: 'https://uk-org6.example.com',
-          countries: ['uk'],
-        },
-        {
-          name: 'UK Organization 7',
-          logo: '/uk-logo7.png',
-          link: 'https://uk-org7.example.com',
-          countries: ['uk'],
-        },
       ];
     }
     return [];
@@ -107,52 +47,36 @@ describe('OrgLogos', () => {
     vi.clearAllMocks();
   });
 
-  test('given US country then displays US organizations', () => {
-    // When
-    renderWithCountry(<OrgLogos />, TEST_COUNTRY_IDS.US);
+  // The carousel renders two copies of each logo for seamless looping,
+  // so we use getAllByAltText and check the first instance.
 
-    // Then
-    expect(screen.getByAltText('US Organization 1')).toBeInTheDocument();
-    expect(screen.getByAltText('US Organization 2')).toBeInTheDocument();
+  test('given US country then displays US organizations', () => {
+    renderWithCountry(<OrgLogos />, TEST_COUNTRY_IDS.US);
+    expect(screen.getAllByAltText('US Organization 1').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByAltText('US Organization 2').length).toBeGreaterThanOrEqual(1);
   });
 
   test('given UK country then displays UK organizations', () => {
-    // When
     renderWithCountry(<OrgLogos />, TEST_COUNTRY_IDS.UK);
-
-    // Then
-    expect(screen.getByAltText('UK Organization 1')).toBeInTheDocument();
-    expect(screen.getByAltText('UK Organization 2')).toBeInTheDocument();
+    expect(screen.getAllByAltText('UK Organization 1').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByAltText('UK Organization 2').length).toBeGreaterThanOrEqual(1);
   });
 
-  test('given organization logo then opens link on click', async () => {
-    // Given
-    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
-    const { userEvent } = await import('@test-utils');
-    const user = userEvent.setup();
-
-    // When
+  test('given organization logo then links to correct URL', () => {
     renderWithCountry(<OrgLogos />, TEST_COUNTRY_IDS.US);
-    await user.click(screen.getByAltText('US Organization 1'));
-
-    // Then
-    expect(windowOpenSpy).toHaveBeenCalledWith('https://us-org1.example.com', '_blank');
+    const link = screen.getAllByAltText('US Organization 1')[0].closest('a');
+    expect(link).toHaveAttribute('href', 'https://us-org1.example.com');
+    expect(link).toHaveAttribute('target', '_blank');
   });
 
   test('given US country then displays benefit platforms copy', () => {
-    // When
     renderWithCountry(<OrgLogos />, TEST_COUNTRY_IDS.US);
-
-    // Then
     expect(screen.getByText(/benefit platforms/)).toBeInTheDocument();
   });
 
-  test('given UK country then displays simpler copy without benefit platforms', () => {
-    // When
+  test('given UK country then displays policy organisations copy', () => {
     renderWithCountry(<OrgLogos />, TEST_COUNTRY_IDS.UK);
-
-    // Then
     expect(screen.queryByText(/benefit platforms/)).not.toBeInTheDocument();
-    expect(screen.getByText('Trusted by researchers and policy organizations')).toBeInTheDocument();
+    expect(screen.getByText('Trusted by researchers and policy organisations')).toBeInTheDocument();
   });
 });

--- a/app/src/tests/unit/components/shared/FeaturedResearchBanner.test.tsx
+++ b/app/src/tests/unit/components/shared/FeaturedResearchBanner.test.tsx
@@ -6,8 +6,7 @@ import {
   BANNER_CARD_TITLES,
   BANNER_DISMISSED_KEY,
   CONTACT_EMAIL,
-  MOCK_DATE_AFTER_BUDGET,
-  MOCK_DATE_BEFORE_BUDGET,
+  MOCK_DATE,
 } from '@/tests/fixtures/components/shared/FeaturedResearchBannerMocks';
 
 vi.mock('@/hooks/useCurrentCountry', () => ({
@@ -19,6 +18,7 @@ describe('FeaturedResearchBanner', () => {
     vi.clearAllMocks();
     sessionStorage.clear();
     vi.useFakeTimers();
+    vi.setSystemTime(MOCK_DATE);
   });
 
   afterEach(() => {
@@ -26,63 +26,19 @@ describe('FeaturedResearchBanner', () => {
   });
 
   test('given UK country then banner displays', () => {
-    // Given
-    vi.setSystemTime(MOCK_DATE_AFTER_BUDGET);
-
-    // When
     render(<FeaturedResearchBanner />);
-
-    // Then
     expect(screen.getByText('Explore our latest research and tools')).toBeInTheDocument();
   });
 
-  test('given before budget date then countdown timer displays', () => {
-    // Given
-    vi.setSystemTime(MOCK_DATE_BEFORE_BUDGET);
-
-    // When
-    render(<FeaturedResearchBanner />);
-
-    // Then
-    expect(screen.getByText('Days')).toBeInTheDocument();
-    expect(screen.getByText('Hours')).toBeInTheDocument();
-    expect(screen.getByText('Minutes')).toBeInTheDocument();
-    expect(screen.getByText('Seconds')).toBeInTheDocument();
-  });
-
-  test('given after budget date then countdown timer does not display', () => {
-    // Given
-    vi.setSystemTime(MOCK_DATE_AFTER_BUDGET);
-
-    // When
-    render(<FeaturedResearchBanner />);
-
-    // Then
-    expect(screen.queryByText('Days')).not.toBeInTheDocument();
-    expect(screen.queryByText('Hours')).not.toBeInTheDocument();
-  });
-
   test('given all analysis cards then display with correct titles', () => {
-    // Given
-    vi.setSystemTime(MOCK_DATE_AFTER_BUDGET);
-
-    // When
     render(<FeaturedResearchBanner />);
-
-    // Then
     expect(screen.getByText(BANNER_CARD_TITLES.SPRING_STATEMENT)).toBeInTheDocument();
     expect(screen.getByText(BANNER_CARD_TITLES.SALARY_SACRIFICE)).toBeInTheDocument();
     expect(screen.getByText(BANNER_CARD_TITLES.STUDENT_LOAN)).toBeInTheDocument();
   });
 
   test('given analysis cards then link to correct URLs', () => {
-    // Given
-    vi.setSystemTime(MOCK_DATE_AFTER_BUDGET);
-
-    // When
     render(<FeaturedResearchBanner />);
-
-    // Then
     const springLink = screen.getByText(BANNER_CARD_TITLES.SPRING_STATEMENT).closest('a');
     const salaryLink = screen.getByText(BANNER_CARD_TITLES.SALARY_SACRIFICE).closest('a');
     const studentLink = screen.getByText(BANNER_CARD_TITLES.STUDENT_LOAN).closest('a');
@@ -93,49 +49,27 @@ describe('FeaturedResearchBanner', () => {
   });
 
   test('given analysis card links then open in same tab', () => {
-    // Given
-    vi.setSystemTime(MOCK_DATE_AFTER_BUDGET);
-
-    // When
     render(<FeaturedResearchBanner />);
-
-    // Then
     const salaryLink = screen.getByText(BANNER_CARD_TITLES.SALARY_SACRIFICE).closest('a');
     expect(salaryLink).not.toHaveAttribute('target', '_blank');
   });
 
   test('given contact CTA then displays with correct email link', () => {
-    // Given
-    vi.setSystemTime(MOCK_DATE_AFTER_BUDGET);
-
-    // When
     render(<FeaturedResearchBanner />);
-
-    // Then
     expect(screen.getByText(/Want custom analysis\?/i)).toBeInTheDocument();
     const contactLink = screen.getByText('Contact us');
     expect(contactLink).toHaveAttribute('href', CONTACT_EMAIL);
   });
 
   test('given close button present then banner can be dismissed', () => {
-    // Given
-    vi.setSystemTime(MOCK_DATE_AFTER_BUDGET);
     render(<FeaturedResearchBanner />);
-
-    // Then
     const closeButton = screen.getByRole('button');
     expect(closeButton).toBeInTheDocument();
   });
 
   test('given previously dismissed banner then does not display', () => {
-    // Given
-    vi.setSystemTime(MOCK_DATE_AFTER_BUDGET);
     sessionStorage.setItem(BANNER_DISMISSED_KEY, 'true');
-
-    // When
     render(<FeaturedResearchBanner />);
-
-    // Then
     expect(screen.queryByText('Explore our latest research and tools')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Update dismissed key and remove countdown timer tests to match the restyled FeaturedResearchBanner from #791. The countdown was removed and the session storage key was renamed.