### PR TITLE
Fix missing report_started GA4 event

### DIFF
--- a/app/src/pages/reportBuilder/hooks/useReportSubmission.ts
+++ b/app/src/pages/reportBuilder/hooks/useReportSubmission.ts
@@ -21,6 +21,7 @@ import { RootState } from '@/store';
 import { Report } from '@/types/ingredients/Report';
 import { Simulation } from '@/types/ingredients/Simulation';
 import { SimulationStateProps } from '@/types/pathwayState';
+import { trackReportStarted } from '@/utils/analytics';
 import { toApiPolicyId } from '../currentLaw';
 import { ReportBuilderState } from '../types';
 
@@ -95,6 +96,7 @@ export function useReportSubmission({
     }
 
     setIsSubmitting(true);
+    trackReportStarted();
 
     try {
       const simulationIds: string[] = [];


### PR DESCRIPTION
## Summary
- Restores the `trackReportStarted()` GA4 event call that was lost when `ReportLabelView.tsx` was deleted during the report builder refactor
- The call is now in `useReportSubmission.ts`, firing when the user submits a new report

## Test plan
- [ ] Create a new report via the report builder
- [ ] Verify `report_started` event appears in GA4 DebugView / Realtime
- [ ] Confirm no duplicate events on retry/error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)