### PR TITLE
Fix post-domain-shift console errors

### DIFF
--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -232,17 +232,11 @@ function NavItem({ setup }: { setup: NavItemSetup }) {
 
   if (href) {
     // External rewrite routes (Model, API) use <a> to avoid Next.js RSC prefetch 404s
-    if (setup.external) {
-      return (
-        <a href={href} style={navItemStyle} {...hoverHandlers}>
-          {label}
-        </a>
-      );
-    }
+    const Tag = setup.external ? "a" : Link;
     return (
-      <Link href={href} style={navItemStyle} {...hoverHandlers}>
+      <Tag href={href} style={navItemStyle} {...hoverHandlers}>
         {label}
-      </Link>
+      </Tag>
     );
   }
 
@@ -426,6 +420,24 @@ function CountrySelector() {
 
 // --- Mobile menu ---
 
+const mobileNavLinkStyle: React.CSSProperties = {
+  color: colors.text.inverse,
+  textDecoration: "none",
+  fontWeight: typography.fontWeight.medium,
+  fontSize: typography.fontSize.sm,
+  fontFamily: typography.fontFamily.primary,
+  display: "block",
+};
+
+function MobileNavLink({ item, onClose }: { item: NavItemSetup; onClose: () => void }) {
+  const Tag = item.external ? "a" : Link;
+  return (
+    <Tag href={item.href || "#"} onClick={onClose} style={mobileNavLinkStyle}>
+      {item.label}
+    </Tag>
+  );
+}
+
 function MobileMenu({
   open,
   onClose,
@@ -553,21 +565,7 @@ function MobileMenu({
                 </div>
               </div>
             ) : (
-              <Link
-                key={item.label}
-                href={item.href || "#"}
-                onClick={onClose}
-                style={{
-                  color: colors.text.inverse,
-                  textDecoration: "none",
-                  fontWeight: typography.fontWeight.medium,
-                  fontSize: typography.fontSize.sm,
-                  fontFamily: typography.fontFamily.primary,
-                  display: "block",
-                }}
-              >
-                {item.label}
-              </Link>
+              <MobileNavLink key={item.label} item={item} onClose={onClose} />
             ),
           )}
         </div>

--- a/website/src/components/ui/OptimisedImage.tsx
+++ b/website/src/components/ui/OptimisedImage.tsx
@@ -50,6 +50,11 @@ function optimisedSrc(src: string, width?: number, quality = 80): string {
     return src;
   }
 
+  // Skip SVGs — vector images can't be raster-optimized
+  if (src.endsWith('.svg')) {
+    return src;
+  }
+
   // Skip in dev — Vercel image API isn't available locally
   if (process.env.NODE_ENV === 'development') {
     return src;


### PR DESCRIPTION
Fixes two console errors after moving policyengine.org to the Next.js website deployment.

- Header: use plain <a> for Model and API links (Vercel rewrites, not Next.js pages). Fixes RSC prefetch 404s.
- OptimisedImage: skip _next/static paths from Vercel image optimization. Fixes 400s on org logos.