### PR TITLE
Extract report output route from calculator catch-all to Next.js

### DIFF
--- a/app/src/CalculatorRouter.tsx
+++ b/app/src/CalculatorRouter.tsx
@@ -27,6 +27,16 @@ function ModifyReportPageRoute() {
   return <ModifyReportPage userReportId={userReportId} />;
 }
 
+/** Bridges react-router useParams to ReportOutputPage's prop interface. */
+function ReportOutputRoute() {
+  const { reportId, subpage, view } = useParams<{
+    reportId: string;
+    subpage?: string;
+    view?: string;
+  }>();
+  return <ReportOutputPage reportId={reportId} subpage={subpage} view={view} />;
+}
+
 /**
  * Layout wrapper that renders StandardLayout with Outlet for nested routes.
  * This allows the app shell (header, sidebar) to remain visible while
@@ -60,7 +70,7 @@ const router = createBrowserRouter(
               children: [
                 {
                   path: 'report-output/:reportId/:subpage?/:view?',
-                  element: <ReportOutputPage />,
+                  element: <ReportOutputRoute />,
                 },
               ],
             },

--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { SocietyWideReportOutput as SocietyWideOutput } from '@/api/societyWideCalculation';
 import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 import { FloatingAlert } from '@/components/common/FloatingAlert';
 import { ReportErrorFallback } from '@/components/report/ReportErrorFallback';
 import { Container, Stack, Text } from '@/components/ui';
 import { CALCULATOR_URL } from '@/constants';
+import { useAppLocation } from '@/contexts/LocationContext';
+import { useAppNavigate } from '@/contexts/NavigationContext';
 import { ReportYearProvider } from '@/contexts/ReportYearContext';
 import { colors, spacing } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
@@ -43,22 +44,24 @@ export type ReportOutputType = 'household' | 'societyWide';
  * - useSharedReportData: uses ShareData from URL (same shape)
  */
 
-export default function ReportOutputPage() {
+interface ReportOutputPageProps {
+  reportId?: string;
+  subpage?: string;
+  view?: string;
+}
+
+export default function ReportOutputPage({
+  reportId: userReportId,
+  subpage,
+  view,
+}: ReportOutputPageProps) {
   if (import.meta.env.DEV) {
     (window as any).__journeyProfiler?.markEvent('report-output-render', 'render');
   }
-  const navigate = useNavigate();
+  const nav = useAppNavigate();
   const countryId = useCurrentCountry();
-  const [searchParams] = useSearchParams();
-  const {
-    reportId: userReportId,
-    subpage,
-    view,
-  } = useParams<{
-    reportId?: string;
-    subpage?: string;
-    view?: string;
-  }>();
+  const location = useAppLocation();
+  const searchParams = new URLSearchParams(location.search);
 
   // Detect shared view from URL
   const shareData = extractShareDataFromUrl(searchParams);
@@ -163,7 +166,7 @@ export default function ReportOutputPage() {
       // ShareData already contains user associations - just pass it directly
       const newUserReport = await saveSharedReport(shareData);
       // Navigate to owned view (same URL pattern but now in localStorage)
-      navigate(`/${countryId}/report-output/${newUserReport.id}/${activeTab}`);
+      nav.push(`/${countryId}/report-output/${newUserReport.id}/${activeTab}`);
     } catch (error) {
       console.error('[ReportOutputPage] Failed to save report:', error);
     }
@@ -176,7 +179,7 @@ export default function ReportOutputPage() {
         from: 'report-output',
         reportPath: `/${countryId}/report-output/${userReportId}`,
       });
-      navigate(`/${countryId}/reports/create/${userReportId}?${params}`);
+      nav.push(`/${countryId}/reports/create/${userReportId}?${params}`);
     }
   };
 
@@ -186,9 +189,9 @@ export default function ReportOutputPage() {
     if (id) {
       const basePath = `/${countryId}/report-output/${id}/reproduce`;
       if (isSharedView) {
-        navigate(`${basePath}?${searchParams.toString()}`);
+        nav.push(`${basePath}?${searchParams.toString()}`);
       } else {
-        navigate(basePath);
+        nav.push(basePath);
       }
     }
   };

--- a/app/src/pages/report-output/ErrorPage.tsx
+++ b/app/src/pages/report-output/ErrorPage.tsx
@@ -1,6 +1,6 @@
 import { IconAlertCircle } from '@tabler/icons-react';
-import { useNavigate } from 'react-router-dom';
 import { Alert, AlertDescription, AlertTitle, Button, Stack } from '@/components/ui';
