### PR TITLE
Fix design system npm publish by removing workspace: protocol

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@policyengine/design-system": "workspace:*",
+    "@policyengine/design-system": "*",
     "@tabler/icons-react": "^3.31.0",
     "fuse.js": "^7.1.0",
     "jsonp": "^0.2.1",


### PR DESCRIPTION
Fixes #852

## Summary

- Replace `"workspace:*"` with `"*"` in `website/package.json` so `npm version` (run by semantic-release) no longer fails with `EUNSUPPORTEDPROTOCOL`
- Bun resolves plain `*` to local workspace packages identically — `app/package.json` already uses this pattern

## Test plan

- [ ] CI passes (the design-system semantic-release step no longer errors)
- [ ] `bun install` still resolves `@policyengine/design-system` to the local workspace package
- [ ] Website dev server works with the design system dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)