### PR TITLE
Fix TAXSIM sub-route rewrites for direct URL access

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -74,6 +74,30 @@
       "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/"
     },
     {
+      "source": "/us/taxsim/run",
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/run"
+    },
+    {
+      "source": "/us/taxsim/run/",
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/run/"
+    },
+    {
+      "source": "/us/taxsim/documentation",
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/documentation"
+    },
+    {
+      "source": "/us/taxsim/documentation/",
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/documentation/"
+    },
+    {
+      "source": "/us/taxsim/dashboard",
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/dashboard"
+    },
+    {
+      "source": "/us/taxsim/dashboard/",
+      "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/dashboard/"
+    },
+    {
       "source": "/us/taxsim/:path*",
       "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/:path*"
     },


### PR DESCRIPTION
## Summary
- Adds explicit Vercel rewrites for `/us/taxsim/run/`, `/us/taxsim/documentation/`, and `/us/taxsim/dashboard/` (with and without trailing slashes)
- The catch-all `/us/taxsim/:path*` doesn't match trailing-slash URLs, causing them to fall through to `website.html` and show "App not found"
- Direct URL access to these routes now works correctly

## Test plan
- [ ] Visit https://www.policyengine.org/us/taxsim/run/ directly — should load the TAXSIM runner
- [ ] Visit https://www.policyengine.org/us/taxsim/documentation/ directly — should load docs
- [ ] Visit https://www.policyengine.org/us/taxsim/ — should still work as before
- [ ] Client-side navigation between pages still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)