### PR TITLE
Refresh stale congressional district outcome payloads

### DIFF
--- a/app/src/pages/report-output/SocietyWideOverview.tsx
+++ b/app/src/pages/report-output/SocietyWideOverview.tsx
@@ -174,6 +174,12 @@ type DistrictOutcomePayload = {
   winner_percentage?: number;
   loser_percentage?: number;
 };
+type DistrictPayloadAvailability = {
+  expectedDistrictIds: string[];
+  hasCompleteCoverage: boolean;
+  hasCompleteWinnerData: boolean;
+  hasCompleteLoserData: boolean;
+};
 
 export function buildOutcomeMapData(
   districts: DistrictOutcomePayload[],
@@ -202,15 +208,69 @@ export function buildOutcomeMapData(
   return { points, missingCount };
 }
 
-export function hasCompleteDistrictOutcomePayload(districts: DistrictOutcomePayload[]): boolean {
-  return (
-    districts.length > 0 &&
-    districts.every(
-      (district) =>
-        typeof district.winner_percentage === 'number' &&
-        typeof district.loser_percentage === 'number'
-    )
+function getExpectedDistrictIds(
+  labelLookup: Map<string, string>,
+  stateCode: string | null
+): string[] {
+  const districtIds = Array.from(labelLookup.keys());
+  if (!stateCode) {
+    return districtIds;
+  }
+
+  const statePrefix = `${stateCode.toUpperCase()}-`;
+  return districtIds.filter((districtId) => districtId.startsWith(statePrefix));
+}
+
+export function getDistrictPayloadAvailability(
+  districts: DistrictOutcomePayload[],
+  labelLookup: Map<string, string>,
+  stateCode: string | null
+): DistrictPayloadAvailability {
+  const districtsById = new Map(
+    districts.map((district) => [normalizeDistrictId(district.district), district] as const)
   );
+  const expectedDistrictIds = getExpectedDistrictIds(labelLookup, stateCode);
+  const relevantDistrictIds =
+    expectedDistrictIds.length > 0 ? expectedDistrictIds : Array.from(districtsById.keys());
+
+  if (relevantDistrictIds.length === 0) {
+    return {
+      expectedDistrictIds,
+      hasCompleteCoverage: false,
+      hasCompleteWinnerData: false,
+      hasCompleteLoserData: false,
+    };
+  }
+
+  const hasCompleteCoverage = relevantDistrictIds.every((districtId) =>
+    districtsById.has(districtId)
+  );
+  const hasCompleteWinnerData =
+    hasCompleteCoverage &&
+    relevantDistrictIds.every(
+      (districtId) => typeof districtsById.get(districtId)?.winner_percentage === 'number'
+    );
+  const hasCompleteLoserData =
+    hasCompleteCoverage &&
+    relevantDistrictIds.every(
+      (districtId) => typeof districtsById.get(districtId)?.loser_percentage === 'number'
+    );
+
+  return {
+    expectedDistrictIds,
+    hasCompleteCoverage,
+    hasCompleteWinnerData,
+    hasCompleteLoserData,
+  };
+}
+
+export function hasCompleteDistrictOutcomePayload(
+  districts: DistrictOutcomePayload[],
+  labelLookup: Map<string, string>,
+  stateCode: string | null
+): boolean {
+  const availability = getDistrictPayloadAvailability(districts, labelLookup, stateCode);
+  return availability.hasCompleteWinnerData && availability.hasCompleteLoserData;
 }
 
 /**
@@ -423,18 +483,29 @@ function CongressionalDistrictCard({
     }));
   }, [output]);
 
-  const hasSavedOutcomeData = useMemo(
-    () => (savedDistricts ? hasCompleteDistrictOutcomePayload(savedDistricts) : false),
-    [savedDistricts]
+  const savedDistrictAvailability = useMemo(
+    () =>
+      savedDistricts
+        ? getDistrictPayloadAvailability(savedDistricts, labelLookup, stateCode)
+        : null,
+    [labelLookup, savedDistricts, stateCode]
   );
+  const hasSavedChangeData = savedDistrictAvailability?.hasCompleteCoverage ?? false;
+  const hasSavedWinnerData = savedDistrictAvailability?.hasCompleteWinnerData ?? false;
+  const hasSavedLoserData = savedDistrictAvailability?.hasCompleteLoserData ?? false;
+  const hasSavedOutcomeData = hasSavedWinnerData && hasSavedLoserData;
+  const hasSavedActiveOutcomeData =
+    outcomeMetric === 'winner' ? hasSavedWinnerData : hasSavedLoserData;
+  const needsSavedPayloadRefresh = !savedDistricts || !hasSavedChangeData || !hasSavedOutcomeData;
 
-  // Auto-start fetch only when the report output is ready and no
-  // complete district outcome data exists in the saved report output.
+  // Auto-start fetch when the saved payload is missing districts or missing
+  // either outcome metric, but still let the active mode use any complete
+  // metric-specific saved data that is already available.
   useEffect(() => {
-    if ((!savedDistricts || !hasSavedOutcomeData) && !hasStarted) {
+    if (needsSavedPayloadRefresh && !hasStarted) {
       startFetch();
     }
-  }, [hasSavedOutcomeData, hasStarted, savedDistricts, startFetch]);
+  }, [hasStarted, needsSavedPayloadRefresh, startFetch]);
 
   // Build map data from context (progressive fill as states complete)
   const changeContextMapData = useMemo(() => {
@@ -459,7 +530,7 @@ function CongressionalDistrictCard({
 
   // Use pre-computed data if available, otherwise progressive context data
   const changeMapData = useMemo(() => {
-    if (savedDistricts) {
+    if (savedDistricts && hasSavedChangeData) {
       return savedDistricts.map((item) => ({
         geoId: item.district,
         label: labelLookup.get(item.district) ?? `District ${item.district}`,
@@ -470,10 +541,10 @@ function CongressionalDistrictCard({
       }));
     }
     return changeContextMapData;
-  }, [changeContextMapData, changeMetric, labelLookup, savedDistricts]);
+  }, [changeContextMapData, changeMetric, hasSavedChangeData, labelLookup, savedDistricts]);
 
   const payloadOutcomeData = useMemo(() => {
-    if (savedDistricts && hasSavedOutcomeData) {
+    if (savedDistricts && hasSavedActiveOutcomeData) {
       return buildOutcomeMapData(savedDistricts, outcomeMetric, labelLookup);
     }
 
@@ -488,7 +559,7 @@ function CongressionalDistrictCard({
       });
     });
     return buildOutcomeMapData(districts, outcomeMetric, labelLookup);
-  }, [hasSavedOutcomeData, labelLookup, outcomeMetric, savedDistricts, stateResponses]);
+  }, [hasSavedActiveOutcomeData, labelLookup, outcomeMetric, savedDistricts, stateResponses]);
 
   const mapData = isOutcomeMode ? payloadOutcomeData.points : changeMapData;
   const outcomeDisplayData = payloadOutcomeData.points;
@@ -549,7 +620,7 @@ function CongressionalDistrictCard({
           value: district.value,
         });
       }
-    } else if (savedDistricts) {
+    } else if (savedDistricts && hasSavedChangeData) {
       for (const d of savedDistricts) {
         all.push({
           id: d.district,
@@ -578,6 +649,7 @@ function CongressionalDistrictCard({
     return all;
   }, [
     changeMetric,
+    hasSavedChangeData,
     isOutcomeMode,
     labelLookup,
     outcomeDisplayData,
@@ -633,14 +705,17 @@ function CongressionalDistrictCard({
     const savedSet = new Set(savedDistricts.map((d) => d.district));
     const missingStates = new Set<string>();
     let count = 0;
-    labelLookup.forEach((_label, districtId) => {
+    const expectedDistrictIds =
+      savedDistrictAvailability?.expectedDistrictIds ??
+      getExpectedDistrictIds(labelLookup, stateCode);
+    expectedDistrictIds.forEach((districtId) => {
       if (!savedSet.has(districtId)) {
         count++;
         missingStates.add(districtId.split('-')[0]);
       }
     });
     return { errorDistrictCount: count, errorStateAbbrs: Array.from(missingStates) };
-  }, [labelLookup, savedDistricts]);
+  }, [labelLookup, savedDistrictAvailability, savedDistricts, stateCode]);
 
   const fetchedErrorSummary = useMemo(() => {
     const abbrs = Array.from(erroredStates).map((code) =>
@@ -661,14 +736,20 @@ function CongressionalDistrictCard({
 
   const activeErrorSummary = useMemo(() => {
     if (isOutcomeMode) {
-      return hasSavedOutcomeData ? savedErrorSummary : fetchedErrorSummary;
+      return hasSavedActiveOutcomeData ? savedErrorSummary : fetchedErrorSummary;
     }
 
-    return savedDistricts ? savedErrorSummary : fetchedErrorSummary;
-  }, [fetchedErrorSummary, hasSavedOutcomeData, isOutcomeMode, savedDistricts, savedErrorSummary]);
+    return hasSavedChangeData ? savedErrorSummary : fetchedErrorSummary;
+  }, [
+    fetchedErrorSummary,
+    hasSavedActiveOutcomeData,
+    hasSavedChangeData,
+    isOutcomeMode,
+    savedErrorSummary,
+  ]);
 
-  const changeDataReady = Boolean(savedDistricts || (!isLoading && hasStarted));
-  const outcomeDataReady = Boolean(hasSavedOutcomeData || (!isLoading && hasStarted));
+  const changeDataReady = Boolean(hasSavedChangeData || (!isLoading && hasStarted));
+  const outcomeDataReady = Boolean(hasSavedActiveOutcomeData || (!isLoading && hasStarted));
   const dataReady = isOutcomeMode ? outcomeDataReady : changeDataReady;
   const progressCount = completedCount;
   const totalCount = totalStates;

--- a/app/src/pages/report-output/SocietyWideOverview.tsx
+++ b/app/src/pages/report-output/SocietyWideOverview.tsx
@@ -169,9 +169,14 @@ type CardKey = 'budget' | 'decile' | 'poverty' | 'winners' | 'inequality' | 'con
 
 type RankedDistrict = { id: string; label: string; value: number };
 type OutcomeMapPoint = { geoId: string; label: string; value: number };
+type DistrictOutcomePayload = {
+  district: string;
+  winner_percentage?: number;
+  loser_percentage?: number;
+};
 
 export function buildOutcomeMapData(
-  districts: Array<{ district: string; winner_percentage?: number; loser_percentage?: number }>,
+  districts: DistrictOutcomePayload[],
   metric: 'winner' | 'loser',
   labelLookup: Map<string, string>
 ): { points: OutcomeMapPoint[]; missingCount: number } {
@@ -195,6 +200,17 @@ export function buildOutcomeMapData(
   });
 
   return { points, missingCount };
+}
+
+export function hasCompleteDistrictOutcomePayload(districts: DistrictOutcomePayload[]): boolean {
+  return (
+    districts.length > 0 &&
+    districts.every(
+      (district) =>
+        typeof district.winner_percentage === 'number' &&
+        typeof district.loser_percentage === 'number'
+    )
+  );
 }
 
 /**
@@ -393,7 +409,7 @@ function CongressionalDistrictCard({
   const outcomeMetric = congressionalMode === 'winner-pct' ? 'winner' : 'loser';
 
   // Check if output already has district data (from nationwide calculation)
-  const existingDistricts = useMemo(() => {
+  const savedDistricts = useMemo(() => {
     if (!('congressional_district_impact' in output)) {
       return null;
     }
@@ -407,13 +423,18 @@ function CongressionalDistrictCard({
     }));
   }, [output]);
 
+  const hasSavedOutcomeData = useMemo(
+    () => (savedDistricts ? hasCompleteDistrictOutcomePayload(savedDistricts) : false),
+    [savedDistricts]
+  );
+
   // Auto-start fetch only when the report output is ready and no
-  // pre-computed district data exists (avoids 51 redundant requests)
+  // complete district outcome data exists in the saved report output.
   useEffect(() => {
-    if (!existingDistricts && !hasStarted) {
+    if ((!savedDistricts || !hasSavedOutcomeData) && !hasStarted) {
       startFetch();
     }
-  }, [existingDistricts, hasStarted, startFetch]);
+  }, [hasSavedOutcomeData, hasStarted, savedDistricts, startFetch]);
 
   // Build map data from context (progressive fill as states complete)
   const changeContextMapData = useMemo(() => {
@@ -438,8 +459,8 @@ function CongressionalDistrictCard({
 
   // Use pre-computed data if available, otherwise progressive context data
   const changeMapData = useMemo(() => {
-    if (existingDistricts) {
-      return existingDistricts.map((item) => ({
+    if (savedDistricts) {
+      return savedDistricts.map((item) => ({
         geoId: item.district,
         label: labelLookup.get(item.district) ?? `District ${item.district}`,
         value:
@@ -449,29 +470,25 @@ function CongressionalDistrictCard({
       }));
     }
     return changeContextMapData;
-  }, [changeContextMapData, changeMetric, existingDistricts, labelLookup]);
+  }, [changeContextMapData, changeMetric, labelLookup, savedDistricts]);
 
   const payloadOutcomeData = useMemo(() => {
-    if (existingDistricts) {
-      return buildOutcomeMapData(existingDistricts, outcomeMetric, labelLookup);
+    if (savedDistricts && hasSavedOutcomeData) {
+      return buildOutcomeMapData(savedDistricts, outcomeMetric, labelLookup);
     }
 
     if (stateResponses.size === 0) {
       return { points: [], missingCount: 0 };
     }
 
-    const districts: Array<{
-      district: string;
-      winner_percentage?: number;
-      loser_percentage?: number;
-    }> = [];
+    const districts: DistrictOutcomePayload[] = [];
     stateResponses.forEach((stateData) => {
       stateData.districts.forEach((district) => {
         districts.push(district);
       });
     });
     return buildOutcomeMapData(districts, outcomeMetric, labelLookup);
-  }, [existingDistricts, labelLookup, outcomeMetric, stateResponses]);
+  }, [hasSavedOutcomeData, labelLookup, outcomeMetric, savedDistricts, stateResponses]);
 
   const mapData = isOutcomeMode ? payloadOutcomeData.points : changeMapData;
   const outcomeDisplayData = payloadOutcomeData.points;
@@ -532,8 +549,8 @@ function CongressionalDistrictCard({
           value: district.value,
         });
       }
-    } else if (existingDistricts) {
-      for (const d of existingDistricts) {
+    } else if (savedDistricts) {
+      for (const d of savedDistricts) {
         all.push({
           id: d.district,
           label: toShortLabel(d.district),
@@ -561,10 +578,10 @@ function CongressionalDistrictCard({
     return all;
   }, [
     changeMetric,
-    existingDistricts,
     isOutcomeMode,
     labelLookup,
     outcomeDisplayData,
+    savedDistricts,
     stateResponses,
   ]);
 
@@ -605,23 +622,27 @@ function CongressionalDistrictCard({
     [congressionalMode]
   );
 
-  // Detect errored districts from EITHER source:
-  // 1. Pre-computed data: districts in labelLookup but missing from existingDistricts
-  // 2. Progressive fetching: districts belonging to states in erroredStates
-  const { errorDistrictCount, errorStateAbbrs } = useMemo(() => {
-    if (existingDistricts) {
-      const existingSet = new Set(existingDistricts.map((d) => d.district));
-      const missingStates = new Set<string>();
-      let count = 0;
-      labelLookup.forEach((_label, districtId) => {
-        if (!existingSet.has(districtId)) {
-          count++;
-          missingStates.add(districtId.split('-')[0]);
-        }
-      });
-      return { errorDistrictCount: count, errorStateAbbrs: Array.from(missingStates) };
+  // Detect errored districts from either source:
+  // 1. Saved report output: districts in labelLookup but missing from savedDistricts
+  // 2. Refreshed state payloads: districts belonging to states in erroredStates
+  const savedErrorSummary = useMemo(() => {
+    if (!savedDistricts) {
+      return { errorDistrictCount: 0, errorStateAbbrs: [] as string[] };
     }
 
+    const savedSet = new Set(savedDistricts.map((d) => d.district));
+    const missingStates = new Set<string>();
+    let count = 0;
+    labelLookup.forEach((_label, districtId) => {
+      if (!savedSet.has(districtId)) {
+        count++;
+        missingStates.add(districtId.split('-')[0]);
+      }
+    });
+    return { errorDistrictCount: count, errorStateAbbrs: Array.from(missingStates) };
+  }, [labelLookup, savedDistricts]);
+
+  const fetchedErrorSummary = useMemo(() => {
     const abbrs = Array.from(erroredStates).map((code) =>
       code.replace(/^state\//, '').toUpperCase()
     );
@@ -636,17 +657,26 @@ function CongressionalDistrictCard({
       }
     });
     return { errorDistrictCount: count, errorStateAbbrs: abbrs };
-  }, [existingDistricts, erroredStates, labelLookup]);
+  }, [erroredStates, labelLookup]);
 
-  const dataReady = Boolean(existingDistricts || (!isLoading && hasStarted));
+  const activeErrorSummary = useMemo(() => {
+    if (isOutcomeMode) {
+      return hasSavedOutcomeData ? savedErrorSummary : fetchedErrorSummary;
+    }
+
+    return savedDistricts ? savedErrorSummary : fetchedErrorSummary;
+  }, [fetchedErrorSummary, hasSavedOutcomeData, isOutcomeMode, savedDistricts, savedErrorSummary]);
+
+  const changeDataReady = Boolean(savedDistricts || (!isLoading && hasStarted));
+  const outcomeDataReady = Boolean(hasSavedOutcomeData || (!isLoading && hasStarted));
+  const dataReady = isOutcomeMode ? outcomeDataReady : changeDataReady;
   const progressCount = completedCount;
   const totalCount = totalStates;
   const progressLabel = 'states';
   const progressPercent = totalCount > 0 ? Math.round((progressCount / totalCount) * 100) : 0;
-  const visibleErrorCount = isOutcomeMode
-    ? errorDistrictCount + payloadOutcomeData.missingCount
-    : errorDistrictCount;
-  const mapErrorStates = errorStateAbbrs;
+  const visibleErrorCount =
+    activeErrorSummary.errorDistrictCount + (isOutcomeMode ? payloadOutcomeData.missingCount : 0);
+  const mapErrorStates = activeErrorSummary.errorStateAbbrs;
 
   return (
     <DashboardCard

--- a/app/src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
@@ -2,8 +2,47 @@ import { render, screen } from '@test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import SocietyWideOverview, {
   buildOutcomeMapData,
+  hasCompleteDistrictOutcomePayload,
 } from '@/pages/report-output/SocietyWideOverview';
 import { createMockSocietyWideOutput } from '@/tests/fixtures/pages/reportOutputMocks';
+
+const { mockUseCongressionalDistrictData } = vi.hoisted(() => ({
+  mockUseCongressionalDistrictData: vi.fn(),
+}));
+
+vi.mock('@/contexts/CongressionalDistrictDataContext', () => ({
+  useCongressionalDistrictData: mockUseCongressionalDistrictData,
+}));
+
+vi.mock('@/components/visualization/USDistrictChoroplethMap', () => ({
+  USDistrictChoroplethMap: vi.fn(() => <div data-testid="district-map" />),
+}));
+
+function createCongressionalDistrictContextMock(overrides: Record<string, unknown> = {}) {
+  return {
+    reformPolicyId: '96491',
+    baselinePolicyId: '2',
+    year: '2026',
+    stateResponses: new Map(),
+    completedCount: 0,
+    loadingCount: 0,
+    totalDistrictsLoaded: 0,
+    totalStates: 51,
+    isComplete: false,
+    isLoading: false,
+    hasStarted: false,
+    errorCount: 0,
+    erroredStates: new Set(),
+    labelLookup: new Map([['AL-01', "Alabama's 1st congressional district"]]),
+    isStateLevelReport: false,
+    stateCode: null,
+    startFetch: vi.fn(),
+    validateAllLoaded: vi.fn(),
+    getCompletedStates: vi.fn(),
+    getLoadingStates: vi.fn(),
+    ...overrides,
+  };
+}
 
 // Mock useCurrentCountry hook
 vi.mock('@/hooks/useCurrentCountry', () => ({
@@ -30,6 +69,7 @@ vi.mock('@/utils/formatPowers', () => ({
 describe('SocietyWideOverview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseCongressionalDistrictData.mockReturnValue(createCongressionalDistrictContextMock());
   });
 
   describe('budgetary impact section', () => {
@@ -252,5 +292,69 @@ describe('SocietyWideOverview', () => {
       },
     ]);
     expect(result.missingCount).toBe(1);
+  });
+
+  test('hasCompleteDistrictOutcomePayload requires winner and loser shares for every district', () => {
+    expect(
+      hasCompleteDistrictOutcomePayload([
+        { district: 'AL-01', winner_percentage: 0.6, loser_percentage: 0.2 },
+        { district: 'AL-02', winner_percentage: 0.5, loser_percentage: 0.3 },
+      ])
+    ).toBe(true);
+
+    expect(
+      hasCompleteDistrictOutcomePayload([
+        { district: 'AL-01', winner_percentage: 0.6, loser_percentage: 0.2 },
+        { district: 'AL-02', winner_percentage: 0.5 },
+      ])
+    ).toBe(false);
+  });
+
+  test('saved districts without outcome shares trigger a same-payload refresh', () => {
+    const startFetch = vi.fn();
+    mockUseCongressionalDistrictData.mockReturnValue(
+      createCongressionalDistrictContextMock({ startFetch })
+    );
+
+    const output = createMockSocietyWideOutput({
+      congressional_district_impact: {
+        districts: [
+          {
+            district: 'AL-01',
+            average_household_income_change: 120,
+            relative_household_income_change: 0.01,
+          },
+        ],
+      },
+    });
+
+    render(<SocietyWideOverview output={output as any} showCongressionalCard />);
+
+    expect(startFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('saved districts with outcome shares do not trigger a refresh', () => {
+    const startFetch = vi.fn();
+    mockUseCongressionalDistrictData.mockReturnValue(
+      createCongressionalDistrictContextMock({ startFetch })
+    );
+
+    const output = createMockSocietyWideOutput({
+      congressional_district_impact: {
+        districts: [
+          {
+            district: 'AL-01',
+            average_household_income_change: 120,
+            relative_household_income_change: 0.01,
+            winner_percentage: 0.58,
+            loser_percentage: 0.21,
+          },
+        ],
+      },
+    });
+
+    render(<SocietyWideOverview output={output as any} showCongressionalCard />);
+
+    expect(startFetch).not.toHaveBeenCalled();
   });
 });

--- a/app/src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import SocietyWideOverview, {
   buildOutcomeMapData,
+  getDistrictPayloadAvailability,
   hasCompleteDistrictOutcomePayload,
 } from '@/pages/report-output/SocietyWideOverview';
 import { createMockSocietyWideOutput } from '@/tests/fixtures/pages/reportOutputMocks';
@@ -294,19 +295,76 @@ describe('SocietyWideOverview', () => {
     expect(result.missingCount).toBe(1);
   });
 
-  test('hasCompleteDistrictOutcomePayload requires winner and loser shares for every district', () => {
+  test('getDistrictPayloadAvailability tracks coverage and each outcome metric separately', () => {
+    const labelLookup = new Map([
+      ['AL-01', "Alabama's 1st congressional district"],
+      ['AL-02', "Alabama's 2nd congressional district"],
+    ]);
+
     expect(
-      hasCompleteDistrictOutcomePayload([
-        { district: 'AL-01', winner_percentage: 0.6, loser_percentage: 0.2 },
-        { district: 'AL-02', winner_percentage: 0.5, loser_percentage: 0.3 },
-      ])
+      getDistrictPayloadAvailability(
+        [
+          { district: 'AL-01', winner_percentage: 0.6, loser_percentage: 0.2 },
+          { district: 'AL-02', winner_percentage: 0.5 },
+        ],
+        labelLookup,
+        null
+      )
+    ).toEqual({
+      expectedDistrictIds: ['AL-01', 'AL-02'],
+      hasCompleteCoverage: true,
+      hasCompleteWinnerData: true,
+      hasCompleteLoserData: false,
+    });
+
+    expect(
+      getDistrictPayloadAvailability(
+        [{ district: 'AL-01', winner_percentage: 0.6, loser_percentage: 0.2 }],
+        labelLookup,
+        null
+      )
+    ).toEqual({
+      expectedDistrictIds: ['AL-01', 'AL-02'],
+      hasCompleteCoverage: false,
+      hasCompleteWinnerData: false,
+      hasCompleteLoserData: false,
+    });
+  });
+
+  test('hasCompleteDistrictOutcomePayload requires full district coverage plus both outcome shares', () => {
+    const labelLookup = new Map([
+      ['AL-01', "Alabama's 1st congressional district"],
+      ['AL-02', "Alabama's 2nd congressional district"],
+    ]);
+
+    expect(
+      hasCompleteDistrictOutcomePayload(
+        [
+          { district: 'AL-01', winner_percentage: 0.6, loser_percentage: 0.2 },
+          { district: 'AL-02', winner_percentage: 0.5, loser_percentage: 0.3 },
+        ],
+        labelLookup,
+        null
+      )
     ).toBe(true);
 
     expect(
-      hasCompleteDistrictOutcomePayload([
-        { district: 'AL-01', winner_percentage: 0.6, loser_percentage: 0.2 },
-        { district: 'AL-02', winner_percentage: 0.5 },
-      ])
+      hasCompleteDistrictOutcomePayload(
+        [
+          { district: 'AL-01', winner_percentage: 0.6, loser_percentage: 0.2 },
+          { district: 'AL-02', winner_percentage: 0.5 },
+        ],
+        labelLookup,
+        null
+      )
+    ).toBe(false);
+
+    expect(
+      hasCompleteDistrictOutcomePayload(
+        [{ district: 'AL-01', winner_percentage: 0.6, loser_percentage: 0.2 }],
+        labelLookup,
+        null
+      )
     ).toBe(false);
   });
 
@@ -356,5 +414,72 @@ describe('SocietyWideOverview', () => {
     render(<SocietyWideOverview output={output as any} showCongressionalCard />);
 
     expect(startFetch).not.toHaveBeenCalled();
+  });
+
+  test('saved districts with complete winner shares but missing loser shares still trigger a refresh', () => {
+    const startFetch = vi.fn();
+    mockUseCongressionalDistrictData.mockReturnValue(
+      createCongressionalDistrictContextMock({
+        startFetch,
+        labelLookup: new Map([
+          ['AL-01', "Alabama's 1st congressional district"],
+          ['AL-02', "Alabama's 2nd congressional district"],
+        ]),
+      })
+    );
+
+    const output = createMockSocietyWideOutput({
+      congressional_district_impact: {
+        districts: [
+          {
+            district: 'AL-01',
+            average_household_income_change: 120,
+            relative_household_income_change: 0.01,
+            winner_percentage: 0.58,
+          },
+          {
+            district: 'AL-02',
+            average_household_income_change: 80,
+            relative_household_income_change: 0.008,
+            winner_percentage: 0.52,
+          },
+        ],
+      },
+    });
+
+    render(<SocietyWideOverview output={output as any} showCongressionalCard />);
+
+    expect(startFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('truncated saved districts trigger a same-payload refresh', () => {
+    const startFetch = vi.fn();
+    mockUseCongressionalDistrictData.mockReturnValue(
+      createCongressionalDistrictContextMock({
+        startFetch,
+        labelLookup: new Map([
+          ['AL-01', "Alabama's 1st congressional district"],
+          ['AL-02', "Alabama's 2nd congressional district"],
+        ]),
+      })
+    );
+
+    const output = createMockSocietyWideOutput({
+      congressional_district_impact: {
+        districts: [
+          {
+            district: 'AL-01',
+            average_household_income_change: 120,
+            relative_household_income_change: 0.01,
+            winner_percentage: 0.58,
+            loser_percentage: 0.21,
+          },
+        ],
+      },
+    });
+
+    render(<SocietyWideOverview output={output as any} showCongressionalCard />);
+
+    expect(startFetch).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes #935

## Summary
- distinguish district coverage from winner-share and loser-share completeness in the congressional overview card
- keep using saved district data for modes that are already complete while refreshing incomplete payloads through the shared state-summary path
- add regression coverage for truncated saved payloads and metric-specific partial outcome data

## Testing
- PATH=/Users/maxghenis/.bun/bin:$PATH bun run --filter=policyengine-app-v2 vitest src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
- PATH=/Users/maxghenis/.bun/bin:$PATH bun run --filter=policyengine-app-v2 typecheck
- PATH=/Users/maxghenis/.bun/bin:$PATH bun run --filter=policyengine-app-v2 prettier --check src/pages/report-output/SocietyWideOverview.tsx src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