+import { useAppNavigate } from '@/contexts/NavigationContext';
 
 interface ErrorPageProps {
   error?: any;
@@ -10,7 +10,7 @@ interface ErrorPageProps {
  * Error page component displayed when report calculation fails
  */
 export default function ErrorPage({ error }: ErrorPageProps) {
-  const navigate = useNavigate();
+  const nav = useAppNavigate();
 
   return (
     <Stack className="tw:gap-md">
@@ -24,7 +24,7 @@ export default function ErrorPage({ error }: ErrorPageProps) {
         </AlertDescription>
       </Alert>
 
-      <Button variant="outline" onClick={() => navigate(-1)} className="tw:w-full">
+      <Button variant="outline" onClick={() => nav.back()} className="tw:w-full">
         Go back
       </Button>
     </Stack>

--- a/app/src/pages/report-output/ReportOutputLayout.tsx
+++ b/app/src/pages/report-output/ReportOutputLayout.tsx
@@ -1,8 +1,8 @@
 import { IconCalendar, IconChevronLeft, IconClock } from '@tabler/icons-react';
-import { useNavigate } from 'react-router-dom';
 import { ReportActionButtons } from '@/components/report/ReportActionButtons';
 import { SharedReportTag } from '@/components/report/SharedReportTag';
 import { Container, Group, Stack, Text, Title } from '@/components/ui';
+import { useAppNavigate } from '@/contexts/NavigationContext';
 import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 
@@ -42,7 +42,7 @@ export default function ReportOutputLayout({
   children,
 }: ReportOutputLayoutProps) {
   const countryId = useCurrentCountry();
-  const navigate = useNavigate();
+  const nav = useAppNavigate();
 
   return (
     <Container size="xl" className="tw:px-xl">
@@ -51,7 +51,7 @@ export default function ReportOutputLayout({
         <Group
           className="tw:gap-xs tw:items-center tw:cursor-pointer"
           style={{ marginBottom: `-${spacing.md}` }}
-          onClick={() => navigate(`/${countryId}/reports`)}
+          onClick={() => nav.push(`/${countryId}/reports`)}
         >
           <IconChevronLeft size={14} color={colors.text.secondary} />
           <Text className="tw:text-sm" style={{ color: colors.text.secondary }}>

--- a/app/src/tests/unit/pages/ReportOutput.page.test.tsx
+++ b/app/src/tests/unit/pages/ReportOutput.page.test.tsx
@@ -19,20 +19,6 @@ import {
 } from '@/tests/fixtures/pages/ReportOutputPageMocks';
 
 // Mock dependencies
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useNavigate: () => vi.fn(),
-    useParams: () => ({
-      reportId: MOCK_USER_REPORT_ID,
-      subpage: 'overview',
-      view: undefined,
-    }),
-    useSearchParams: () => [new URLSearchParams(), vi.fn()],
-  };
-});
-
 vi.mock('@/hooks/useCurrentCountry', () => ({
   useCurrentCountry: () => 'us',
 }));
@@ -118,7 +104,7 @@ describe('ReportOutputPage', () => {
 
   test('given report with year then year is passed to layout', () => {
     // Given - MOCK_REPORT has year '2024'
-    render(<ReportOutputPage />);
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
 
     // Then - Year should be displayed in the layout
     expect(screen.getByText(/Year: 2024/)).toBeInTheDocument();
@@ -126,7 +112,7 @@ describe('ReportOutputPage', () => {
 
   test('given report label then label is displayed', () => {
     // Given
-    render(<ReportOutputPage />);
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
 
     // Then
     expect(screen.getByRole('heading', { name: 'Test Report' })).toBeInTheDocument();
@@ -134,7 +120,7 @@ describe('ReportOutputPage', () => {
 
   test('given society-wide report with complete calculation then renders without error', () => {
     // Given
-    render(<ReportOutputPage />);
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
 
     // Then - page renders layout and delegates to society-wide output
     expect(screen.queryByText('Loading report...')).not.toBeInTheDocument();
@@ -159,7 +145,7 @@ describe('ReportOutputPage', () => {
     });
 
     // When
-    render(<ReportOutputPage />);
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
 
     // Then - page renders layout and delegates to society-wide output
     expect(screen.queryByText('Loading report...')).not.toBeInTheDocument();
@@ -184,7 +170,7 @@ describe('ReportOutputPage', () => {
     });
 
     // When
-    render(<ReportOutputPage />);
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
 
     // Then - page renders layout and delegates to society-wide output
     expect(screen.queryByText('Loading report...')).not.toBeInTheDocument();
@@ -209,7 +195,7 @@ describe('ReportOutputPage', () => {
     });
 
     // When
-    render(<ReportOutputPage />);
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
 
     // Then - constituency and local authority content should not be shown
     expect(screen.queryByText('Constituencies')).not.toBeInTheDocument();
@@ -234,7 +220,7 @@ describe('ReportOutputPage', () => {
     });
 
     // When
-    render(<ReportOutputPage />);
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
 
     // Then - Constituency and local authority tabs should not be shown
     expect(screen.queryByText('Constituencies')).not.toBeInTheDocument();

--- a/calculator-app/src/app/[countryId]/report-output/[reportId]/[[...rest]]/page.tsx
+++ b/calculator-app/src/app/[countryId]/report-output/[reportId]/[[...rest]]/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { use } from "react";
+import StandardLayout from "@/components/StandardLayout";
+import ReportOutputPage from "@/pages/ReportOutput.page";
+import { CalculatorProviders } from "../../../providers";
+
+export default function ReportOutputRoute({
+  params,
+}: {
+  params: Promise<{ reportId: string; rest?: string[] }>;
+}) {
+  const { reportId, rest } = use(params);
+  const subpage = rest?.[0];
+  const view = rest?.[1];
+
+  return (
+    <CalculatorProviders>
+      <StandardLayout>
+        <ReportOutputPage reportId={reportId} subpage={subpage} view={view} />
+      </StandardLayout>
+    </CalculatorProviders>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract `ReportOutputPage` from the `[[...slug]]` catch-all into a dedicated Next.js route at `[countryId]/report-output/[reportId]/[[...rest]]/page.tsx`
- Swap all react-router-dom hooks (`useNavigate`, `useParams`, `useSearchParams`) to router abstractions (`useAppNavigate`, `useAppLocation`) and props
- Add `ReportOutputRoute` bridge wrapper in `CalculatorRouter.tsx` for Vite compatibility
- Also swap `ReportOutputLayout` and `ErrorPage` to use `useAppNavigate`

## Test plan
- [x] All 16 existing tests pass (ReportOutputPage + ReportOutputLayout)
- [x] Typecheck clean for both `app/` and `calculator-app/`
- [x] Lint passes with zero warnings
- [ ] Manual: verify report output page works in Vite dev server
- [ ] Manual: verify report output page works in Next.js dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)