### PR TITLE
Add zone asset rewrite for API docs

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -41,6 +41,8 @@ const nextConfig: NextConfig = {
         // Household API docs (Vercel) — beforeFiles so it intercepts before Next.js trailing slash redirect
         { source: "/us/api", destination: "https://household-api-docs-policy-engine.vercel.app/us/api/" },
         { source: "/us/api/:path*", destination: "https://household-api-docs-policy-engine.vercel.app/us/api/:path*" },
+        // Zone asset proxy — API docs uses assetPrefix: '/_zones/household-api-docs'
+        { source: "/_zones/household-api-docs/:path*", destination: "https://household-api-docs-policy-engine.vercel.app/_zones/household-api-docs/:path*" },
       ],
       // afterFiles: checked after pages/public files but before dynamic routes.
       afterFiles: [


### PR DESCRIPTION
Adds a rewrite to proxy API docs CSS/JS assets through policyengine.org.

The household-api-docs app uses assetPrefix: '/_zones/household-api-docs' (PR PolicyEngine/household-api-docs#9) so its assets don't collide with our app's /_next/ files when served through our rewrite proxy.

This PR adds the corresponding rewrite on our side to forward those asset requests to their deployment.

Merge after PolicyEngine/household-api-docs#9 is deployed.