### PR TITLE
Perf test: Layout + portal for param selector

### DIFF
--- a/app/src/components/FullScreenPortal.tsx
+++ b/app/src/components/FullScreenPortal.tsx
@@ -19,12 +19,12 @@ export default function FullScreenPortal({ children }: FullScreenPortalProps) {
     setContainer(el);
   }, []);
 
-  if (!container) return null;
+  if (!container) {
+    return null;
+  }
 
   return createPortal(
-    <div className="tw:fixed tw:inset-0 tw:z-[100] tw:bg-white">
-      {children}
-    </div>,
-    container,
+    <div className="tw:fixed tw:inset-0 tw:z-[100] tw:bg-white">{children}</div>,
+    container
   );
 }

--- a/app/src/components/FullScreenPortal.tsx
+++ b/app/src/components/FullScreenPortal.tsx
@@ -1,0 +1,30 @@
+/**
+ * FullScreenPortal — renders children into a fixed full-screen overlay
+ * via React portal. The underlying layout (sidebar, header) stays
+ * mounted underneath but is visually covered.
+ */
+
+import { ReactNode, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface FullScreenPortalProps {
+  children: ReactNode;
+}
+
+export default function FullScreenPortal({ children }: FullScreenPortalProps) {
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const el = document.getElementById('fullscreen-portal');
+    setContainer(el);
+  }, []);
+
+  if (!container) return null;
+
+  return createPortal(
+    <div className="tw:fixed tw:inset-0 tw:z-[100] tw:bg-white">
+      {children}
+    </div>,
+    container,
+  );
+}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -10,11 +10,13 @@ import {
   IconScale,
   IconUsers,
 } from '@tabler/icons-react';
+import { useEffect } from 'react';
 import { Button } from '@/components/ui';
 import { WEBSITE_URL } from '@/constants';
 import { useAppLocation } from '@/contexts/LocationContext';
 import { useAppNavigate } from '@/contexts/NavigationContext';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import { perfMount } from '@/utils/perfHarness';
 import { colors, typography } from '../designTokens';
 import SidebarDivider from './sidebar/SidebarDivider';
 import SidebarNavItem from './sidebar/SidebarNavItem';
