### PR TITLE
Fix KYPA rewrite destination to include basePath

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -59,11 +59,11 @@
     },
     {
       "source": "/us/keep-your-pay-act",
-      "destination": "https://keep-your-pay-act.vercel.app/"
+      "destination": "https://keep-your-pay-act.vercel.app/us/keep-your-pay-act"
     },
     {
       "source": "/us/keep-your-pay-act/:path*",
-      "destination": "https://keep-your-pay-act.vercel.app/:path*"
+      "destination": "https://keep-your-pay-act.vercel.app/us/keep-your-pay-act/:path*"
     },
     {
       "source": "/us/taxsim",


### PR DESCRIPTION
## Summary
- Fix Vercel rewrite for `/us/keep-your-pay-act` — destination was missing the basePath, causing 404

The KYPA Next.js app serves from `/us/keep-your-pay-act` (its basePath), but the rewrite was proxying to the root URL.

## Test plan
- [ ] Verify `policyengine.org/us/keep-your-pay-act` loads with CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
