### PR TITLE
Fix API docs redirect loop

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -38,6 +38,9 @@ const nextConfig: NextConfig = {
         // Oregon Kicker Refund calculator (Vercel)
         { source: "/us/oregon-kicker-refund", destination: "https://oregon-kicker-refund.vercel.app/us/oregon-kicker-refund" },
         { source: "/us/oregon-kicker-refund/:path*", destination: "https://oregon-kicker-refund.vercel.app/us/oregon-kicker-refund/:path*" },
+        // Household API docs (Vercel) — beforeFiles so it intercepts before Next.js trailing slash redirect
+        { source: "/us/api", destination: "https://household-api-docs-policy-engine.vercel.app/us/api/" },
+        { source: "/us/api/:path*", destination: "https://household-api-docs-policy-engine.vercel.app/us/api/:path*" },
       ],
       // afterFiles: checked after pages/public files but before dynamic routes.
       afterFiles: [
@@ -55,9 +58,6 @@ const nextConfig: NextConfig = {
         // Model documentation (Vercel)
         { source: "/:countryId/model", destination: "https://policyengine-model-phi.vercel.app/?country=:countryId" },
         { source: "/:countryId/model/:path*", destination: "https://policyengine-model-phi.vercel.app/:path*?country=:countryId" },
-        // Household API docs (Vercel)
-        { source: "/us/api", destination: "https://household-api-docs-policy-engine.vercel.app/us/api" },
-        { source: "/us/api/:path*", destination: "https://household-api-docs-policy-engine.vercel.app/us/api/:path*" },
         // California wealth tax calculator embed (Vercel)
         { source: "/us/california-wealth-tax/embed", destination: "https://california-wealth-tax.vercel.app/us/california-wealth-tax/embed" },
         { source: "/us/california-wealth-tax/embed/:path*", destination: "https://california-wealth-tax.vercel.app/us/california-wealth-tax/embed/:path*" },


### PR DESCRIPTION
The /us/api page is broken with infinite redirects. 

Cause: household-api-docs PR #6 added a redirect from /us/api to /us/api/ (trailing slash). Our rewrite sends /us/api to their app without the slash, their app redirects back with the slash, our rewrite intercepts again — loop.

Fix: add trailing slash to the rewrite destination so the request arrives already with the slash.