### PR TITLE
Auto-resize model iframe via postMessage

### DIFF
--- a/app/src/pages/Model.page.tsx
+++ b/app/src/pages/Model.page.tsx
@@ -1,15 +1,27 @@
 /**
- * Embeds the PolicyEngine Model overview in a simple iframe
- * with a fixed height. The postMessage-based auto-sizing from the
- * child app is intentionally not used to avoid resize loops.
+ * Embeds the PolicyEngine Model overview in an iframe that auto-sizes
+ * to match the child content height via postMessage.
  */
+import { useCallback, useEffect, useState } from 'react';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 
-const HEIGHT = '4000px';
+const MIN_HEIGHT = 4000;
 
 export default function ModelPage() {
   const countryId = useCurrentCountry();
   const embedUrl = `https://policyengine-model.vercel.app/?embed&country=${countryId}`;
+  const [height, setHeight] = useState(MIN_HEIGHT);
+
+  const onMessage = useCallback((e: MessageEvent) => {
+    if (e.data?.type === 'policyengine-model-height' && typeof e.data.height === 'number') {
+      setHeight(Math.max(e.data.height, MIN_HEIGHT));
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [onMessage]);
 
   return (
     <iframe
@@ -17,7 +29,7 @@ export default function ModelPage() {
       title="Model overview | PolicyEngine"
       style={{
         width: '100%',
-        height: HEIGHT,
+        height: `${height}px`,
         border: 'none',
         display: 'block',
       }}


### PR DESCRIPTION
## Summary
- The embedded policyengine-model content is ~6830px tall but the iframe was hardcoded to 4000px, clipping the Data pipeline and Behavioral responses sections
- Now the model app posts its `scrollHeight` via `postMessage` using a `ResizeObserver`, and the parent iframe listens and auto-resizes
- Minimum height stays at 4000px as a fallback

## Test plan
- [ ] Visit /us/model — all 4 sections visible (microsim walkthrough, rules coverage, data pipeline, behavioral responses)
- [ ] Visit /uk/model — UK content renders, behavioral → behavioural spelling
- [ ] No resize loops or flickering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
