### PR TITLE
Add Vercel config for calculator-app

### DIFF
--- a/calculator-app/scripts/vercel-build.sh
+++ b/calculator-app/scripts/vercel-build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+cd "$REPO_ROOT/packages/design-system"
+bun run build
+
+cd "$REPO_ROOT/calculator-app"
+bun run build

--- a/calculator-app/vercel.json
+++ b/calculator-app/vercel.json
@@ -2,6 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "cd .. && bun install --frozen-lockfile",
-  "buildCommand": "cd ../packages/design-system && bun run build && cd ../../calculator-app && bun run build",
+  "buildCommand": "bash scripts/vercel-build.sh",
   "outputDirectory": ".next"
 }


### PR DESCRIPTION
## Summary
- Adds `vercel.json` to `calculator-app/` for the `policyengine-calculator-next` Vercel project
- Configures framework (Next.js), install command (monorepo root), build command (via `scripts/vercel-build.sh`), and output directory
- Adds `scripts/vercel-build.sh` — builds design-system first, then calculator-app (same pattern as `website/scripts/vercel-build.sh`)

## Manual steps still needed (Vercel dashboard)
- Set root directory to `calculator-app`
- Set framework preset to Next.js
- Add env vars: `NEXT_PUBLIC_WEBSITE_URL`, `NEXT_PUBLIC_CALCULATOR_URL`, `NEXT_PUBLIC_IPAPI_CO_KEY`

## Test plan
- [ ] Verify `policyengine-calculator-next` builds successfully on Vercel after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)