### PR TITLE
Skip version fragment workflow reruns

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   chromatic:
     name: Visual regression tests
+    if: ${{ github.event_name != 'push' || github.event.head_commit.message != 'Update changelog_entry.yaml' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-design-system.yaml
+++ b/.github/workflows/publish-design-system.yaml
@@ -26,6 +26,7 @@ on:
 
 jobs:
   publish:
+    if: ${{ github.event_name != 'push' || github.event.head_commit.message != 'Update changelog_entry.yaml' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -2,12 +2,13 @@ name: Push checks
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
   lint:
     name: Lint and format
+    if: ${{ github.event_name != 'push' || github.event.head_commit.message != 'Update changelog_entry.yaml' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -33,6 +34,7 @@ jobs:
 
   typecheck:
     name: Type checking
+    if: ${{ github.event_name != 'push' || github.event.head_commit.message != 'Update changelog_entry.yaml' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -54,6 +56,7 @@ jobs:
 
   test:
     name: Tests
+    if: ${{ github.event_name != 'push' || github.event.head_commit.message != 'Update changelog_entry.yaml' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -78,6 +81,7 @@ jobs:
 
   check-embeds:
     name: Check embedded site URLs
+    if: ${{ github.event_name != 'push' || github.event.head_commit.message != 'Update changelog_entry.yaml' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -106,6 +110,7 @@ jobs:
 
   build:
     name: Build
+    if: ${{ github.event_name != 'push' || github.event.head_commit.message != 'Update changelog_entry.yaml' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes #927

## Summary

- Skip push-triggered workflow jobs for the exact `Update changelog_entry.yaml` version-fragment commit.
- Switch Push checks from `master` to `main`.
- Leave PR and manual workflow_dispatch runs unaffected.

## Verification

- `git diff --check`
- YAML parsed successfully with Ruby YAML loader
- `actionlint` unavailable locally