### PR TITLE
Fix report year selector to use API metadata

### DIFF
--- a/app/src/pages/reportBuilder/components/ReportMetaPanel.tsx
+++ b/app/src/pages/reportBuilder/components/ReportMetaPanel.tsx
@@ -7,6 +7,7 @@
 
 import React, { useLayoutEffect, useState } from 'react';
 import { IconCheck, IconFileDescription, IconPencil } from '@tabler/icons-react';
+import { useSelector } from 'react-redux';
 import {
   Button,
   Input,
@@ -19,6 +20,7 @@ import {
 } from '@/components/ui';
 import { CURRENT_YEAR } from '@/constants';
 import { colors, spacing, typography } from '@/designTokens';
+import { getTaxYears } from '@/libs/metadataUtils';
 import { FONT_SIZES } from '../constants';
 import type { ReportBuilderState } from '../types';
 
@@ -34,8 +36,6 @@ const segmentBase: React.CSSProperties = {
   alignItems: 'center',
 };
 
-const YEAR_OPTIONS = ['2023', '2024', '2025', '2026'];
-
 interface ReportMetaPanelProps {
   reportState: ReportBuilderState;
   setReportState: React.Dispatch<React.SetStateAction<ReportBuilderState>>;
@@ -43,6 +43,7 @@ interface ReportMetaPanelProps {
 }
 
 export function ReportMetaPanel({ reportState, setReportState, isReadOnly }: ReportMetaPanelProps) {
+  const yearOptions = useSelector(getTaxYears);
   const [isEditingLabel, setIsEditingLabel] = useState(false);
   const [labelInput, setLabelInput] = useState('');
   const [inputWidth, setInputWidth] = useState<number | null>(null);
@@ -238,9 +239,9 @@ export function ReportMetaPanel({ reportState, setReportState, isReadOnly }: Rep
             <SelectValue />
           </SelectTrigger>
           <SelectContent align="end">
-            {YEAR_OPTIONS.map((year) => (
-              <SelectItem key={year} value={year}>
-                {year}
+            {yearOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
               </SelectItem>
             ))}
           </SelectContent>


### PR DESCRIPTION
## Summary
- Replaces hardcoded `YEAR_OPTIONS = ['2023', '2024', '2025', '2026']` with dynamic years from API metadata
- Uses existing `getTaxYears` selector which reads from `state.metadata.economyOptions.time_period`
- Enables users to select simulation years up to 2035 (as provided by the US API)

## Root cause
The report year dropdown was hardcoded to only show years 2023-2026, while the API provides years 2024-2035. This prevented users from running simulations for future years.

## Test plan
- [ ] Navigate to Report Builder
- [ ] Click on the year dropdown in the top bar
- [ ] Verify years now extend to 2035 (or whatever the API provides)
- [ ] Select a future year and confirm the simulation runs correctly

Fixes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)