@@ -28,6 +30,9 @@ export default function Sidebar({ isOpen = true }: SidebarProps) {
   const location = useAppLocation();
   const nav = useAppNavigate();
   const countryId = useCurrentCountry();
+
+  // [PERF HARNESS] Track mount/unmount lifecycle
+  useEffect(() => perfMount('Sidebar'), []);
 
   // All internal navigation paths include the country prefix for consistency with v1 app
   const navItems = [

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import {
   IconBook,
   IconBrandGithub,
@@ -10,7 +11,6 @@ import {
   IconScale,
   IconUsers,
 } from '@tabler/icons-react';
-import { useEffect } from 'react';
 import { Button } from '@/components/ui';
 import { WEBSITE_URL } from '@/constants';
 import { useAppLocation } from '@/contexts/LocationContext';

--- a/app/src/components/StandardLayout.tsx
+++ b/app/src/components/StandardLayout.tsx
@@ -8,11 +8,12 @@
  * children are rendered directly without double-wrapping.
  */
 
-import { useEffect } from 'react';
+import { Profiler, useEffect } from 'react';
 import { LayoutProvider, useIsInsideLayout } from '@/contexts/LayoutContext';
 import { useAppLocation } from '@/contexts/LocationContext';
 import { useDisclosure } from '@/hooks/useDisclosure';
 import { cn } from '@/lib/utils';
+import { perfMount, perfProfilerCallback } from '@/utils/perfHarness';
 import GiveCalcBanner from './shared/GiveCalcBanner';
 import HeaderNavigation from './shared/HomeHeader';
 import Sidebar from './Sidebar';
@@ -25,6 +26,9 @@ export default function StandardLayout({ children }: StandardLayoutProps) {
   const isInsideLayout = useIsInsideLayout();
   const location = useAppLocation();
   const [navbarOpened, { toggle: toggleNavbar, close: closeNavbar }] = useDisclosure();
+
+  // [PERF HARNESS] Track mount/unmount lifecycle
+  useEffect(() => perfMount('StandardLayout'), []);
 
   // Close navbar on route change (mobile UX)
   useEffect(() => {
@@ -39,6 +43,7 @@ export default function StandardLayout({ children }: StandardLayoutProps) {
 
   return (
     <LayoutProvider>
+      <Profiler id="StandardLayout" onRender={perfProfilerCallback}>
       <div className="tw:h-screen tw:overflow-hidden tw:flex tw:flex-col">
         <header className="tw:sticky tw:top-0 tw:z-50 tw:shrink-0">
           <HeaderNavigation navbarOpened={navbarOpened} onToggleNavbar={toggleNavbar} />
@@ -61,6 +66,7 @@ export default function StandardLayout({ children }: StandardLayoutProps) {
           </main>
         </div>
       </div>
+      </Profiler>
     </LayoutProvider>
   );
 }

--- a/app/src/components/StandardLayout.tsx
+++ b/app/src/components/StandardLayout.tsx
@@ -10,6 +10,7 @@
 
 import { Profiler, useEffect } from 'react';
 import { LayoutProvider, useIsInsideLayout } from '@/contexts/LayoutContext';
+import { useLayoutVisibility } from '@/contexts/LayoutVisibilityContext';
 import { useAppLocation } from '@/contexts/LocationContext';
 import { useDisclosure } from '@/hooks/useDisclosure';
 import { cn } from '@/lib/utils';
@@ -24,6 +25,7 @@ interface StandardLayoutProps {
 
 export default function StandardLayout({ children }: StandardLayoutProps) {
   const isInsideLayout = useIsInsideLayout();
+  const { isFullScreen } = useLayoutVisibility();
   const location = useAppLocation();
   const [navbarOpened, { toggle: toggleNavbar, close: closeNavbar }] = useDisclosure();
 
@@ -56,12 +58,16 @@ export default function StandardLayout({ children }: StandardLayoutProps) {
               'tw:w-[300px] tw:shrink-0 tw:border-r tw:border-border-light tw:overflow-y-auto tw:bg-white',
               'tw:hidden tw:sm:block',
               navbarOpened &&
-                'tw:fixed tw:inset-0 tw:z-40 tw:block tw:sm:relative tw:sm:z-auto tw:top-0'
+                'tw:fixed tw:inset-0 tw:z-40 tw:block tw:sm:relative tw:sm:z-auto tw:top-0',
+              isFullScreen && 'tw:!hidden'
             )}
           >
             <Sidebar />
           </nav>
-          <main className="tw:flex-1 tw:min-w-0 tw:max-w-[calc(100vw-300px)] tw:overflow-y-auto tw:overflow-x-hidden tw:p-[24px] tw:bg-gray-50">
+          <main className={cn(
+            'tw:flex-1 tw:min-w-0 tw:overflow-y-auto tw:overflow-x-hidden tw:bg-gray-50',
+            isFullScreen ? 'tw:max-w-full tw:p-0' : 'tw:max-w-[calc(100vw-300px)] tw:p-[24px]'
+          )}>
             {children}
           </main>
         </div>

--- a/app/src/components/StandardLayout.tsx
+++ b/app/src/components/StandardLayout.tsx
@@ -46,32 +46,34 @@ export default function StandardLayout({ children }: StandardLayoutProps) {
   return (
     <LayoutProvider>
       <Profiler id="StandardLayout" onRender={perfProfilerCallback}>
-      <div className="tw:h-screen tw:overflow-hidden tw:flex tw:flex-col">
-        <header className="tw:sticky tw:top-0 tw:z-50 tw:shrink-0">
-          <HeaderNavigation navbarOpened={navbarOpened} onToggleNavbar={toggleNavbar} />
-          <GiveCalcBanner />
-        </header>
+        <div className="tw:h-screen tw:overflow-hidden tw:flex tw:flex-col">
+          <header className="tw:sticky tw:top-0 tw:z-50 tw:shrink-0">
+            <HeaderNavigation navbarOpened={navbarOpened} onToggleNavbar={toggleNavbar} />
+            <GiveCalcBanner />
+          </header>
 
-        <div className="tw:flex tw:flex-1 tw:min-h-0">
-          <nav
-            className={cn(
-              'tw:w-[300px] tw:shrink-0 tw:border-r tw:border-border-light tw:overflow-y-auto tw:bg-white',
-              'tw:hidden tw:sm:block',
-              navbarOpened &&
-                'tw:fixed tw:inset-0 tw:z-40 tw:block tw:sm:relative tw:sm:z-auto tw:top-0',
-              isFullScreen && 'tw:!hidden'
-            )}
-          >
-            <Sidebar />
-          </nav>
-          <main className={cn(
-            'tw:flex-1 tw:min-w-0 tw:overflow-y-auto tw:overflow-x-hidden tw:bg-gray-50',
-            isFullScreen ? 'tw:max-w-full tw:p-0' : 'tw:max-w-[calc(100vw-300px)] tw:p-[24px]'
-          )}>
-            {children}
-          </main>
+          <div className="tw:flex tw:flex-1 tw:min-h-0">
+            <nav
+              className={cn(
+                'tw:w-[300px] tw:shrink-0 tw:border-r tw:border-border-light tw:overflow-y-auto tw:bg-white',
+                'tw:hidden tw:sm:block',
+                navbarOpened &&
+                  'tw:fixed tw:inset-0 tw:z-40 tw:block tw:sm:relative tw:sm:z-auto tw:top-0',
+                isFullScreen && 'tw:!hidden'
+              )}
+            >
+              <Sidebar />
+            </nav>
+            <main
+              className={cn(
+                'tw:flex-1 tw:min-w-0 tw:overflow-y-auto tw:overflow-x-hidden tw:bg-gray-50',
+                isFullScreen ? 'tw:max-w-full tw:p-0' : 'tw:max-w-[calc(100vw-300px)] tw:p-[24px]'
+              )}
+            >
+              {children}
+            </main>
+          </div>
         </div>
-      </div>
       </Profiler>
     </LayoutProvider>
   );

--- a/app/src/contexts/LayoutVisibilityContext.tsx
+++ b/app/src/contexts/LayoutVisibilityContext.tsx
@@ -1,0 +1,37 @@
+/**
+ * LayoutVisibilityContext — lets child components toggle the sidebar
+ * visibility without unmounting StandardLayout.
+ *
+ * When fullScreen is true, StandardLayout hides its sidebar via CSS
+ * and expands <main> to full width.
+ */
+
+import { createContext, ReactNode, useCallback, useContext, useState } from 'react';
+
+interface LayoutVisibilityValue {
+  isFullScreen: boolean;
+  setFullScreen: (value: boolean) => void;
+}
+
+const LayoutVisibilityContext = createContext<LayoutVisibilityValue>({
+  isFullScreen: false,
+  setFullScreen: () => {},
+});
+
+export function LayoutVisibilityProvider({ children }: { children: ReactNode }) {
+  const [isFullScreen, setIsFullScreen] = useState(false);
+
+  const setFullScreen = useCallback((value: boolean) => {
+    setIsFullScreen(value);
+  }, []);
+
+  return (
+    <LayoutVisibilityContext.Provider value={{ isFullScreen, setFullScreen }}>
+      {children}
+    </LayoutVisibilityContext.Provider>
+  );
+}
+
+export function useLayoutVisibility(): LayoutVisibilityValue {
+  return useContext(LayoutVisibilityContext);
+}

--- a/app/src/pathways/policy/PolicyPathwayWrapper.tsx
+++ b/app/src/pathways/policy/PolicyPathwayWrapper.tsx
@@ -5,7 +5,7 @@
  * Reuses shared views from the report pathway with mode="standalone".
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import StandardLayout from '@/components/StandardLayout';
 import { useAppNavigate } from '@/contexts/NavigationContext';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
@@ -14,6 +14,7 @@ import { StandalonePolicyViewMode } from '@/types/pathwayModes/PolicyViewMode';
 import { PolicyStateProps } from '@/types/pathwayState';
 import { createPolicyCallbacks } from '@/utils/pathwayCallbacks';
 import { initializePolicyState } from '@/utils/pathwayState/initializePolicyState';
+import { perfModeChange, perfMount } from '@/utils/perfHarness';
 // Policy views (reusing from report pathway)
 import PolicyLabelView from '../report/views/policy/PolicyLabelView';
 import PolicyParameterSelectorView from '../report/views/policy/PolicyParameterSelectorView';
@@ -30,6 +31,9 @@ export default function PolicyPathwayWrapper({ onComplete }: PolicyPathwayWrappe
   const countryId = useCurrentCountry();
   const nav = useAppNavigate();
 
+  // [PERF HARNESS]
+  useEffect(() => perfMount('PolicyPathwayWrapper'), []);
+
   const handleCancel = useCallback(() => {
     nav.push(`/${countryId}/policies`);
   }, [nav, countryId]);
@@ -43,6 +47,15 @@ export default function PolicyPathwayWrapper({ onComplete }: PolicyPathwayWrappe
   const { currentMode, navigateToMode, goBack, canGoBack } = usePathwayNavigation(
     StandalonePolicyViewMode.LABEL
   );
+
+  // [PERF HARNESS] Track mode changes
+  const prevMode = useRef(currentMode);
+  useEffect(() => {
+    if (prevMode.current !== currentMode) {
+      perfModeChange('PolicyPathway', prevMode.current, currentMode);
+      prevMode.current = currentMode;
+    }
+  }, [currentMode]);
 
   // ========== CALLBACKS ==========
   // Use shared callback factory with onPolicyComplete for standalone navigation

--- a/app/src/pathways/policy/PolicyPathwayWrapper.tsx
+++ b/app/src/pathways/policy/PolicyPathwayWrapper.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import StandardLayout from '@/components/StandardLayout';
+import { useLayoutVisibility } from '@/contexts/LayoutVisibilityContext';
 import { useAppNavigate } from '@/contexts/NavigationContext';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import { usePathwayNavigation } from '@/hooks/usePathwayNavigation';
@@ -56,6 +56,14 @@ export default function PolicyPathwayWrapper({ onComplete }: PolicyPathwayWrappe
       prevMode.current = currentMode;
     }
   }, [currentMode]);
+
+  // Toggle sidebar visibility based on view mode
+  const { setFullScreen } = useLayoutVisibility();
+  useEffect(() => {
+    const shouldHide = MODES_WITH_OWN_LAYOUT.has(currentMode as StandalonePolicyViewMode);
+    setFullScreen(shouldHide);
+    return () => setFullScreen(false);
+  }, [currentMode, setFullScreen]);
 
   // ========== CALLBACKS ==========
   // Use shared callback factory with onPolicyComplete for standalone navigation
@@ -127,11 +135,7 @@ export default function PolicyPathwayWrapper({ onComplete }: PolicyPathwayWrappe
       currentView = <></>;
   }
 
-  // Conditionally wrap with StandardLayout
-  // PolicyParameterSelectorView manages its own AppShell
-  if (MODES_WITH_OWN_LAYOUT.has(currentMode as StandalonePolicyViewMode)) {
-    return currentView;
-  }
-
-  return <StandardLayout>{currentView}</StandardLayout>;
+  // StandardLayout is provided by the parent layout — just render the view.
+  // Sidebar visibility is toggled via LayoutVisibilityContext above.
+  return currentView;
 }

--- a/app/src/pathways/policy/PolicyPathwayWrapper.tsx
+++ b/app/src/pathways/policy/PolicyPathwayWrapper.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useLayoutVisibility } from '@/contexts/LayoutVisibilityContext';
+import FullScreenPortal from '@/components/FullScreenPortal';
 import { useAppNavigate } from '@/contexts/NavigationContext';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import { usePathwayNavigation } from '@/hooks/usePathwayNavigation';
@@ -56,14 +56,6 @@ export default function PolicyPathwayWrapper({ onComplete }: PolicyPathwayWrappe
       prevMode.current = currentMode;
     }
   }, [currentMode]);
-
-  // Toggle sidebar visibility based on view mode
-  const { setFullScreen } = useLayoutVisibility();
-  useEffect(() => {
-    const shouldHide = MODES_WITH_OWN_LAYOUT.has(currentMode as StandalonePolicyViewMode);
-    setFullScreen(shouldHide);
-    return () => setFullScreen(false);
-  }, [currentMode, setFullScreen]);
 
   // ========== CALLBACKS ==========
   // Use shared callback factory with onPolicyComplete for standalone navigation
@@ -135,7 +127,11 @@ export default function PolicyPathwayWrapper({ onComplete }: PolicyPathwayWrappe
       currentView = <></>;
   }
 
-  // StandardLayout is provided by the parent layout — just render the view.
-  // Sidebar visibility is toggled via LayoutVisibilityContext above.
+  // StandardLayout is provided by the parent layout.
+  // Views that manage their own AppShell render inside a portal overlay.
+  if (MODES_WITH_OWN_LAYOUT.has(currentMode as StandalonePolicyViewMode)) {
+    return <FullScreenPortal>{currentView}</FullScreenPortal>;
+  }
+
   return currentView;
 }

--- a/app/src/pathways/population/PopulationPathwayWrapper.tsx
+++ b/app/src/pathways/population/PopulationPathwayWrapper.tsx
@@ -7,7 +7,6 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import StandardLayout from '@/components/StandardLayout';
 import { CURRENT_YEAR } from '@/constants';
 import { useAppNavigate } from '@/contexts/NavigationContext';
 import { ReportYearProvider } from '@/contexts/ReportYearContext';
@@ -145,9 +144,5 @@ export default function PopulationPathwayWrapper({ onComplete }: PopulationPathw
   }
 
   // StandardLayout is provided by the parent layout — just render the view.
-  return (
-    <ReportYearProvider year={CURRENT_YEAR}>
-      {currentView}
-    </ReportYearProvider>
-  );
+  return <ReportYearProvider year={CURRENT_YEAR}>{currentView}</ReportYearProvider>;
 }

--- a/app/src/pathways/population/PopulationPathwayWrapper.tsx
+++ b/app/src/pathways/population/PopulationPathwayWrapper.tsx
@@ -144,9 +144,10 @@ export default function PopulationPathwayWrapper({ onComplete }: PopulationPathw
       currentView = <></>;
   }
 
+  // StandardLayout is provided by the parent layout — just render the view.
   return (
     <ReportYearProvider year={CURRENT_YEAR}>
-      <StandardLayout>{currentView}</StandardLayout>
+      {currentView}
     </ReportYearProvider>
   );
 }

--- a/app/src/pathways/simulation/SimulationPathwayWrapper.tsx
+++ b/app/src/pathways/simulation/SimulationPathwayWrapper.tsx
@@ -5,7 +5,7 @@
  * Reuses all shared views from the report pathway with mode="standalone".
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import StandardLayout from '@/components/StandardLayout';
 import { MOCK_USER_ID } from '@/constants';
@@ -18,6 +18,7 @@ import { useUserPolicies } from '@/hooks/useUserPolicy';
 import { RootState } from '@/store';
 import { SimulationViewMode } from '@/types/pathwayModes/SimulationViewMode';
 import { SimulationStateProps } from '@/types/pathwayState';
+import { perfModeChange, perfMount } from '@/utils/perfHarness';
 import {
   createPolicyCallbacks,
   createPopulationCallbacks,
@@ -53,6 +54,9 @@ export default function SimulationPathwayWrapper({ onComplete }: SimulationPathw
   const countryId = useCurrentCountry();
   const nav = useAppNavigate();
 
+  // [PERF HARNESS]
+  useEffect(() => perfMount('SimulationPathwayWrapper'), []);
+
   const handleCancel = useCallback(() => {
     nav.push(`/${countryId}/simulations`);
   }, [nav, countryId]);
@@ -72,6 +76,15 @@ export default function SimulationPathwayWrapper({ onComplete }: SimulationPathw
   const { currentMode, navigateToMode, goBack, canGoBack } = usePathwayNavigation(
     SimulationViewMode.LABEL
   );
+
+  // [PERF HARNESS] Track mode changes
+  const prevMode = useRef(currentMode);
+  useEffect(() => {
+    if (prevMode.current !== currentMode) {
+      perfModeChange('SimulationPathway', prevMode.current, currentMode);
+      prevMode.current = currentMode;
+    }
+  }, [currentMode]);
 
   // ========== FETCH USER DATA FOR CONDITIONAL NAVIGATION ==========
   const userId = MOCK_USER_ID.toString();

--- a/app/src/pathways/simulation/SimulationPathwayWrapper.tsx
+++ b/app/src/pathways/simulation/SimulationPathwayWrapper.tsx
@@ -18,13 +18,13 @@ import { useUserPolicies } from '@/hooks/useUserPolicy';
 import { RootState } from '@/store';
 import { SimulationViewMode } from '@/types/pathwayModes/SimulationViewMode';
 import { SimulationStateProps } from '@/types/pathwayState';
-import { perfModeChange, perfMount } from '@/utils/perfHarness';
 import {
   createPolicyCallbacks,
   createPopulationCallbacks,
   createSimulationCallbacks,
 } from '@/utils/pathwayCallbacks';
 import { initializeSimulationState } from '@/utils/pathwayState/initializeSimulationState';
+import { perfModeChange, perfMount } from '@/utils/perfHarness';
 import PolicyExistingView from '../report/views/policy/PolicyExistingView';
 // Policy views
 import PolicyLabelView from '../report/views/policy/PolicyLabelView';

--- a/app/src/pathways/simulation/SimulationPathwayWrapper.tsx
+++ b/app/src/pathways/simulation/SimulationPathwayWrapper.tsx
@@ -7,7 +7,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useLayoutVisibility } from '@/contexts/LayoutVisibilityContext';
+import FullScreenPortal from '@/components/FullScreenPortal';
 import { MOCK_USER_ID } from '@/constants';
 import { useAppNavigate } from '@/contexts/NavigationContext';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
@@ -85,14 +85,6 @@ export default function SimulationPathwayWrapper({ onComplete }: SimulationPathw
       prevMode.current = currentMode;
     }
   }, [currentMode]);
-
-  // Toggle sidebar visibility based on view mode
-  const { setFullScreen } = useLayoutVisibility();
-  useEffect(() => {
-    const shouldHide = MODES_WITH_OWN_LAYOUT.has(currentMode as SimulationViewMode);
-    setFullScreen(shouldHide);
-    return () => setFullScreen(false);
-  }, [currentMode, setFullScreen]);
 
   // ========== FETCH USER DATA FOR CONDITIONAL NAVIGATION ==========
   const userId = MOCK_USER_ID.toString();
@@ -383,7 +375,11 @@ export default function SimulationPathwayWrapper({ onComplete }: SimulationPathw
       currentView = <></>;
   }
 
-  // StandardLayout is provided by the parent layout — just render the view.
-  // Sidebar visibility is toggled via LayoutVisibilityContext above.
+  // StandardLayout is provided by the parent layout.
+  // Views that manage their own AppShell render inside a portal overlay.
+  if (MODES_WITH_OWN_LAYOUT.has(currentMode as SimulationViewMode)) {
+    return <FullScreenPortal>{currentView}</FullScreenPortal>;
+  }
+
   return currentView;
 }

--- a/app/src/pathways/simulation/SimulationPathwayWrapper.tsx
+++ b/app/src/pathways/simulation/SimulationPathwayWrapper.tsx
@@ -7,7 +7,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import StandardLayout from '@/components/StandardLayout';
+import { useLayoutVisibility } from '@/contexts/LayoutVisibilityContext';
 import { MOCK_USER_ID } from '@/constants';
 import { useAppNavigate } from '@/contexts/NavigationContext';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
@@ -85,6 +85,14 @@ export default function SimulationPathwayWrapper({ onComplete }: SimulationPathw
       prevMode.current = currentMode;
     }
   }, [currentMode]);
