### PR TITLE
Fix model rewrite: use phi alias to bypass deployment protection

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -79,11 +79,11 @@
     },
     {
       "source": "/:countryId/model",
-      "destination": "https://policyengine-model-policy-engine.vercel.app/?country=:countryId"
+      "destination": "https://policyengine-model-phi.vercel.app/?country=:countryId"
     },
     {
       "source": "/:countryId/model/:path*",
-      "destination": "https://policyengine-model-policy-engine.vercel.app/:path*?country=:countryId"
+      "destination": "https://policyengine-model-phi.vercel.app/:path*?country=:countryId"
     },
     {
       "source": "/us/api",


### PR DESCRIPTION
## Summary
- Switch model rewrite destination from `-policy-engine.vercel.app` (has deployment protection → 401) to `-phi.vercel.app` (serves without auth)

## Test plan
- [ ] Visit policyengine.org/us/model — should load the model overview page
- [ ] Visit policyengine.org/us/model/data/pipeline — should show the 14-step pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)