### PR TITLE
Replace model iframe with Vercel rewrite

### DIFF
--- a/app/src/WebsiteRouter.tsx
+++ b/app/src/WebsiteRouter.tsx
@@ -24,7 +24,6 @@ const BrandWritingPage = lazy(() => import('./pages/BrandWriting.page'));
 const ClaudePluginsPage = lazy(() => import('./pages/ClaudePlugins.page'));
 const DonatePage = lazy(() => import('./pages/Donate.page'));
 const OrgLogosEmbedPage = lazy(() => import('./pages/embed/OrgLogosEmbed.page'));
-const ModelPage = lazy(() => import('./pages/Model.page'));
 const PrivacyPage = lazy(() => import('./pages/Privacy.page'));
 const ResearchPage = lazy(() => import('./pages/Research.page'));
 const SupportersPage = lazy(() => import('./pages/Supporters.page'));
@@ -36,6 +35,13 @@ const YearInReviewPage = lazy(() => import('./pages/YearInReview.page'));
 function BlogRedirect() {
   const { postName } = useParams();
   return <Navigate to={`../research/${postName}`} replace />;
+}
+
+// /model is handled by Vercel rewrite; methodology does a full-page redirect
+function MethodologyRedirect() {
+  const { countryId } = useParams();
+  window.location.replace(`/${countryId}/model`);
+  return null;
 }
 
 const router = createBrowserRouter(
@@ -82,7 +88,7 @@ const router = createBrowserRouter(
                 },
                 {
                   path: 'methodology',
-                  element: <Navigate to="../model" replace />,
+                  element: <MethodologyRedirect />,
                 },
                 {
                   path: 'support',
@@ -120,10 +126,7 @@ const router = createBrowserRouter(
                   path: 'ai-inequality',
                   element: <AIGrowthResearchPage />,
                 },
-                {
-                  path: 'model',
-                  element: <ModelPage />,
-                },
+                // /model is handled by Vercel rewrite to policyengine-model.vercel.app
                 {
                   path: 'claude-plugin',
                   element: <ClaudePluginsPage />,

--- a/vercel.json
+++ b/vercel.json
@@ -77,6 +77,14 @@
       "source": "/us/taxsim/:path*",
       "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/:path*"
     },
+    {
+      "source": "/:countryId/model",
+      "destination": "https://policyengine-model.vercel.app/:countryId/model"
+    },
+    {
+      "source": "/:countryId/model/:path*",
+      "destination": "https://policyengine-model.vercel.app/:countryId/model/:path*"
+    },
     { "source": "/(.*)", "destination": "/website.html" }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- Replace the iframe-based model page with a Vercel server-side rewrite to `policyengine-model.vercel.app`
- The model site now renders with its own PE header, sidebar nav, and all new pages (Parameters, Variables, Calibration, Validation) directly at `/:countryId/model`
- Remove `Model.page.tsx` route (Vercel handles it before the SPA)
- Update `/methodology` redirect to use full-page navigation since `/model` is no longer a React Router route

## Test plan
- [ ] Visit `policyengine.org/us/model` — should show model site with gradient header, sidebar nav
- [ ] Visit `policyengine.org/uk/model` — should show UK version with behavioural spelling
- [ ] Visit `policyengine.org/us/methodology` — should redirect to `/us/model`
- [ ] Nav links (Research, API, etc.) in the model header should work correctly
- [ ] Country selector globe should switch between US/UK

🤖 Generated with [Claude Code](https://claude.com/claude-code)