### PR TITLE
Fix model rewrite URL and path prefix

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -79,11 +79,11 @@
     },
     {
       "source": "/:countryId/model",
-      "destination": "https://policyengine-model.vercel.app/:countryId/model"
+      "destination": "https://policyengine-model-policy-engine.vercel.app/?country=:countryId"
     },
     {
       "source": "/:countryId/model/:path*",
-      "destination": "https://policyengine-model.vercel.app/:countryId/model/:path*"
+      "destination": "https://policyengine-model-policy-engine.vercel.app/:path*?country=:countryId"
     },
     {
       "source": "/us/api",


### PR DESCRIPTION
## Summary
- Update policyengine-model Vercel rewrite to point to correct team-scoped domain (`policyengine-model-policy-engine.vercel.app`)
- Strip `/:countryId/model` prefix and pass country as query param, matching the model app's Next.js root-based routing

The model project was moved from Max's personal Vercel scope to the PolicyEngine team, changing its production domain. The old rewrites also passed the full path through, but the model app now uses Next.js App Router with root-based routes (`/`, `/data/pipeline`, etc.).

## Test plan
- [ ] Visit policyengine.org/us/model and verify the overview page loads
- [ ] Visit policyengine.org/us/model/data/pipeline and verify 14-step pipeline renders
- [ ] Visit policyengine.org/us/model/data/calibration and verify calibration targets table shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)