### PR TITLE
Fix www canonical URLs and add JSON-LD to blog articles

### DIFF
--- a/website/src/app/[countryId]/research/[slug]/page.tsx
+++ b/website/src/app/[countryId]/research/[slug]/page.tsx
@@ -68,12 +68,39 @@ export default async function ArticlePage({
   const content = getArticleContent(post.filename);
   const isNotebook = isNotebookFile(post.filename);
 
+  const imageUrl = post.image
+    ? post.image.startsWith("http")
+      ? post.image
+      : `https://www.policyengine.org/assets/posts/${post.image}`
+    : undefined;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: post.title,
+    description: post.description,
+    datePublished: post.date,
+    author: post.authors.map((name) => ({ "@type": "Person", name })),
+    publisher: {
+      "@type": "Organization",
+      name: "PolicyEngine",
+      url: "https://www.policyengine.org",
+    },
+    ...(imageUrl ? { image: imageUrl } : {}),
+  };
+
   return (
-    <ArticleClient
-      post={post}
-      content={content}
-      isNotebook={isNotebook}
-      countryId={countryId}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ArticleClient
+        post={post}
+        content={content}
+        isNotebook={isNotebook}
+        countryId={countryId}
+      />
+    </>
   );
 }

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://policyengine.org"),
+  metadataBase: new URL("https://www.policyengine.org"),
   title: {
     template: "%s | PolicyEngine",
     default: "PolicyEngine",

--- a/website/src/app/robots.ts
+++ b/website/src/app/robots.ts
@@ -6,6 +6,6 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: "https://policyengine.org/sitemap.xml",
+    sitemap: "https://www.policyengine.org/sitemap.xml",
   };
 }

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 import { getPostsSorted } from "@/data/posts/postTransformers";
 
-const BASE_URL = "https://policyengine.org";
+const BASE_URL = "https://www.policyengine.org";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const entries: MetadataRoute.Sitemap = [];
@@ -44,9 +44,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const posts = getPostsSorted();
   for (const post of posts) {
     const slug = post.slug;
-    const countries = post.tags.filter((t: string) =>
-      ["us", "uk"].includes(t),
-    );
+    const countries = post.tags.filter((t: string) => ["us", "uk"].includes(t));
     const targetCountries = countries.length > 0 ? countries : ["us"];
 
     for (const country of targetCountries) {


### PR DESCRIPTION
## Summary
- **Fix canonical URL mismatch**: `metadataBase`, `sitemap.ts`, and `robots.ts` all used `https://policyengine.org` (non-www), but production serves on `https://www.policyengine.org`. The non-www domain 307 redirects to www, so crawlers hitting a www page saw a canonical pointing to non-www, followed it, got redirected back to www — a confusing signal that can hurt search indexing.
- **Add JSON-LD structured data to blog articles**: Adds `<script type="application/ld+json">` with Article schema (headline, description, date, authors, publisher, image) to research article pages. This enables rich search results in Google (thumbnails, author, publish date).

## Test plan
- [ ] Build website (`cd website && bun run build`) — verify no errors
- [ ] Check generated sitemap at `/sitemap.xml` — all URLs should use `www.policyengine.org`
- [ ] Check `/robots.txt` — sitemap reference should use `www.policyengine.org`
- [ ] View source on any blog article — verify `<script type="application/ld+json">` block is present with correct Article schema
- [ ] Test with [Google Rich Results Test](https://search.google.com/test/rich-results) on a blog article URL
- [ ] Test with [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) — OG URLs should show `www.policyengine.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)