+
+  // Toggle sidebar visibility based on view mode
+  const { setFullScreen } = useLayoutVisibility();
+  useEffect(() => {
+    const shouldHide = MODES_WITH_OWN_LAYOUT.has(currentMode as SimulationViewMode);
+    setFullScreen(shouldHide);
+    return () => setFullScreen(false);
+  }, [currentMode, setFullScreen]);
 
   // ========== FETCH USER DATA FOR CONDITIONAL NAVIGATION ==========
   const userId = MOCK_USER_ID.toString();
@@ -375,11 +383,7 @@ export default function SimulationPathwayWrapper({ onComplete }: SimulationPathw
       currentView = <></>;
   }
 
-  // Conditionally wrap with StandardLayout
-  // Views in MODES_WITH_OWN_LAYOUT manage their own AppShell
-  if (MODES_WITH_OWN_LAYOUT.has(currentMode as SimulationViewMode)) {
-    return currentView;
-  }
-
-  return <StandardLayout>{currentView}</StandardLayout>;
+  // StandardLayout is provided by the parent layout — just render the view.
+  // Sidebar visibility is toggled via LayoutVisibilityContext above.
+  return currentView;
 }

--- a/app/src/utils/perfHarness.ts
+++ b/app/src/utils/perfHarness.ts
@@ -8,7 +8,9 @@
  * Remove this file before merging the winning approach.
  */
 
