### PR TITLE
Fix state legislative tracker deep links returning 404

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -29,6 +29,9 @@ const nextConfig: NextConfig = {
       // External Next.js apps that serve full pages must go here
       // so they take priority over the dynamic [slug] route.
       beforeFiles: [
+        // State legislative tracker (Modal) — served directly, not via iframe
+        { source: "/:countryId/state-legislative-tracker", destination: "https://policyengine--state-legislative-tracker.modal.run/" },
+        { source: "/:countryId/state-legislative-tracker/:path*", destination: "https://policyengine--state-legislative-tracker.modal.run/:path*" },
         // Working Americans Tax Cut Act (Vercel)
         { source: "/us/watca", destination: "https://working-americans-tax-cut-act-one.vercel.app/us/watca" },
         { source: "/us/watca/:path*", destination: "https://working-americans-tax-cut-act-one.vercel.app/us/watca/:path*" },

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -29,9 +29,6 @@ const nextConfig: NextConfig = {
       // External Next.js apps that serve full pages must go here
       // so they take priority over the dynamic [slug] route.
       beforeFiles: [
-        // State legislative tracker (Modal) — served directly, not via iframe
-        { source: "/:countryId/state-legislative-tracker", destination: "https://policyengine--state-legislative-tracker.modal.run/" },
-        { source: "/:countryId/state-legislative-tracker/:path*", destination: "https://policyengine--state-legislative-tracker.modal.run/:path*" },
         // Working Americans Tax Cut Act (Vercel)
         { source: "/us/watca", destination: "https://working-americans-tax-cut-act-one.vercel.app/us/watca" },
         { source: "/us/watca/:path*", destination: "https://working-americans-tax-cut-act-one.vercel.app/us/watca/:path*" },

--- a/website/src/app/[countryId]/[slug]/AppClient.tsx
+++ b/website/src/app/[countryId]/[slug]/AppClient.tsx
@@ -56,20 +56,27 @@ export default function AppClient({ app, countryId, subPath }: AppClientProps) {
     return `/${segments.slice(0, 2).join("/")}`;
   }, [pathname]);
 
+  // Derive sub-path from the browser URL.
+  // e.g. pathname="/us/state-legislative-tracker/MN/mn-hf4621", basePath="/us/state-legislative-tracker"
+  // → derivedSubPath="/MN/mn-hf4621"
+  const derivedSubPath = useMemo(() => {
+    const extra = pathname.slice(basePath.length);
+    return extra || subPath || "";
+  }, [pathname, basePath, subPath]);
+
   // Forward parent URL query params and sub-path into the iframe src
   const iframeBaseUrl = useMemo(() => {
     try {
       const resolved = new URL(app.source, window.location.origin);
-      // Append sub-path for deep links (e.g. /MN/mn-hf4621)
-      if (subPath) {
-        resolved.pathname = resolved.pathname.replace(/\/$/, "") + subPath;
+      if (derivedSubPath) {
+        resolved.pathname = resolved.pathname.replace(/\/$/, "") + derivedSubPath;
       }
       resolved.search = searchParams.toString() ? `?${searchParams.toString()}` : "";
       return resolved.toString();
     } catch {
       return app.source;
     }
-  }, [searchParams, app.source, subPath]);
+  }, [searchParams, app.source, derivedSubPath]);
 
   // Listen for messages from iframe and sync to parent URL bar
   useEffect(() => {

--- a/website/src/app/[countryId]/[slug]/AppClient.tsx
+++ b/website/src/app/[countryId]/[slug]/AppClient.tsx
@@ -20,6 +20,7 @@ interface AppClientProps {
     countryId: string;
   };
   countryId: string;
+  subPath?: string;
 }
 
 function trackToolEngaged(params: { toolSlug: string; toolTitle: string }) {
@@ -28,7 +29,7 @@ function trackToolEngaged(params: { toolSlug: string; toolTitle: string }) {
   }
 }
 
-export default function AppClient({ app, countryId }: AppClientProps) {
+export default function AppClient({ app, countryId, subPath }: AppClientProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const pathname = usePathname();
@@ -55,16 +56,20 @@ export default function AppClient({ app, countryId }: AppClientProps) {
     return `/${segments.slice(0, 2).join("/")}`;
   }, [pathname]);
 
-  // Forward parent URL query params into the iframe src
+  // Forward parent URL query params and sub-path into the iframe src
   const iframeBaseUrl = useMemo(() => {
     try {
       const resolved = new URL(app.source, window.location.origin);
+      // Append sub-path for deep links (e.g. /MN/mn-hf4621)
+      if (subPath) {
+        resolved.pathname = resolved.pathname.replace(/\/$/, "") + subPath;
+      }
       resolved.search = searchParams.toString() ? `?${searchParams.toString()}` : "";
       return resolved.toString();
     } catch {
       return app.source;
     }
-  }, [searchParams, app.source]);
+  }, [searchParams, app.source, subPath]);
 
   // Listen for messages from iframe and sync to parent URL bar
   useEffect(() => {

--- a/website/src/app/[countryId]/[slug]/[...rest]/page.tsx
+++ b/website/src/app/[countryId]/[slug]/[...rest]/page.tsx
@@ -1,0 +1,38 @@
+import { Suspense } from "react";
+import appsData from "@/data/apps.json";
+import { notFound } from "next/navigation";
+import AppClient from "../AppClient";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const apps = appsData as any[];
+
+/**
+ * Catch-all route for embedded app deep links.
+ *
+ * When an iframe app (e.g. state-legislative-tracker) uses replaceState to
+ * update the parent URL with sub-paths like /MN/mn-hf4621, this route
+ * catches those paths and passes them into the iframe src so deep links
+ * work when pasted directly.
+ */
+export default async function AppDeepLinkPage({
+  params,
+}: {
+  params: Promise<{ countryId: string; slug: string; rest: string[] }>;
+}) {
+  const { slug, countryId, rest } = await params;
+  const app =
+    apps.find((a) => a.slug === slug && a.countryId === countryId) ||
+    apps.find((a) => a.slug === slug);
+
+  if (!app) {
+    notFound();
+  }
+
+  const subPath = "/" + rest.join("/");
+
+  return (
+    <Suspense>
+      <AppClient app={app} countryId={countryId} subPath={subPath} />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Status: SUPERSEDED by #914

This PR attempted to fix tracker deep links by keeping the iframe and deriving the sub-path client-side. It had reliability issues:
- Double-load when clicking links inside the tracker
- Browser back button requires two presses
- Copy-pasted deep links still load the tracker home page, not the deep link

PR #914 takes a simpler approach — switching from iframe to Vercel rewrite — which fixes deep links natively.

---

## Original approach (for reference)

Added a catch-all route `[countryId]/[slug]/[...rest]/page.tsx` and modified `AppClient` to derive the sub-path from `usePathname()` client-side. The pre-built `[slug]` static page takes priority over the catch-all in Next.js, so the server-side `subPath` prop never reached the client. The client-side derivation partially worked but caused iframe reload cascades due to the postMessage URL sync mechanism.