### PR TITLE
Add UK API docs rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -137,6 +137,18 @@
       "source": "/us/oregon-kicker-refund/:path*",
       "destination": "https://oregon-kicker-refund.vercel.app/us/oregon-kicker-refund/:path*"
     },
+    {
+      "source": "/uk/api",
+      "destination": "https://household-api-docs-policy-engine.vercel.app/uk/api"
+    },
+    {
+      "source": "/uk/api/",
+      "destination": "https://household-api-docs-policy-engine.vercel.app/uk/api/"
+    },
+    {
+      "source": "/uk/api/:path*",
+      "destination": "https://household-api-docs-policy-engine.vercel.app/uk/api/:path*"
+    },
     { "source": "/(.*)", "destination": "/website.html" }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- route `/uk/api` traffic to the household API docs deployment alongside the existing `/us/api` proxy

## Verification
- `jq empty vercel.json`