-const ENABLED = typeof window !== "undefined";
+/* eslint-disable no-console */
+
+const ENABLED = typeof window !== 'undefined';
 
 // Stable reference time for the session
 const sessionStart = ENABLED ? performance.now() : 0;
@@ -27,7 +29,9 @@ function ts(): string {
  *   useEffect(() => perfMount("StandardLayout"), []);
  */
 export function perfMount(name: string): () => void {
-  if (!ENABLED) return () => {};
+  if (!ENABLED) {
+    return () => {};
+  }
 
   const mountTime = performance.now();
   performance.mark(`${name}-mount`);
@@ -45,7 +49,7 @@ export function perfMount(name: string): () => void {
   };
 }
 
-// ── Navigation timing ───────────────────────────────────────────
+// ── Navigation timing ─────���─────────────────────────────────────
 
 let lastPathname: string | null = null;
 let navStartTime: number | null = null;
@@ -59,16 +63,16 @@ let navStartTime: number | null = null;
  *   useEffect(() => { perfNavChange(pathname); }, [pathname]);
  */
 export function perfNavChange(pathname: string): void {
-  if (!ENABLED) return;
+  if (!ENABLED) {
+    return;
+  }
 
   const now = performance.now();
 
   if (lastPathname !== null && lastPathname !== pathname) {
-    performance.mark("nav-start");
+    performance.mark('nav-start');
     navStartTime = now;
-    console.log(
-      `[PERF] ${ts()} NAV     ${lastPathname} → ${pathname}`,
-    );
+    console.log(`[PERF] ${ts()} NAV     ${lastPathname} → ${pathname}`);
   }
 
   lastPathname = pathname;
@@ -79,18 +83,18 @@ export function perfNavChange(pathname: string): void {
  * component's useEffect). Measures nav-start → content-visible.
  */
 export function perfContentVisible(pageName: string): void {
-  if (!ENABLED || navStartTime === null) return;
+  if (!ENABLED || navStartTime === null) {
+    return;
+  }
 
   const elapsed = performance.now() - navStartTime;
-  performance.mark("content-visible");
+  performance.mark('content-visible');
   try {
-    performance.measure("nav→content", "nav-start", "content-visible");
+    performance.measure('nav→content', 'nav-start', 'content-visible');
   } catch {
     // marks may have been cleared
   }
-  console.log(
-    `[PERF] ${ts()} VISIBLE ${pageName} (${elapsed.toFixed(1)}ms after nav)`,
-  );
+  console.log(`[PERF] ${ts()} VISIBLE ${pageName} (${elapsed.toFixed(1)}ms after nav)`);
   navStartTime = null;
 }
 
@@ -104,26 +108,30 @@ export function perfContentVisible(pageName: string): void {
  */
 export function perfProfilerCallback(
   id: string,
-  phase: "mount" | "update" | "nested-update",
+  phase: 'mount' | 'update' | 'nested-update',
   actualDuration: number,
   baseDuration: number,
-  startTime: number,
-  commitTime: number,
+  _startTime: number,
+  _commitTime: number
 ): void {
-  if (!ENABLED) return;
+  if (!ENABLED) {
+    return;
+  }
 
   console.log(
-    `[PERF] ${ts()} RENDER  ${id} phase=${phase} actual=${actualDuration.toFixed(1)}ms base=${baseDuration.toFixed(1)}ms`,
+    `[PERF] ${ts()} RENDER  ${id} phase=${phase} actual=${actualDuration.toFixed(1)}ms base=${baseDuration.toFixed(1)}ms`
   );
 }
 
-// ── Pathway mode change ─────────────────────────────────────────
+// ─��� Pathway mode change ───���────────────────────────��────────────
 
 /**
  * Log pathway view mode transitions (e.g. LABEL → PARAMETER_SELECTOR).
  */
 export function perfModeChange(wrapper: string, from: string, to: string): void {
-  if (!ENABLED) return;
+  if (!ENABLED) {
+    return;
+  }
 
   performance.mark(`${wrapper}-mode-${to}`);
   console.log(`[PERF] ${ts()} MODE    ${wrapper}: ${from} → ${to}`);

--- a/app/src/utils/perfHarness.ts
+++ b/app/src/utils/perfHarness.ts
@@ -1,0 +1,130 @@
+/**
+ * Performance instrumentation harness for navigation testing.
+ *
+ * Logs component lifecycle, navigation timing, and render metrics
+ * to the browser console. All output is prefixed with [PERF] for
+ * easy filtering in DevTools.
+ *
+ * Remove this file before merging the winning approach.
+ */
+
+const ENABLED = typeof window !== "undefined";
+
+// Stable reference time for the session
+const sessionStart = ENABLED ? performance.now() : 0;
+
+function ts(): string {
+  return `+${(performance.now() - sessionStart).toFixed(1)}ms`;
+}
+
+// ── Component lifecycle ─────────────────────────────────────────
+
+/**
+ * Call inside useEffect(() => { ... return cleanup }, []) to log
+ * mount and unmount of a component with timing.
+ *
+ * Usage:
+ *   useEffect(() => perfMount("StandardLayout"), []);
+ */
+export function perfMount(name: string): () => void {
+  if (!ENABLED) return () => {};
+
+  const mountTime = performance.now();
+  performance.mark(`${name}-mount`);
+  console.log(`[PERF] ${ts()} MOUNT   ${name}`);
+
+  return () => {
+    const lifetime = performance.now() - mountTime;
+    performance.mark(`${name}-unmount`);
+    try {
+      performance.measure(`${name}-lifetime`, `${name}-mount`, `${name}-unmount`);
+    } catch {
+      // marks may have been cleared
+    }
+    console.log(`[PERF] ${ts()} UNMOUNT ${name} (alive ${lifetime.toFixed(1)}ms)`);
+  };
+}
+
+// ── Navigation timing ───────────────────────────────────────────
+
+let lastPathname: string | null = null;
+let navStartTime: number | null = null;
+
+/**
+ * Call on every pathname change to track navigation duration.
+ * Logs the time between consecutive pathname changes and the
+ * gap between nav-start and next StandardLayout mount.
+ *
+ * Usage (in layout.tsx):
+ *   useEffect(() => { perfNavChange(pathname); }, [pathname]);
+ */
+export function perfNavChange(pathname: string): void {
+  if (!ENABLED) return;
+
+  const now = performance.now();
+
+  if (lastPathname !== null && lastPathname !== pathname) {
+    performance.mark("nav-start");
+    navStartTime = now;
+    console.log(
+      `[PERF] ${ts()} NAV     ${lastPathname} → ${pathname}`,
+    );
+  }
+
+  lastPathname = pathname;
+}
+
+/**
+ * Call when the destination content is visible (e.g. in the page
+ * component's useEffect). Measures nav-start → content-visible.
+ */
+export function perfContentVisible(pageName: string): void {
+  if (!ENABLED || navStartTime === null) return;
+
+  const elapsed = performance.now() - navStartTime;
+  performance.mark("content-visible");
+  try {
+    performance.measure("nav→content", "nav-start", "content-visible");
+  } catch {
+    // marks may have been cleared
+  }
+  console.log(
+    `[PERF] ${ts()} VISIBLE ${pageName} (${elapsed.toFixed(1)}ms after nav)`,
+  );
+  navStartTime = null;
+}
+
+// ── React Profiler callback ─────────────────────────────────────
+
+/**
+ * Pass as the onRender prop of <React.Profiler>.
+ *
+ * Usage:
+ *   <Profiler id="StandardLayout" onRender={perfProfilerCallback}>
+ */
+export function perfProfilerCallback(
+  id: string,
+  phase: "mount" | "update" | "nested-update",
+  actualDuration: number,
+  baseDuration: number,
+  startTime: number,
+  commitTime: number,
+): void {
+  if (!ENABLED) return;
+
+  console.log(
+    `[PERF] ${ts()} RENDER  ${id} phase=${phase} actual=${actualDuration.toFixed(1)}ms base=${baseDuration.toFixed(1)}ms`,
+  );
+}
+
+// ── Pathway mode change ─────────────────────────────────────────
+
+/**
+ * Log pathway view mode transitions (e.g. LABEL → PARAMETER_SELECTOR).
+ */
+export function perfModeChange(wrapper: string, from: string, to: string): void {
+  if (!ENABLED) return;
+
+  performance.mark(`${wrapper}-mode-${to}`);
+  console.log(`[PERF] ${ts()} MODE    ${wrapper}: ${from} → ${to}`);
+}

--- a/calculator-app/src/app/[countryId]/households/create/page.tsx
+++ b/calculator-app/src/app/[countryId]/households/create/page.tsx
@@ -3,15 +3,8 @@
 import { useEffect } from "react";
 import PopulationPathwayWrapper from "@/pathways/population/PopulationPathwayWrapper";
 import { perfContentVisible } from "@/utils/perfHarness";
-import { CalculatorProviders } from "../../providers";
 
 export default function HouseholdCreateRoute() {
-  // [PERF HARNESS]
   useEffect(() => { perfContentVisible('HouseholdCreateRoute'); }, []);
-
-  return (
-    <CalculatorProviders>
-      <PopulationPathwayWrapper />
-    </CalculatorProviders>
-  );
+  return <PopulationPathwayWrapper />;
 }

--- a/calculator-app/src/app/[countryId]/households/create/page.tsx
+++ b/calculator-app/src/app/[countryId]/households/create/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { useEffect } from "react";
 import PopulationPathwayWrapper from "@/pathways/population/PopulationPathwayWrapper";
+import { perfContentVisible } from "@/utils/perfHarness";
 import { CalculatorProviders } from "../../providers";
 
 export default function HouseholdCreateRoute() {
+  // [PERF HARNESS]
+  useEffect(() => { perfContentVisible('HouseholdCreateRoute'); }, []);
+
   return (
     <CalculatorProviders>
       <PopulationPathwayWrapper />

--- a/calculator-app/src/app/[countryId]/households/page.tsx
+++ b/calculator-app/src/app/[countryId]/households/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { useEffect } from "react";
 import StandardLayout from "@/components/StandardLayout";
 import PopulationsPage from "@/pages/Populations.page";
+import { perfContentVisible } from "@/utils/perfHarness";
 import { CalculatorProviders } from "../providers";
 
 export default function HouseholdsRoute() {
+  // [PERF HARNESS]
+  useEffect(() => { perfContentVisible('HouseholdsRoute'); }, []);
+
   return (
     <CalculatorProviders>
       <StandardLayout>

--- a/calculator-app/src/app/[countryId]/households/page.tsx
+++ b/calculator-app/src/app/[countryId]/households/page.tsx
@@ -1,20 +1,10 @@
 "use client";
 
 import { useEffect } from "react";
-import StandardLayout from "@/components/StandardLayout";
 import PopulationsPage from "@/pages/Populations.page";
 import { perfContentVisible } from "@/utils/perfHarness";
-import { CalculatorProviders } from "../providers";
 
 export default function HouseholdsRoute() {
-  // [PERF HARNESS]
   useEffect(() => { perfContentVisible('HouseholdsRoute'); }, []);
-
-  return (
-    <CalculatorProviders>
-      <StandardLayout>
-        <PopulationsPage />
-      </StandardLayout>
-    </CalculatorProviders>
-  );
+  return <PopulationsPage />;
 }

--- a/calculator-app/src/app/[countryId]/layout.tsx
+++ b/calculator-app/src/app/[countryId]/layout.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+// Force Vercel rebuild for calculator-next
 import { use, useEffect, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import StandardLayout from "@/components/StandardLayout";

--- a/calculator-app/src/app/[countryId]/layout.tsx
+++ b/calculator-app/src/app/[countryId]/layout.tsx
@@ -6,6 +6,7 @@ import { CountryProvider } from "@/contexts/CountryContext";
 import { LocationProvider } from "@/contexts/LocationContext";
 import { NavigationProvider } from "@/contexts/NavigationContext";
 import { countryIds, type CountryId } from "@/libs/countries";
+import { perfNavChange } from "@/utils/perfHarness";
 
 /**
  * Layout for extracted Next.js pages under /:countryId/*.
@@ -41,6 +42,11 @@ export default function CountryLayout({
     }),
     [pathname, searchParams],
   );
+
+  // [PERF HARNESS] Track navigation timing
+  useEffect(() => {
+    perfNavChange(pathname);
+  }, [pathname]);
 
   useEffect(() => {
     if (!isValid) {

--- a/calculator-app/src/app/[countryId]/layout.tsx
+++ b/calculator-app/src/app/[countryId]/layout.tsx
@@ -2,16 +2,21 @@
 
 import { use, useEffect, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import StandardLayout from "@/components/StandardLayout";
 import { CountryProvider } from "@/contexts/CountryContext";
 import { LocationProvider } from "@/contexts/LocationContext";
 import { NavigationProvider } from "@/contexts/NavigationContext";
 import { countryIds, type CountryId } from "@/libs/countries";
 import { perfNavChange } from "@/utils/perfHarness";
+import { CalculatorProviders } from "./providers";
 
 /**
  * Layout for extracted Next.js pages under /:countryId/*.
- * Provides CountryContext, NavigationContext, and LocationContext
- * so shared components work identically in both router contexts.
+ * Provides CountryContext, NavigationContext, LocationContext,
+ * CalculatorProviders, and StandardLayout so they persist
+ * across page navigations without re-mounting.
+ *
+ * Approach 4: Portal target for full-screen takeover views.
  */
 export default function CountryLayout({
   children,
@@ -62,7 +67,10 @@ export default function CountryLayout({
     <CountryProvider value={countryId as CountryId}>
       <NavigationProvider value={navValue}>
         <LocationProvider value={locationValue}>
-          {children}
+          <CalculatorProviders>
+            <StandardLayout>{children}</StandardLayout>
+            <div id="fullscreen-portal" />
+          </CalculatorProviders>
         </LocationProvider>
       </NavigationProvider>
     </CountryProvider>

--- a/calculator-app/src/app/[countryId]/policies/create/page.tsx
+++ b/calculator-app/src/app/[countryId]/policies/create/page.tsx
@@ -3,15 +3,8 @@
 import { useEffect } from "react";
 import PolicyPathwayWrapper from "@/pathways/policy/PolicyPathwayWrapper";
 import { perfContentVisible } from "@/utils/perfHarness";
-import { CalculatorProviders } from "../../providers";
 
 export default function PolicyCreateRoute() {
-  // [PERF HARNESS]
   useEffect(() => { perfContentVisible('PolicyCreateRoute'); }, []);
-
-  return (
-    <CalculatorProviders>
-      <PolicyPathwayWrapper />
-    </CalculatorProviders>
-  );
+  return <PolicyPathwayWrapper />;
 }

--- a/calculator-app/src/app/[countryId]/policies/create/page.tsx
+++ b/calculator-app/src/app/[countryId]/policies/create/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { useEffect } from "react";
 import PolicyPathwayWrapper from "@/pathways/policy/PolicyPathwayWrapper";
+import { perfContentVisible } from "@/utils/perfHarness";
 import { CalculatorProviders } from "../../providers";
 
 export default function PolicyCreateRoute() {
+  // [PERF HARNESS]
+  useEffect(() => { perfContentVisible('PolicyCreateRoute'); }, []);
+
   return (
     <CalculatorProviders>
       <PolicyPathwayWrapper />

--- a/calculator-app/src/app/[countryId]/policies/page.tsx
+++ b/calculator-app/src/app/[countryId]/policies/page.tsx
@@ -1,20 +1,10 @@
 "use client";
 
 import { useEffect } from "react";
-import StandardLayout from "@/components/StandardLayout";
 import PoliciesPage from "@/pages/Policies.page";
 import { perfContentVisible } from "@/utils/perfHarness";
-import { CalculatorProviders } from "../providers";
 
 export default function PoliciesRoute() {
-  // [PERF HARNESS]
   useEffect(() => { perfContentVisible('PoliciesRoute'); }, []);
-
-  return (
-    <CalculatorProviders>
-      <StandardLayout>
-        <PoliciesPage />
-      </StandardLayout>
-    </CalculatorProviders>
-  );
+  return <PoliciesPage />;
 }

--- a/calculator-app/src/app/[countryId]/policies/page.tsx
+++ b/calculator-app/src/app/[countryId]/policies/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { useEffect } from "react";
 import StandardLayout from "@/components/StandardLayout";
 import PoliciesPage from "@/pages/Policies.page";
+import { perfContentVisible } from "@/utils/perfHarness";
 import { CalculatorProviders } from "../providers";
 
 export default function PoliciesRoute() {
+  // [PERF HARNESS]
+  useEffect(() => { perfContentVisible('PoliciesRoute'); }, []);
+
   return (
     <CalculatorProviders>
       <StandardLayout>

--- a/calculator-app/src/app/[countryId]/providers.tsx
+++ b/calculator-app/src/app/[countryId]/providers.tsx
@@ -12,6 +12,7 @@ import { useFetchMetadata } from "@/hooks/useMetadata";
 import { setCurrentCountry } from "@/reducers/metadataReducer";
 import { AppDispatch, store } from "@/store";
 import { cacheMonitor } from "@/utils/cacheMonitor";
+import { perfMount } from "@/utils/perfHarness";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -33,6 +34,9 @@ export function CalculatorProviders({
 }: {
   children: React.ReactNode;
 }) {
+  // [PERF HARNESS] Track mount/unmount lifecycle
+  useEffect(() => perfMount('CalculatorProviders'), []);
+
   return (
     <AppProvider mode="calculator">
       <Provider store={store}>

--- a/calculator-app/src/app/[countryId]/report-output/[reportId]/[[...rest]]/page.tsx
+++ b/calculator-app/src/app/[countryId]/report-output/[reportId]/[[...rest]]/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { use } from "react";
-import StandardLayout from "@/components/StandardLayout";
+import { use, useEffect } from "react";
 import ReportOutputPage from "@/pages/ReportOutput.page";
-import { CalculatorProviders } from "../../../providers";
+import { perfContentVisible } from "@/utils/perfHarness";
 
 export default function ReportOutputRoute({
   params,
@@ -14,11 +13,6 @@ export default function ReportOutputRoute({
   const subpage = rest?.[0];
   const view = rest?.[1];
 
-  return (
-    <CalculatorProviders>
-      <StandardLayout>
-        <ReportOutputPage reportId={reportId} subpage={subpage} view={view} />
-      </StandardLayout>
-    </CalculatorProviders>
-  );
+  useEffect(() => { perfContentVisible('ReportOutputRoute'); }, []);
+  return <ReportOutputPage reportId={reportId} subpage={subpage} view={view} />;
 }

--- a/calculator-app/src/app/[countryId]/reports/create/[userReportId]/page.tsx
+++ b/calculator-app/src/app/[countryId]/reports/create/[userReportId]/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { use } from "react";
-import StandardLayout from "@/components/StandardLayout";
+import { use, useEffect } from "react";
 import ModifyReportPage from "@/pages/reportBuilder/ModifyReportPage";
-import { CalculatorProviders } from "../../../providers";
+import { perfContentVisible } from "@/utils/perfHarness";
 
 export default function ModifyReportRoute({
   params,
@@ -12,11 +11,6 @@ export default function ModifyReportRoute({
 }) {
   const { userReportId } = use(params);
 
-  return (
-    <CalculatorProviders>
-      <StandardLayout>
-        <ModifyReportPage userReportId={userReportId} />
-      </StandardLayout>
-    </CalculatorProviders>
-  );
+  useEffect(() => { perfContentVisible('ModifyReportRoute'); }, []);
+  return <ModifyReportPage userReportId={userReportId} />;
 }

--- a/calculator-app/src/app/[countryId]/reports/create/page.tsx
+++ b/calculator-app/src/app/[countryId]/reports/create/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { useEffect } from "react";
 import StandardLayout from "@/components/StandardLayout";
 import ReportBuilderPage from "@/pages/reportBuilder/ReportBuilderPage";
+import { perfContentVisible } from "@/utils/perfHarness";
 import { CalculatorProviders } from "../../providers";
 
 export default function ReportBuilderRoute() {
+  // [PERF HARNESS]
+  useEffect(() => { perfContentVisible('ReportBuilderRoute'); }, []);
+
   return (
     <CalculatorProviders>
       <StandardLayout>

--- a/calculator-app/src/app/[countryId]/reports/create/page.tsx
+++ b/calculator-app/src/app/[countryId]/reports/create/page.tsx
@@ -1,20 +1,10 @@
 "use client";
 
 import { useEffect } from "react";
-import StandardLayout from "@/components/StandardLayout";
 import ReportBuilderPage from "@/pages/reportBuilder/ReportBuilderPage";
 import { perfContentVisible } from "@/utils/perfHarness";
-import { CalculatorProviders } from "../../providers";
 
 export default function ReportBuilderRoute() {
-  // [PERF HARNESS]
   useEffect(() => { perfContentVisible('ReportBuilderRoute'); }, []);
-
-  return (
-    <CalculatorProviders>
-      <StandardLayout>
-        <ReportBuilderPage />
-      </StandardLayout>
-    </CalculatorProviders>
-  );
+  return <ReportBuilderPage />;
 }

--- a/calculator-app/src/app/[countryId]/reports/page.tsx
+++ b/calculator-app/src/app/[countryId]/reports/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { useEffect } from "react";
 import StandardLayout from "@/components/StandardLayout";
 import ReportsPage from "@/pages/Reports.page";
+import { perfContentVisible } from "@/utils/perfHarness";
 import { CalculatorProviders } from "../providers";
 
 export default function ReportsRoute() {
+  // [PERF HARNESS]
+  useEffect(() => { perfContentVisible('ReportsRoute'); }, []);
+
   return (
     <CalculatorProviders>
       <StandardLayout>

--- a/calculator-app/src/app/[countryId]/reports/page.tsx
+++ b/calculator-app/src/app/[countryId]/reports/page.tsx
@@ -1,20 +1,10 @@
 "use client";
 
 import { useEffect } from "react";
-import StandardLayout from "@/components/StandardLayout";
 import ReportsPage from "@/pages/Reports.page";
 import { perfContentVisible } from "@/utils/perfHarness";
-import { CalculatorProviders } from "../providers";
 
 export default function ReportsRoute() {
-  // [PERF HARNESS]
   useEffect(() => { perfContentVisible('ReportsRoute'); }, []);
-
-  return (
-    <CalculatorProviders>
-      <StandardLayout>
-        <ReportsPage />
-      </StandardLayout>
-    </CalculatorProviders>
-  );
+  return <ReportsPage />;
 }

--- a/calculator-app/src/app/[countryId]/simulations/create/page.tsx
+++ b/calculator-app/src/app/[countryId]/simulations/create/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { useEffect } from "react";
 import SimulationPathwayWrapper from "@/pathways/simulation/SimulationPathwayWrapper";
+import { perfContentVisible } from "@/utils/perfHarness";
 import { CalculatorProviders } from "../../providers";
 
 export default function SimulationCreateRoute() {
+  // [PERF HARNESS]
+  useEffect(() => { perfContentVisible('SimulationCreateRoute'); }, []);
+
   return (
     <CalculatorProviders>
       <SimulationPathwayWrapper />

--- a/calculator-app/src/app/[countryId]/simulations/create/page.tsx
+++ b/calculator-app/src/app/[countryId]/simulations/create/page.tsx
@@ -3,15 +3,8 @@
 import { useEffect } from "react";
 import SimulationPathwayWrapper from "@/pathways/simulation/SimulationPathwayWrapper";
 import { perfContentVisible } from "@/utils/perfHarness";
-import { CalculatorProviders } from "../../providers";
 
 export default function SimulationCreateRoute() {
-  // [PERF HARNESS]
   useEffect(() => { perfContentVisible('SimulationCreateRoute'); }, []);
-
-  return (
-    <CalculatorProviders>
-      <SimulationPathwayWrapper />
-    </CalculatorProviders>
-  );
+  return <SimulationPathwayWrapper />;
 }

--- a/calculator-app/src/app/[countryId]/simulations/page.tsx
+++ b/calculator-app/src/app/[countryId]/simulations/page.tsx
@@ -1,20 +1,10 @@
 "use client";
 
 import { useEffect } from "react";
-import StandardLayout from "@/components/StandardLayout";
 import SimulationsPage from "@/pages/Simulations.page";
 import { perfContentVisible } from "@/utils/perfHarness";
-import { CalculatorProviders } from "../providers";
 
 export default function SimulationsRoute() {
-  // [PERF HARNESS]
   useEffect(() => { perfContentVisible('SimulationsRoute'); }, []);
-
-  return (
-    <CalculatorProviders>
-      <StandardLayout>
-        <SimulationsPage />
-      </StandardLayout>
-    </CalculatorProviders>
-  );
+  return <SimulationsPage />;
 }

--- a/calculator-app/src/app/[countryId]/simulations/page.tsx
+++ b/calculator-app/src/app/[countryId]/simulations/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { useEffect } from "react";
 import StandardLayout from "@/components/StandardLayout";
 import SimulationsPage from "@/pages/Simulations.page";
+import { perfContentVisible } from "@/utils/perfHarness";
 import { CalculatorProviders } from "../providers";
 
 export default function SimulationsRoute() {
+  // [PERF HARNESS]
+  useEffect(() => { perfContentVisible('SimulationsRoute'); }, []);
+
   return (
     <CalculatorProviders>
       <StandardLayout>


### PR DESCRIPTION
## Context

PR #887 moved StandardLayout into the shared layout to fix white flash on navigation, but broke the parameter editor (double header/sidebar). It was reverted via #913.

We then built a perf instrumentation harness and tested 4 approaches on Vercel preview deploys:

| PR | Approach | Result |
|---|---|---|
| #915 | Layout + CSS visibility toggle | Good — sidebar never unmounts, but occasional ~900ms cached navs |
| #916 | Route groups + CSS toggle | **Eliminated** — layout remounts on group crossing (688-2232ms) |
| #917 | Layout + portal overlay | **Winner** — sidebar never unmounts, sub-10ms cached navs, no double header |
| #918 | Current structure + prefetching | **Eliminated** — every nav still unmounts/remounts sidebar (820-1400ms) |

## What this PR does

- Moves `StandardLayout` + `CalculatorProviders` into `[countryId]/layout.tsx` so they persist across all navigations (never unmount)
- Adds `FullScreenPortal` component — the parameter selector renders as a fixed full-screen overlay via React portal, covering the sidebar/header naturally
- Pathway wrappers no longer conditionally wrap/unwrap StandardLayout — full-screen views use `<FullScreenPortal>` instead
- Strips `CalculatorProviders` and `StandardLayout` from all individual page files (they're in the layout now)

**Note**: This branch still includes the perf instrumentation harness (`perfHarness.ts`, `[PERF]` console logs). These will be removed when we rebase onto main for the final clean PR.

## Key perf numbers (production Vercel preview)

- **Listing↔listing (cached)**: 3-6ms (vs 820-1400ms before)
- **Listing→create (first load)**: 874-1488ms (chunk download)
- **Param selector enter/exit**: instant mode change, no mount/unmount
- **Sidebar/StandardLayout/CalculatorProviders**: mount once at page load, never unmount

## Test plan

- [ ] Navigate between listing pages (reports, simulations, policies, households) — no white flash
- [ ] Navigate listing → create pathway — sidebar stays, content swaps
- [ ] Go to policies/create, advance to parameter selector — full-screen overlay, no double header
- [ ] Go back from parameter selector — sidebar reappears instantly
- [ ] Same flow for simulations/create → parameter selector
- [ ] Check console `[PERF]` logs — no UNMOUNT entries for StandardLayout/Sidebar