### PR TITLE
Fix report output actions, canonical navigation, and SSR-safe overview charts

### DIFF
--- a/app/src/components/common/ClientPlot.tsx
+++ b/app/src/components/common/ClientPlot.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { Spinner } from '@/components/ui';
+
+type PlotComponent = React.ComponentType<Record<string, unknown>>;
+
+let cachedPlotComponent: PlotComponent | null = null;
+let plotComponentPromise: Promise<PlotComponent> | null = null;
+
+function loadPlotComponent(): Promise<PlotComponent> {
+  if (cachedPlotComponent) {
+    return Promise.resolve(cachedPlotComponent);
+  }
+
+  if (!plotComponentPromise) {
+    plotComponentPromise = import('react-plotly.js').then((mod) => {
+      cachedPlotComponent = mod.default as PlotComponent;
+      return cachedPlotComponent;
+    });
+  }
+
+  return plotComponentPromise;
+}
+
+function getFallbackHeight(style: unknown): number | string {
+  if (style && typeof style === 'object' && 'height' in style) {
+    const maybeHeight = (style as { height?: number | string }).height;
+    if (maybeHeight !== undefined) {
+      return maybeHeight;
+    }
+  }
+
+  return 400;
+}
+
+/**
+ * Client-only Plotly wrapper for pages that may be server-rendered.
+ * Plotly touches `window` at module scope, so we defer the import until after mount.
+ */
+export function ClientPlot(props: Record<string, unknown>) {
+  const [Plot, setPlot] = useState<PlotComponent | null>(() => cachedPlotComponent);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!Plot) {
+      loadPlotComponent()
+        .then((component) => {
+          if (!cancelled) {
+            setPlot(() => component);
+          }
+        })
+        .catch((error) => {
+          console.error('Failed to load Plotly chart:', error);
+        });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [Plot]);
+
+  if (!Plot) {
+    return (
+      <div
+        className="tw:flex tw:items-center tw:justify-center"
+        style={{ width: '100%', height: getFallbackHeight(props.style) }}
+      >
+        <Spinner size="md" />
+      </div>
+    );
+  }
+
+  return <Plot {...props} />;
+}

--- a/app/src/components/common/ClientPlot.tsx
+++ b/app/src/components/common/ClientPlot.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
+import type { PlotParams } from 'react-plotly.js';
 import { Spinner } from '@/components/ui';
 
-type PlotComponent = React.ComponentType<Record<string, unknown>>;
+type PlotComponent = React.ComponentType<PlotParams>;
 
 let cachedPlotComponent: PlotComponent | null = null;
 let plotComponentPromise: Promise<PlotComponent> | null = null;
@@ -36,7 +37,7 @@ function getFallbackHeight(style: unknown): number | string {
  * Client-only Plotly wrapper for pages that may be server-rendered.
  * Plotly touches `window` at module scope, so we defer the import until after mount.
  */
-export function ClientPlot(props: Record<string, unknown>) {
+export function ClientPlot(props: PlotParams) {
   const [Plot, setPlot] = useState<PlotComponent | null>(() => cachedPlotComponent);
 
   useEffect(() => {

--- a/app/src/components/report/ReportActionButtons.story.tsx
+++ b/app/src/components/report/ReportActionButtons.story.tsx
@@ -5,9 +5,10 @@ const meta: Meta<typeof ReportActionButtons> = {
   title: 'Report output/ReportActionButtons',
   component: ReportActionButtons,
   args: {
-    onShare: () => {},
     onSave: () => {},
     onView: () => {},
+    onReproduce: () => {},
+    shareUrl: 'https://app.policyengine.org/us/report-output/test-report?share=abc123',
   },
 };
 

--- a/app/src/components/report/ReportActionButtons.tsx
+++ b/app/src/components/report/ReportActionButtons.tsx
@@ -1,73 +1,76 @@
 import { IconBookmark, IconCode, IconSettings } from '@tabler/icons-react';
-import { ShareButton } from '@/components/common/ActionButtons';
 import { Group } from '@/components/ui';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { ReportShareButton } from './ReportShareButton';
 
 interface ReportActionButtonsProps {
   isSharedView: boolean;
-  onShare?: () => void;
   onSave?: () => void;
   onView?: () => void;
   onReproduce?: () => void;
+  shareUrl?: string | null;
 }
 
 /**
  * ReportActionButtons - Action buttons for report output header
  *
- * Renders different buttons based on view type:
- * - Normal view: Reproduce + View/edit + Share buttons
- * - Shared view: Save button with tooltip
+ * Renders report-header actions based on available capabilities.
+ * Shared views can safely expose the same read-only actions as owned views,
+ * with an extra save action to let the user persist their own copy locally.
  */
 export function ReportActionButtons({
   isSharedView,
-  onShare,
   onSave,
   onView,
   onReproduce,
+  shareUrl,
 }: ReportActionButtonsProps) {
-  if (isSharedView) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Save report to my reports"
-            onClick={onSave}
-          >
-            <IconBookmark size={18} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="right">Save to my reports</TooltipContent>
-      </Tooltip>
-    );
-  }
+  const viewLabel = isSharedView ? 'View report setup' : 'View/edit report';
 
   return (
     <Group gap="xs" className="tw:ml-1.5">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" aria-label="View/edit report" onClick={onView}>
-            <IconSettings size={18} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">View/edit report</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Reproduce in Python"
-            onClick={onReproduce}
-          >
-            <IconCode size={18} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Reproduce in Python</TooltipContent>
-      </Tooltip>
-      <ShareButton onClick={onShare} />
+      {isSharedView && onSave && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Save report to my reports"
+              onClick={onSave}
+            >
+              <IconBookmark size={18} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Save to my reports</TooltipContent>
+        </Tooltip>
+      )}
+      {onView && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label={viewLabel} onClick={onView}>
+              <IconSettings size={18} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{viewLabel}</TooltipContent>
+        </Tooltip>
+      )}
+      {onReproduce && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Reproduce in Python"
+              onClick={onReproduce}
+            >
+              <IconCode size={18} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Reproduce in Python</TooltipContent>
+        </Tooltip>
+      )}
+      <ReportShareButton shareUrl={shareUrl} />
     </Group>
   );
 }

--- a/app/src/components/report/ReportShareButton.tsx
+++ b/app/src/components/report/ReportShareButton.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react';
+import { IconAlertTriangle, IconCheck, IconCopy, IconShare } from '@tabler/icons-react';
+import {
+  Button,
+  Card,
+  CardContent,
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  Text,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui';
+
+interface ReportShareButtonProps {
+  shareUrl?: string | null;
+}
+
+/**
+ * ReportShareButton - Copies the share URL immediately and shows a short
+ * confirmation popover without dumping the raw link into the UI.
+ */
+export function ReportShareButton({ shareUrl }: ReportShareButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setStatus('idle');
+    }
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleShare = async () => {
+    if (!shareUrl) {
+      return;
+    }
+
+    setOpen(true);
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setStatus('success');
+
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+      }
+      closeTimeoutRef.current = setTimeout(() => setOpen(false), 2200);
+    } catch (error) {
+      setStatus('error');
+      console.error('[ReportShareButton] Failed to copy share URL:', error);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverAnchor asChild>
+            <Button variant="ghost" size="icon" aria-label="Share" disabled={!shareUrl} onClick={handleShare}>
+              <IconShare size={18} />
+            </Button>
+          </PopoverAnchor>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Share</TooltipContent>
+      </Tooltip>
+
+      <PopoverContent align="end" className="tw:w-[320px] tw:p-0">
+        <Card className="tw:border-0 tw:shadow-none">
+          <CardContent className="tw:flex tw:items-start tw:gap-3 tw:py-5">
+            <div className="tw:mt-0.5 tw:flex tw:h-9 tw:w-9 tw:flex-shrink-0 tw:items-center tw:justify-center tw:rounded-full tw:bg-muted">
+              {status === 'error' ? <IconAlertTriangle size={16} /> : <IconCheck size={16} />}
+            </div>
+            <div className="tw:min-w-0 tw:flex-1">
+              <Text className="tw:text-sm tw:font-semibold">
+                {status === 'error' ? 'Could not copy link' : 'Link copied to clipboard'}
+              </Text>
+              <Text className="tw:mt-1 tw:text-sm tw:text-muted-foreground">
+                {status === 'error'
+                  ? 'Clipboard access failed. Try copying again.'
+                  : 'Anyone with the link can view this report in read-only mode.'}
+              </Text>
+              {status === 'error' && (
+                <Button onClick={handleShare} variant="secondary" size="sm" className="tw:mt-3">
+                  <IconCopy size={16} />
+                  Copy again
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { SocietyWideReportOutput as SocietyWideOutput } from '@/api/societyWideCalculation';
 import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 import { FloatingAlert } from '@/components/common/FloatingAlert';
@@ -14,6 +13,7 @@ import { useSaveSharedReport } from '@/hooks/useSaveSharedReport';
 import { useSharedReportData } from '@/hooks/useSharedReportData';
 import { useUserReportById } from '@/hooks/useUserReports';
 import { formatReportTimestamp } from '@/utils/dateUtils';
+import { getReportOutputPath } from '@/utils/reportRouting';
 import { resolveDefaultReportOutputSubpage } from '@/utils/reportOutputSubpage';
 import {
   buildSharePath,
@@ -62,14 +62,14 @@ export default function ReportOutputPage({
   const countryId = useCurrentCountry();
   const location = useAppLocation();
   const searchParams = new URLSearchParams(location.search);
+  const currentReportPath = `${location.pathname}${location.search}`;
 
   // Detect shared view from URL
   const shareData = extractShareDataFromUrl(searchParams);
   const isSharedView = shareData !== null;
   const shareDataUserReportId = shareData ? getShareDataUserReportId(shareData) : null;
-
-  // Alert state for clipboard copy notification
-  const [showCopyAlert, setShowCopyAlert] = useState(false);
+  const shareParam = searchParams.get('share');
+  const sharedSearch = shareParam ? new URLSearchParams({ share: shareParam }).toString() : '';
 
   // If no userReportId and not a shared view, show error
   if (!userReportId && !isSharedView) {
@@ -123,39 +123,6 @@ export default function ReportOutputPage({
   // Hook for saving shared reports with all ingredients
   const { saveSharedReport, saveResult, setSaveResult } = useSaveSharedReport();
 
-  // Handle share button click - copy share URL to clipboard
-  const handleShare = async () => {
-    if (!userReport || !userSimulations?.length) {
-      return;
-    }
-
-    // Create ShareData from user associations
-    const shareDataToEncode = createShareData(
-      userReport,
-      userSimulations ?? [],
-      userPolicies ?? [],
-      userHouseholds ?? [],
-      userGeographies ?? []
-    );
-
-    if (!shareDataToEncode) {
-      console.error('[ReportOutputPage] Failed to create share data');
-      return;
-    }
-
-    const sharePath = buildSharePath(shareDataToEncode);
-    const shareUrl = `${CALCULATOR_URL}${sharePath}`;
-
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-      setShowCopyAlert(true);
-      // Auto-hide alert after 3 seconds
-      setTimeout(() => setShowCopyAlert(false), 3000);
-    } catch (error) {
-      console.error('[ReportOutputPage] Failed to copy share URL:', error);
-    }
-  };
-
   // Handle save button click - create user associations and navigate to owned view
   const handleSave = async () => {
     if (!shareData) {
@@ -174,12 +141,11 @@ export default function ReportOutputPage({
 
   // Handle view button click - navigate to report builder in view mode
   const handleView = () => {
-    if (userReportId) {
-      const params = new URLSearchParams({
-        from: 'report-output',
-        reportPath: `/${countryId}/report-output/${userReportId}`,
-      });
-      nav.push(`/${countryId}/reports/create/${userReportId}?${params}`);
+    const id = isSharedView ? shareDataUserReportId : userReportId;
+    if (id) {
+      nav.push(
+        `/${countryId}/reports/create/${id}${sharedSearch ? `?${sharedSearch}` : ''}`
+      );
     }
   };
 
@@ -187,31 +153,27 @@ export default function ReportOutputPage({
   const handleReproduce = () => {
     const id = isSharedView ? shareDataUserReportId : userReportId;
     if (id) {
-      const basePath = `/${countryId}/report-output/${id}/reproduce`;
-      if (isSharedView) {
-        nav.push(`${basePath}?${searchParams.toString()}`);
-      } else {
-        nav.push(basePath);
-      }
+      nav.push(
+        `/${countryId}/report-output/${id}/reproduce${sharedSearch ? `?${sharedSearch}` : ''}`
+      );
     }
   };
 
-  // Show loading state while fetching data
+  // Show loading state while fetching data with no cached report to render yet
   if (import.meta.env.DEV && dataLoading) {
     (window as any).__journeyProfiler?.markEvent('report-output-data-loading', 'render');
   }
-  if (dataLoading) {
-    return (
-      <Container size="xl" style={{ paddingLeft: spacing.xl, paddingRight: spacing.xl }}>
-        <Stack gap="xl">
-          <Text>Loading report...</Text>
-        </Stack>
-      </Container>
-    );
-  }
+  if (!report || !outputType) {
+    if (dataLoading) {
+      return (
+        <Container size="xl" style={{ paddingLeft: spacing.xl, paddingRight: spacing.xl }}>
+          <Stack gap="xl">
+            <Text>Loading report...</Text>
+          </Stack>
+        </Container>
+      );
+    }
 
-  // Show error if data failed to load
-  if (dataError || !report) {
     return (
       <Container size="xl" style={{ paddingLeft: spacing.xl, paddingRight: spacing.xl }}>
         <Stack gap="xl">
@@ -226,6 +188,34 @@ export default function ReportOutputPage({
   // Determine the display label and ID for the report
   const displayLabel = userReport?.label;
   const displayReportId = isSharedView ? shareDataUserReportId : userReportId;
+  const defaultReportOutputPath =
+    displayReportId !== null && displayReportId !== undefined
+      ? `${getReportOutputPath(countryId, displayReportId)}${sharedSearch ? `?${sharedSearch}` : ''}`
+      : undefined;
+  const layoutBackPath = activeTab === 'reproduce' ? defaultReportOutputPath : undefined;
+  const layoutBackLabel = activeTab === 'reproduce' ? 'report output' : undefined;
+  const shareUrl = (() => {
+    if (isSharedView && shareData) {
+      return `${CALCULATOR_URL}${currentReportPath}`;
+    }
+
+    if (!userReport || !userSimulations?.length) {
+      return null;
+    }
+
+    const shareDataToEncode = createShareData(
+      userReport,
+      userSimulations ?? [],
+      userPolicies ?? [],
+      userHouseholds ?? [],
+      userGeographies ?? []
+    );
+    if (!shareDataToEncode) {
+      return null;
+    }
+
+    return `${CALCULATOR_URL}${buildSharePath(shareDataToEncode)}`;
+  })();
 
   // Render content based on output type
   // Both shared and owned views now use the same user associations shape
@@ -273,12 +263,6 @@ export default function ReportOutputPage({
 
   return (
     <ReportYearProvider year={report?.year ?? null}>
-      {showCopyAlert && (
-        <FloatingAlert onClose={() => setShowCopyAlert(false)}>
-          Share link copied to clipboard!
-        </FloatingAlert>
-      )}
-
       {saveResult && (
         <FloatingAlert
           type={saveResult === 'success' || saveResult === 'already_saved' ? 'success' : 'warning'}
@@ -298,10 +282,12 @@ export default function ReportOutputPage({
         reportYear={report?.year}
         timestamp={timestamp}
         isSharedView={isSharedView}
-        onShare={handleShare}
         onSave={handleSave}
-        onView={!isSharedView ? handleView : undefined}
+        onView={handleView}
         onReproduce={handleReproduce}
+        shareUrl={shareUrl}
+        backPath={layoutBackPath}
+        backLabel={layoutBackLabel}
       >
         <ErrorBoundary
           fallback={(error, errorInfo) => (

--- a/app/src/pages/report-output/HouseholdReportOutput.tsx
+++ b/app/src/pages/report-output/HouseholdReportOutput.tsx
@@ -176,17 +176,16 @@ export function HouseholdReportOutput({
   // RENDER FLOW: Linear progression through data availability
   // ============================================================
 
-  // 1. Show loading state while fetching data from DB
-  if (dataLoading) {
-    return <LoadingPage message="Loading report..." />;
-  }
+  // 1. Show loading or error only when we have no report shell to render yet
+  if (!report) {
+    if (dataLoading) {
+      return <LoadingPage message="Loading report..." />;
+    }
 
-  // 2. Show error if data failed to load
-  if (dataError || !report) {
     return <ErrorPage error={dataError || new Error('Report not found')} />;
   }
 
-  // 3. Data loaded - render input-only tabs immediately (no calculation needed)
+  // 2. Input-only tabs can render as soon as the report payload exists
   const InputTabRenderer = INPUT_ONLY_TABS[normalizedSubpage];
   if (InputTabRenderer) {
     return InputTabRenderer({
@@ -199,19 +198,29 @@ export function HouseholdReportOutput({
     });
   }
 
-  // 4. Show error if any simulation has error status
+  // 3. Output-dependent tabs still wait for any remaining report data
+  if (dataLoading) {
+    return <LoadingPage message="Loading report..." />;
+  }
+
+  // 4. Show error if data failed to load
+  if (dataError) {
+    return <ErrorPage error={dataError} />;
+  }
+
+  // 5. Show error if any simulation has error status
   if (isError) {
     return <ErrorPage error={new Error(viewModel.getErrorMessage())} />;
   }
 
-  // 5. Show loading if calculation is pending (for output-dependent tabs)
+  // 6. Show loading if calculation is pending (for output-dependent tabs)
   if (isPending) {
     const displayStatusLabel = getDisplayStatus('pending');
     const message = progressMessage || `${displayStatusLabel} household simulations...`;
     return <LoadingPage message={message} progress={hasCalcStatus ? displayProgress : undefined} />;
   }
 
-  // 6. Calculation complete - render output tabs
+  // 7. Calculation complete - render output tabs
   if (isComplete) {
     const rawOutput = viewModel.getFormattedOutput();
     const policyLabels = viewModel.getPolicyLabels();

--- a/app/src/pages/report-output/ReportOutputLayout.story.tsx
+++ b/app/src/pages/report-output/ReportOutputLayout.story.tsx
@@ -5,8 +5,10 @@ const meta: Meta<typeof ReportOutputLayout> = {
   title: 'Report output/ReportOutputLayout',
   component: ReportOutputLayout,
   args: {
-    onShare: () => {},
     onSave: () => {},
+    onView: () => {},
+    onReproduce: () => {},
+    shareUrl: 'https://app.policyengine.org/us/report-output/test-report?share=abc123',
   },
 };
 

--- a/app/src/pages/report-output/ReportOutputLayout.tsx
+++ b/app/src/pages/report-output/ReportOutputLayout.tsx
@@ -12,10 +12,12 @@ interface ReportOutputLayoutProps {
   reportYear?: string;
   timestamp?: string;
   isSharedView?: boolean;
-  onShare?: () => void;
   onSave?: () => void;
   onView?: () => void;
   onReproduce?: () => void;
+  shareUrl?: string | null;
+  backPath?: string;
+  backLabel?: string;
   children: React.ReactNode;
 }
 
@@ -35,10 +37,12 @@ export default function ReportOutputLayout({
   reportYear,
   timestamp = 'Ran today at 05:23:41',
   isSharedView = false,
-  onShare,
   onSave,
   onView,
   onReproduce,
+  shareUrl,
+  backPath,
+  backLabel,
   children,
 }: ReportOutputLayoutProps) {
   const countryId = useCurrentCountry();
@@ -51,11 +55,11 @@ export default function ReportOutputLayout({
         <Group
           className="tw:gap-xs tw:items-center tw:cursor-pointer"
           style={{ marginBottom: `-${spacing.md}` }}
-          onClick={() => nav.push(`/${countryId}/reports`)}
+          onClick={() => nav.push(backPath || `/${countryId}/reports`)}
         >
           <IconChevronLeft size={14} color={colors.text.secondary} />
           <Text className="tw:text-sm" style={{ color: colors.text.secondary }}>
-            Back to reports
+            {backLabel ? `Back to ${backLabel}` : 'Back to reports'}
           </Text>
         </Group>
 
@@ -81,10 +85,10 @@ export default function ReportOutputLayout({
             </Group>
             <ReportActionButtons
               isSharedView={isSharedView}
-              onShare={onShare}
               onSave={onSave}
               onView={onView}
               onReproduce={onReproduce}
+              shareUrl={shareUrl}
             />
           </Group>
 

--- a/app/src/pages/report-output/SocietyWideOverview.tsx
+++ b/app/src/pages/report-output/SocietyWideOverview.tsx
@@ -7,10 +7,10 @@ import {
   IconScale,
   IconUsers,
 } from '@tabler/icons-react';
-import Plot from 'react-plotly.js';
 import { useSelector } from 'react-redux';
 import { normalizeDistrictId } from '@/adapters/congressional-district/congressionalDistrictDataAdapter';
 import { SocietyWideReportOutput } from '@/api/societyWideCalculation';
+import { ClientPlot } from '@/components/common/ClientPlot';
 import DashboardCard from '@/components/report/DashboardCard';
 import MetricCard from '@/components/report/MetricCard';
 import { Group, Progress, SegmentedControl, Stack, Text } from '@/components/ui';
@@ -1182,7 +1182,7 @@ export default function SocietyWideOverview({
             {/* Spacer pushes chart toward right half */}
             <div style={{ flex: '1 1 10%' }} />
             <div style={{ flex: '0 1 55%', minWidth: 0 }}>
-              <Plot
+              <ClientPlot
                 data={
                   [
                     {
@@ -1259,7 +1259,7 @@ export default function SocietyWideOverview({
         shrunkenHeader={cardHeader(IconChartBar, 'Decile impacts')}
         shrunkenBody={
           <div>
-            <Plot
+            <ClientPlot
               data={[
                 {
                   x: decileKeys,

--- a/app/src/pages/reportBuilder/ModifyReportPage.tsx
+++ b/app/src/pages/reportBuilder/ModifyReportPage.tsx
@@ -16,6 +16,7 @@ import { useAppNavigate } from '@/contexts/NavigationContext';
 import { spacing } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import { getReportOutputPath } from '@/utils/reportRouting';
+import { extractShareDataFromUrl } from '@/utils/shareUtils';
 import { ReportBuilderShell, SimulationBlockFull } from './components';
 import { useModifyReportSubmission } from './hooks/useModifyReportSubmission';
 import { useReportBuilderState } from './hooks/useReportBuilderState';
@@ -26,11 +27,17 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
   const nav = useAppNavigate();
   const location = useAppLocation();
   const searchParams = new URLSearchParams(location.search);
-  const cameFromReportOutput = searchParams.get('from') === 'report-output';
-  const reportOutputPath = searchParams.get('reportPath');
+  const shareData = extractShareDataFromUrl(searchParams);
+  const isSharedSource = shareData !== null;
+  const shareParam = searchParams.get('share');
+  const sharedSearch = shareParam ? new URLSearchParams({ share: shareParam }).toString() : '';
+  const reportOutputPath = userReportId
+    ? `${getReportOutputPath(countryId, userReportId)}${sharedSearch ? `?${sharedSearch}` : ''}`
+    : undefined;
 
   const { reportState, setReportState, originalState, isLoading, error } = useReportBuilderState(
-    userReportId ?? ''
+    userReportId ?? '',
+    { shareData }
   );
 
   const [pickerState, setPickerState] = useState<IngredientPickerState>({
@@ -51,6 +58,7 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
   // View/edit mode state
   const [isEditing, setIsEditing] = useState(false);
   const [showSameNameWarning, setShowSameNameWarning] = useState(false);
+  const isReadOnly = isSharedSource || !isEditing;
 
   const isEitherSubmitting = isSavingNew || isReplacing;
 
@@ -67,6 +75,9 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
 
   // Dynamic toolbar actions
   const topBarActions: TopBarAction[] = useMemo(() => {
+    if (isSharedSource) {
+      return [];
+    }
     if (!isEditing) {
       return [
         {
@@ -114,6 +125,7 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
       },
     ];
   }, [
+    isSharedSource,
     isEditing,
     handleSaveAsNewClick,
     handleReplace,
@@ -122,21 +134,21 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
     isEitherSubmitting,
   ]);
 
-  if (isLoading || !reportState) {
-    return (
-      <Container size="xl" style={{ paddingLeft: spacing.xl, paddingRight: spacing.xl }}>
-        <Stack gap="xl">
-          <Text>Loading report...</Text>
-        </Stack>
-      </Container>
-    );
-  }
+  if (!reportState) {
+    if (error) {
+      return (
+        <Container size="xl" style={{ paddingLeft: spacing.xl, paddingRight: spacing.xl }}>
+          <Stack gap="xl">
+            <Text c="red">Error loading report: {error.message}</Text>
+          </Stack>
+        </Container>
+      );
+    }
 
-  if (error) {
     return (
       <Container size="xl" style={{ paddingLeft: spacing.xl, paddingRight: spacing.xl }}>
         <Stack gap="xl">
-          <Text c="red">Error loading report: {error.message}</Text>
+          <Text>{isLoading ? 'Loading report...' : 'Report not found'}</Text>
         </Stack>
       </Container>
     );
@@ -145,16 +157,16 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
   return (
     <>
       <ReportBuilderShell
-        title={isEditing ? 'Edit report' : 'View report setup'}
-        backPath={cameFromReportOutput ? (reportOutputPath ?? undefined) : undefined}
-        backLabel={cameFromReportOutput ? reportState?.label || 'Report output' : undefined}
+        title={isEditing && !isSharedSource ? 'Edit report' : 'View report setup'}
+        backPath={reportOutputPath}
+        backLabel={reportOutputPath ? 'report output' : undefined}
         actions={topBarActions}
         reportState={reportState}
         setReportState={setReportState as React.Dispatch<React.SetStateAction<ReportBuilderState>>}
         pickerState={pickerState}
         setPickerState={setPickerState}
         BlockComponent={SimulationBlockFull}
-        isReadOnly={!isEditing}
+        isReadOnly={isReadOnly}
       />
 
       <Dialog

--- a/app/src/pages/reportBuilder/components/SimulationCanvas.tsx
+++ b/app/src/pages/reportBuilder/components/SimulationCanvas.tsx
@@ -101,7 +101,7 @@ export function SimulationCanvas({
               isReadOnly={isReadOnly}
             />
           ) : (
-            <AddSimulationCard onClick={canvas.handleAddSimulation} disabled={false} />
+            <AddSimulationCard onClick={canvas.handleAddSimulation} disabled={!!isReadOnly} />
           )}
         </div>
       </div>
@@ -144,6 +144,7 @@ export function SimulationCanvas({
         simulationIndex={canvas.policyCreationState.simulationIndex}
         initialPolicy={canvas.policyCreationState.initialPolicy}
         initialEditorMode={canvas.policyCreationState.initialEditorMode}
+        lockEditing={!!isReadOnly}
         reportYear={reportYear}
       />
     </>

--- a/app/src/pages/reportBuilder/hooks/useReportBuilderState.ts
+++ b/app/src/pages/reportBuilder/hooks/useReportBuilderState.ts
@@ -1,6 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useSharedReportData } from '@/hooks/useSharedReportData';
 import { useUserReportById } from '@/hooks/useUserReports';
+import type { ReportIngredientsInput } from '@/hooks/utils/useFetchReportIngredients';
 import { RootState } from '@/store';
 import type { ReportBuilderState } from '../types';
 import { hydrateReportBuilderState } from '../utils/hydrateReportBuilderState';
@@ -13,38 +15,46 @@ interface UseReportBuilderStateReturn {
   error: Error | null;
 }
 
-export function useReportBuilderState(userReportId: string): UseReportBuilderStateReturn {
+interface UseReportBuilderStateOptions {
+  shareData?: ReportIngredientsInput | null;
+}
+
+export function useReportBuilderState(
+  userReportId: string,
+  options?: UseReportBuilderStateOptions
+): UseReportBuilderStateReturn {
   const currentLawId = useSelector((state: RootState) => state.metadata.currentLawId);
-  const data = useUserReportById(userReportId);
+  const shareData = options?.shareData ?? null;
+  const isSharedSource = shareData !== null;
+  const sourceKey = isSharedSource
+    ? `${shareData.userReport.countryId}:${shareData.userReport.id ?? shareData.userReport.reportId}`
+    : userReportId;
+  const ownedData = useUserReportById(userReportId, { enabled: !isSharedSource });
+  const sharedData = useSharedReportData(shareData, { enabled: isSharedSource });
+  const data = isSharedSource ? sharedData : ownedData;
 
   const [reportState, setReportState] = useState<ReportBuilderState | null>(null);
   const originalStateRef = useRef<ReportBuilderState | null>(null);
+  const hydratedSourceKeyRef = useRef<string | null>(null);
 
-  useEffect(() => {
-    if (
-      !data.isLoading &&
-      !data.error &&
-      data.userReport &&
-      data.report &&
-      data.simulations.length > 0 &&
-      reportState === null
-    ) {
-      const hydrated = hydrateReportBuilderState({
-        userReport: data.userReport,
-        report: data.report,
-        simulations: data.simulations,
-        policies: data.policies,
-        households: data.households,
-        geographies: data.geographies,
-        userSimulations: data.userSimulations,
-        userPolicies: data.userPolicies,
-        userHouseholds: data.userHouseholds,
-        userGeographies: data.userGeographies,
-        currentLawId,
-      });
-      setReportState(hydrated);
-      originalStateRef.current = hydrated;
+  const hydratedState = useMemo(() => {
+    if (!data.userReport || !data.report || data.simulations.length === 0) {
+      return null;
     }
+
+    return hydrateReportBuilderState({
+      userReport: data.userReport,
+      report: data.report,
+      simulations: data.simulations,
+      policies: data.policies,
+      households: data.households,
+      geographies: data.geographies,
+      userSimulations: data.userSimulations,
+      userPolicies: data.userPolicies,
+      userHouseholds: data.userHouseholds,
+      userGeographies: data.userGeographies,
+      currentLawId,
+    });
   }, [
     data.isLoading,
     data.error,
@@ -59,13 +69,38 @@ export function useReportBuilderState(userReportId: string): UseReportBuilderSta
     data.userHouseholds,
     data.userGeographies,
     currentLawId,
-    reportState,
   ]);
 
+  const resolvedReportState =
+    hydratedSourceKeyRef.current === sourceKey && reportState ? reportState : hydratedState;
+  const resolvedOriginalState =
+    hydratedSourceKeyRef.current === sourceKey ? originalStateRef.current : hydratedState;
+
+  useEffect(() => {
+    if (hydratedSourceKeyRef.current !== sourceKey) {
+      setReportState(null);
+      originalStateRef.current = null;
+    }
+  }, [sourceKey]);
+
+  useEffect(() => {
+    if (
+      hydratedState &&
+      hydratedSourceKeyRef.current !== sourceKey &&
+      reportState === null &&
+      !data.isLoading &&
+      !data.error
+    ) {
+      setReportState(hydratedState);
+      originalStateRef.current = hydratedState;
+      hydratedSourceKeyRef.current = sourceKey;
+    }
+  }, [data.error, data.isLoading, hydratedState, reportState, sourceKey]);
+
   return {
-    reportState,
+    reportState: resolvedReportState,
     setReportState,
-    originalState: originalStateRef.current,
+    originalState: resolvedOriginalState,
     isLoading: data.isLoading,
     error: data.error,
   };

--- a/app/src/pages/reportBuilder/modals/PolicyCreationModal.tsx
+++ b/app/src/pages/reportBuilder/modals/PolicyCreationModal.tsx
@@ -69,6 +69,19 @@ interface PolicyCreationModalProps {
   initialPolicy?: PolicyStateProps;
   initialEditorMode?: EditorMode;
   initialAssociationId?: string;
+  lockEditing?: boolean;
+}
+
+function resolveEditorMode(
+  initialPolicy: PolicyStateProps | undefined,
+  initialEditorMode: EditorMode | undefined,
+  lockEditing: boolean
+): EditorMode {
+  if (lockEditing && initialPolicy) {
+    return 'display';
+  }
+
+  return initialEditorMode || (initialPolicy ? 'edit' : 'create');
 }
 
 export function PolicyCreationModal({
@@ -80,6 +93,7 @@ export function PolicyCreationModal({
   initialPolicy,
   initialEditorMode,
   initialAssociationId,
+  lockEditing = false,
 }: PolicyCreationModalProps) {
   const countryId = useCurrentCountry();
 
@@ -128,7 +142,7 @@ export function PolicyCreationModal({
 
   // Editor mode: create (new policy), display (read-only existing), edit (modifying existing)
   const [editorMode, setEditorMode] = useState<EditorMode>(
-    initialEditorMode || (initialPolicy ? 'edit' : 'create')
+    resolveEditorMode(initialPolicy, initialEditorMode, lockEditing)
   );
   const isReadOnly = editorMode === 'display';
   const colorConfig = INGREDIENT_COLORS.policy;
@@ -138,7 +152,7 @@ export function PolicyCreationModal({
     if (isOpen) {
       setPolicyLabel(initialPolicy?.label || '');
       setPolicyParameters(initialPolicy?.parameters || []);
-      setEditorMode(initialEditorMode || (initialPolicy ? 'edit' : 'create'));
+      setEditorMode(resolveEditorMode(initialPolicy, initialEditorMode, lockEditing));
       setActiveTab('overview');
       setSelectedParam(null);
       setExpandedMenuItems(new Set());
@@ -147,7 +161,7 @@ export function PolicyCreationModal({
       setEndDate(defaultEndDate);
       setParameterSearch('');
     }
-  }, [isOpen, initialEditorMode, initialPolicy, defaultStartDate, defaultEndDate]);
+  }, [isOpen, initialEditorMode, initialPolicy, lockEditing, defaultStartDate, defaultEndDate]);
 
   // Create local policy state object for components
   const localPolicy: PolicyStateProps = useMemo(
@@ -616,7 +630,7 @@ export function PolicyCreationModal({
                   Create policy
                 </Button>
               )}
-              {editorMode === 'display' && (
+              {editorMode === 'display' && !lockEditing && (
                 <EditDefaultButton label="Edit this policy" onClick={() => setEditorMode('edit')} />
               )}
               {editorMode === 'edit' && (

--- a/app/src/tests/fixtures/pages/report-output/ReportOutputLayoutMocks.ts
+++ b/app/src/tests/fixtures/pages/report-output/ReportOutputLayoutMocks.ts
@@ -6,3 +6,5 @@ export const MOCK_REPORT_ID = 'test-report-123';
 export const MOCK_REPORT_LABEL = 'Test Economic Impact Report';
 export const MOCK_REPORT_YEAR = '2024';
 export const MOCK_TIMESTAMP = 'Ran today at 05:23:41';
+export const MOCK_SHARE_URL =
+  'https://app.policyengine.org/us/report-output/test-report-123?share=abc123';

--- a/app/src/tests/unit/components/report/ReportActionButtons.test.tsx
+++ b/app/src/tests/unit/components/report/ReportActionButtons.test.tsx
@@ -1,16 +1,36 @@
 import { render, screen, userEvent } from '@test-utils';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ReportActionButtons } from '@/components/report/ReportActionButtons';
 
+const TEST_SHARE_URL = 'https://app.policyengine.org/us/report-output/test-report?share=abc123';
+
 describe('ReportActionButtons', () => {
-  test('given isSharedView=true then renders save button only', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  test('given isSharedView=true then renders save, view, reproduce, and share buttons', () => {
     // Given
-    render(<ReportActionButtons isSharedView onSave={vi.fn()} />);
+    render(
+      <ReportActionButtons
+        isSharedView
+        onSave={vi.fn()}
+        onView={vi.fn()}
+        onReproduce={vi.fn()}
+        shareUrl={TEST_SHARE_URL}
+      />
+    );
 
     // Then
     expect(screen.getByRole('button', { name: /save report to my reports/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /share/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /view/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /share/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /view report setup/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reproduce in python/i })).toBeInTheDocument();
   });
 
   test('given isSharedView=false then renders reproduce, view, and share buttons', () => {
@@ -18,9 +38,9 @@ describe('ReportActionButtons', () => {
     render(
       <ReportActionButtons
         isSharedView={false}
-        onShare={vi.fn()}
         onView={vi.fn()}
         onReproduce={vi.fn()}
+        shareUrl={TEST_SHARE_URL}
       />
     );
 
@@ -44,17 +64,18 @@ describe('ReportActionButtons', () => {
     expect(handleSave).toHaveBeenCalledOnce();
   });
 
-  test('given onShare callback then calls it when share clicked', async () => {
+  test('given share url then copies immediately and shows confirmation without raw link', async () => {
     // Given
     const user = userEvent.setup();
-    const handleShare = vi.fn();
-    render(<ReportActionButtons isSharedView={false} onShare={handleShare} />);
+    render(<ReportActionButtons isSharedView={false} shareUrl={TEST_SHARE_URL} />);
 
     // When
     await user.click(screen.getByRole('button', { name: /share/i }));
 
     // Then
-    expect(handleShare).toHaveBeenCalledOnce();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(TEST_SHARE_URL);
+    expect(screen.getByText(/link copied to clipboard/i)).toBeInTheDocument();
+    expect(screen.queryByText(TEST_SHARE_URL)).not.toBeInTheDocument();
   });
 
   test('given onReproduce callback then calls it when reproduce clicked', async () => {

--- a/app/src/tests/unit/pages/ReportOutput.page.test.tsx
+++ b/app/src/tests/unit/pages/ReportOutput.page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@test-utils';
+import { render, screen, userEvent } from '@test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { useUserReportById } from '@/hooks/useUserReports';
 import ReportOutputPage from '@/pages/ReportOutput.page';
@@ -18,10 +18,42 @@ import {
   MOCK_USER_REPORT_UK,
 } from '@/tests/fixtures/pages/ReportOutputPageMocks';
 
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+const mockBack = vi.fn();
+let mockLocation = {
+  pathname: `/us/report-output/${MOCK_USER_REPORT_ID}/overview`,
+  search: '',
+};
+
 // Mock dependencies
 vi.mock('@/hooks/useCurrentCountry', () => ({
   useCurrentCountry: () => 'us',
 }));
+
+vi.mock('@/contexts/NavigationContext', async () => {
+  const actual = await vi.importActual<typeof import('@/contexts/NavigationContext')>(
+    '@/contexts/NavigationContext'
+  );
+  return {
+    ...actual,
+    useAppNavigate: () => ({
+      push: mockPush,
+      replace: mockReplace,
+      back: mockBack,
+    }),
+  };
+});
+
+vi.mock('@/contexts/LocationContext', async () => {
+  const actual = await vi.importActual<typeof import('@/contexts/LocationContext')>(
+    '@/contexts/LocationContext'
+  );
+  return {
+    ...actual,
+    useAppLocation: () => mockLocation,
+  };
+});
 
 vi.mock('@/hooks/useUserReports', () => ({
   useUserReportById: vi.fn(() => ({
@@ -84,6 +116,18 @@ vi.mock('@/hooks/useReportProgressDisplay', () => ({
   })),
 }));
 
+vi.mock('@/hooks/household', () => ({
+  useSimulationProgressDisplay: vi.fn(() => ({
+    displayProgress: 100,
+    hasCalcStatus: true,
+    message: 'Complete',
+  })),
+  useHouseholdReportOrchestrator: vi.fn(() => ({
+    startReport: vi.fn(),
+    isCalculating: vi.fn(() => false),
+  })),
+}));
+
 vi.mock('@/hooks/useStartCalculationOnLoad', () => ({
   useStartCalculationOnLoad: vi.fn(),
 }));
@@ -100,6 +144,10 @@ vi.mock('@/hooks/useSaveSharedReport', () => ({
 describe('ReportOutputPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLocation = {
+      pathname: `/us/report-output/${MOCK_USER_REPORT_ID}/overview`,
+      search: '',
+    };
   });
 
   test('given report with year then year is passed to layout', () => {
@@ -225,5 +273,109 @@ describe('ReportOutputPage', () => {
     // Then - Constituency and local authority tabs should not be shown
     expect(screen.queryByText('Constituencies')).not.toBeInTheDocument();
     expect(screen.queryByText('Local authorities')).not.toBeInTheDocument();
+  });
+
+  test('given cached report data while loading on reproduce then renders without the blocking loading page', () => {
+    // Given
+    vi.mocked(useUserReportById).mockReturnValue({
+      userReport: MOCK_USER_REPORT,
+      report: MOCK_REPORT_WITH_YEAR,
+      simulations: [MOCK_SIMULATION_GEOGRAPHY],
+      userSimulations: [],
+      userPolicies: [],
+      policies: [],
+      households: [],
+      userHouseholds: [],
+      geographies: [],
+      userGeographies: [],
+      isLoading: true,
+      error: null,
+    });
+
+    // When
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="reproduce" />);
+
+    // Then
+    expect(screen.getByText(/reproduce these results/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Loading report\.\.\.$/i)).not.toBeInTheDocument();
+  });
+
+  test('given cached household report data while loading on reproduce then renders household reproducibility immediately', () => {
+    // Given
+    vi.mocked(useUserReportById).mockReturnValue({
+      userReport: MOCK_USER_REPORT,
+      report: {
+        ...MOCK_REPORT_WITH_YEAR,
+        label: 'Test Household Report',
+        simulationIds: ['sim-household'],
+      },
+      simulations: [
+        {
+          id: 'sim-household',
+          countryId: 'us' as const,
+          populationType: 'household' as const,
+          populationId: 'household-1',
+          policyId: 'policy-1',
+          status: 'complete' as const,
+          output: null,
+          label: null,
+          isCreated: true,
+        },
+      ],
+      userSimulations: [],
+      userPolicies: [],
+      policies: [],
+      households: [
+        {
+          id: 'household-1',
+          countryId: 'us',
+          householdData: {},
+        },
+      ],
+      userHouseholds: [],
+      geographies: [],
+      userGeographies: [],
+      isLoading: true,
+      error: null,
+    });
+
+    // When
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="reproduce" />);
+
+    // Then
+    expect(screen.getByText(/reproduce these results/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Loading report\.\.\.$/i)).not.toBeInTheDocument();
+  });
+
+  test('given reproduce page then breadcrumb says back to report output', () => {
+    // Given
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="reproduce" />);
+
+    // Then
+    expect(screen.getByText('Back to report output')).toBeInTheDocument();
+  });
+
+  test('given view action then it uses the canonical owned report setup URL', async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    // When
+    await user.click(screen.getByRole('button', { name: /view/i }));
+
+    // Then
+    expect(mockPush).toHaveBeenCalledWith(`/${'us'}/reports/create/${MOCK_USER_REPORT_ID}`);
+  });
+
+  test('given reproduce action then it uses the canonical reproduce URL', async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    // When
+    await user.click(screen.getByRole('button', { name: /reproduce in python/i }));
+
+    // Then
+    expect(mockPush).toHaveBeenCalledWith(`/${'us'}/report-output/${MOCK_USER_REPORT_ID}/reproduce`);
   });
 });

--- a/app/src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx
+++ b/app/src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx
@@ -1,22 +1,43 @@
-import { render, screen } from '@test-utils';
-import { describe, expect, test, vi } from 'vitest';
+import { render, screen, userEvent } from '@test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import ReportOutputLayout from '@/pages/report-output/ReportOutputLayout';
 import {
   MOCK_REPORT_ID,
   MOCK_REPORT_LABEL,
   MOCK_REPORT_YEAR,
+  MOCK_SHARE_URL,
   MOCK_TIMESTAMP,
 } from '@/tests/fixtures/pages/report-output/ReportOutputLayoutMocks';
+
+const mockPush = vi.fn();
 
 vi.mock('@/hooks/useCurrentCountry', () => ({
   useCurrentCountry: () => 'us',
 }));
+
+vi.mock('@/contexts/NavigationContext', async () => {
+  const actual = await vi.importActual<typeof import('@/contexts/NavigationContext')>(
+    '@/contexts/NavigationContext'
+  );
+  return {
+    ...actual,
+    useAppNavigate: () => ({
+      push: mockPush,
+      replace: vi.fn(),
+      back: vi.fn(),
+    }),
+  };
+});
 
 vi.mock('@/components/report/SharedReportTag', () => ({
   SharedReportTag: () => <span data-testid="shared-report-tag">Shared</span>,
 }));
 
 describe('ReportOutputLayout', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
   test('given report year then year is displayed in metadata line', () => {
     // Given
     render(
@@ -136,7 +157,7 @@ describe('ReportOutputLayout', () => {
     expect(screen.getByText(testContent)).toBeInTheDocument();
   });
 
-  test('given isSharedView=true then shows SharedReportTag and save button', () => {
+  test('given isSharedView=true then shows shared actions including save and view setup', () => {
     // Given
     render(
       <ReportOutputLayout
@@ -146,6 +167,9 @@ describe('ReportOutputLayout', () => {
         timestamp={MOCK_TIMESTAMP}
         isSharedView
         onSave={vi.fn()}
+        onView={vi.fn()}
+        onReproduce={vi.fn()}
+        shareUrl={MOCK_SHARE_URL}
       >
         <div>Content</div>
       </ReportOutputLayout>
@@ -154,9 +178,12 @@ describe('ReportOutputLayout', () => {
     // Then
     expect(screen.getByTestId('shared-report-tag')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /save report to my reports/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /view report setup/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reproduce in python/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /share/i })).toBeInTheDocument();
   });
 
-  test('given isSharedView=false then shows view, edit, and share buttons', () => {
+  test('given isSharedView=false then shows view, reproduce, and share buttons', () => {
     // Given
     render(
       <ReportOutputLayout
@@ -165,9 +192,9 @@ describe('ReportOutputLayout', () => {
         reportYear={MOCK_REPORT_YEAR}
         timestamp={MOCK_TIMESTAMP}
         isSharedView={false}
-        onShare={vi.fn()}
         onView={vi.fn()}
         onReproduce={vi.fn()}
+        shareUrl={MOCK_SHARE_URL}
       >
         <div>Content</div>
       </ReportOutputLayout>
@@ -178,5 +205,28 @@ describe('ReportOutputLayout', () => {
     expect(screen.getByRole('button', { name: /reproduce in python/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /share/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /view/i })).toBeInTheDocument();
+  });
+
+  test('given back path then breadcrumb returns to the originating report page', async () => {
+    // Given
+    const user = userEvent.setup();
+    render(
+      <ReportOutputLayout
+        reportId={MOCK_REPORT_ID}
+        reportLabel={MOCK_REPORT_LABEL}
+        reportYear={MOCK_REPORT_YEAR}
+        timestamp={MOCK_TIMESTAMP}
+        backPath="/us/report-output/report-123/overview?share=abc"
+        backLabel="Test Report"
+      >
+        <div>Content</div>
+      </ReportOutputLayout>
+    );
+
+    // When
+    await user.click(screen.getByText(/back to test report/i));
+
+    // Then
+    expect(mockPush).toHaveBeenCalledWith('/us/report-output/report-123/overview?share=abc');
   });
 });

--- a/app/src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen } from '@test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import ModifyReportPage from '@/pages/reportBuilder/ModifyReportPage';
+import { useReportBuilderState } from '@/pages/reportBuilder/hooks/useReportBuilderState';
+import { extractShareDataFromUrl } from '@/utils/shareUtils';
+
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+const mockBack = vi.fn();
+const mockSetReportState = vi.fn();
+const mockHandleSaveAsNew = vi.fn();
+const mockHandleReplace = vi.fn();
+
+const MOCK_SHARE_DATA = {
+  userReport: {
+    id: 'sur-shared-123',
+    reportId: 'report-123',
+    countryId: 'us' as const,
+    label: 'Shared report',
+    isCreated: true,
+  },
+  userSimulations: [],
+  userPolicies: [],
+  userHouseholds: [],
+  userGeographies: [],
+};
+
+const MOCK_REPORT_STATE = {
+  id: 'sur-shared-123',
+  label: 'Shared report',
+  year: '2026',
+  simulations: [],
+};
+
+let mockLocation = {
+  pathname: '/us/reports/create/sur-shared-123',
+  search: '',
+};
+
+vi.mock('@/hooks/useCurrentCountry', () => ({
+  useCurrentCountry: () => 'us',
+}));
+
+vi.mock('@/contexts/LocationContext', async () => {
+  const actual = await vi.importActual<typeof import('@/contexts/LocationContext')>(
+    '@/contexts/LocationContext'
+  );
+  return {
+    ...actual,
+    useAppLocation: () => mockLocation,
+  };
+});
+
+vi.mock('@/contexts/NavigationContext', async () => {
+  const actual = await vi.importActual<typeof import('@/contexts/NavigationContext')>(
+    '@/contexts/NavigationContext'
+  );
+  return {
+    ...actual,
+    useAppNavigate: () => ({
+      push: mockPush,
+      replace: mockReplace,
+      back: mockBack,
+    }),
+  };
+});
+
+vi.mock('@/utils/shareUtils', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/shareUtils')>('@/utils/shareUtils');
+  return {
+    ...actual,
+    extractShareDataFromUrl: vi.fn(() => null),
+  };
+});
+
+vi.mock('@/pages/reportBuilder/hooks/useReportBuilderState', () => ({
+  useReportBuilderState: vi.fn(() => ({
+    reportState: MOCK_REPORT_STATE,
+    setReportState: mockSetReportState,
+    originalState: MOCK_REPORT_STATE,
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+vi.mock('@/pages/reportBuilder/hooks/useModifyReportSubmission', () => ({
+  useModifyReportSubmission: vi.fn(() => ({
+    handleSaveAsNew: mockHandleSaveAsNew,
+    handleReplace: mockHandleReplace,
+    isSavingNew: false,
+    isReplacing: false,
+  })),
+}));
+
+vi.mock('@/pages/reportBuilder/components', () => ({
+  ReportBuilderShell: ({
+    title,
+    actions,
+    isReadOnly,
+    backPath,
+    backLabel,
+  }: {
+    title: string;
+    actions: Array<{ key: string; label: string }>;
+    isReadOnly?: boolean;
+    backPath?: string;
+    backLabel?: string;
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      <div>{isReadOnly ? 'Read only' : 'Editable'}</div>
+      <div>{backPath ? `Back target: ${backLabel} -> ${backPath}` : 'No back target'}</div>
+      {actions.map((action) => (
+        <button key={action.key} type="button">
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
+  SimulationBlockFull: () => <div>Simulation block</div>,
+}));
+
+describe('ModifyReportPage', () => {
+  beforeEach(() => {
+    mockLocation = {
+      pathname: '/us/reports/create/sur-shared-123',
+      search: '',
+    };
+    mockPush.mockReset();
+    mockReplace.mockReset();
+    mockBack.mockReset();
+    mockSetReportState.mockReset();
+    mockHandleSaveAsNew.mockReset();
+    mockHandleReplace.mockReset();
+    vi.mocked(useReportBuilderState).mockClear();
+    vi.mocked(extractShareDataFromUrl).mockReset();
+  });
+
+  test('given shared report source then loads share data and renders read-only setup', () => {
+    // Given
+    mockLocation.search = '?share=encoded-data';
+    vi.mocked(extractShareDataFromUrl).mockReturnValue(MOCK_SHARE_DATA);
+
+    // When
+    render(<ModifyReportPage userReportId="sur-shared-123" />);
+
+    // Then
+    expect(vi.mocked(useReportBuilderState)).toHaveBeenCalledWith('sur-shared-123', {
+      shareData: MOCK_SHARE_DATA,
+    });
+    expect(screen.getByRole('heading', { name: /view report setup/i })).toBeInTheDocument();
+    expect(screen.getByText('Read only')).toBeInTheDocument();
+    expect(
+      screen.getByText('Back target: report output -> /us/report-output/sur-shared-123?share=encoded-data')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /edit report/i })).not.toBeInTheDocument();
+  });
+
+  test('given owned report source then renders the edit action', () => {
+    // Given
+    vi.mocked(extractShareDataFromUrl).mockReturnValue(null);
+
+    // When
+    render(<ModifyReportPage userReportId="sur-owned-123" />);
+
+    // Then
+    expect(vi.mocked(useReportBuilderState)).toHaveBeenCalledWith('sur-owned-123', {
+      shareData: null,
+    });
+    expect(
+      screen.getByText('Back target: report output -> /us/report-output/sur-owned-123')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit report/i })).toBeInTheDocument();
+  });
+
+  test('given cached report state while query is still loading then renders setup without blocking', () => {
+    // Given
+    vi.mocked(extractShareDataFromUrl).mockReturnValue(null);
+    vi.mocked(useReportBuilderState).mockReturnValueOnce({
+      reportState: MOCK_REPORT_STATE,
+      setReportState: mockSetReportState,
+      originalState: MOCK_REPORT_STATE,
+      isLoading: true,
+      error: null,
+    });
+
+    // When
+    render(<ModifyReportPage userReportId="sur-owned-123" />);
+
+    // Then
+    expect(screen.getByRole('heading', { name: /view report setup/i })).toBeInTheDocument();
+    expect(screen.queryByText(/loading report/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/src/tests/unit/pages/reportBuilder/hooks/useReportBuilderState.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/hooks/useReportBuilderState.test.tsx
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { useSharedReportData } from '@/hooks/useSharedReportData';
+import { useUserReportById } from '@/hooks/useUserReports';
+import { useReportBuilderState } from '@/pages/reportBuilder/hooks/useReportBuilderState';
+
+vi.mock('react-redux', async () => {
+  const actual = await vi.importActual<typeof import('react-redux')>('react-redux');
+  return {
+    ...actual,
+    useSelector: vi.fn((selector: (state: any) => unknown) =>
+      selector({
+        metadata: {
+          currentLawId: 1,
+        },
+      })
+    ),
+  };
+});
+
+vi.mock('@/hooks/useUserReports', () => ({
+  useUserReportById: vi.fn(),
+}));
+
+vi.mock('@/hooks/useSharedReportData', () => ({
+  useSharedReportData: vi.fn(),
+}));
+
+const MOCK_ENHANCED_REPORT = {
+  userReport: {
+    id: 'sur-owned-123',
+    reportId: 'report-123',
+    countryId: 'us',
+    label: 'Warm cached report',
+  },
+  report: {
+    id: 'report-123',
+    countryId: 'us',
+    year: '2026',
+    simulationIds: ['sim-1'],
+  },
+  simulations: [
+    {
+      id: 'sim-1',
+      countryId: 'us',
+      apiVersion: '1.0.0',
+      status: 'complete',
+      output: null,
+      policyId: 'policy-1',
+      populationType: 'geography',
+      populationId: 'us',
+    },
+  ],
+  policies: [
+    {
+      id: 'policy-1',
+      label: 'Baseline policy',
+      parameters: [],
+    },
+  ],
+  households: [],
+  geographies: [
+    {
+      id: 'us',
+      geographyId: 'us',
+      countryId: 'us',
+      name: 'United States',
+    },
+  ],
+  userSimulations: [
+    {
+      simulationId: 'sim-1',
+      label: 'Baseline',
+    },
+  ],
+  userPolicies: [
+    {
+      policyId: 'policy-1',
+      label: 'Baseline policy',
+    },
+  ],
+  userHouseholds: [],
+  userGeographies: [],
+  isLoading: true,
+  error: null,
+};
+
+describe('useReportBuilderState', () => {
+  beforeEach(() => {
+    vi.mocked(useUserReportById).mockReset();
+    vi.mocked(useSharedReportData).mockReset();
+    vi.mocked(useSharedReportData).mockReturnValue({
+      userReport: undefined,
+      report: undefined,
+      simulations: [],
+      policies: [],
+      households: [],
+      geographies: [],
+      userSimulations: [],
+      userPolicies: [],
+      userHouseholds: [],
+      userGeographies: [],
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  test('given cached report data while query is still loading then returns hydrated state immediately', () => {
+    // Given
+    vi.mocked(useUserReportById).mockReturnValue(MOCK_ENHANCED_REPORT as any);
+
+    // When
+    const { result } = renderHook(() => useReportBuilderState('sur-owned-123'));
+
+    // Then
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.reportState).toMatchObject({
+      id: 'sur-owned-123',
+      label: 'Warm cached report',
+      year: '2026',
+    });
+    expect(result.current.reportState?.simulations[0]).toMatchObject({
+      id: 'sim-1',
+      label: 'Baseline',
+    });
+  });
+});


### PR DESCRIPTION
Fixes #941

## Summary

- expose the safe report-output header actions in shared mode while keeping shared setup read-only
- switch setup and reproduce navigation to canonical owned/shared URLs and standardize the `Back to report output` breadcrumb
- remove unnecessary loading-page transitions when cached report data is already available
- load Plotly charts client-side in society-wide overview so SSR does not fail on `window`

## Testing

- `cd app && bun run vitest --testTimeout 20000 src/tests/unit/pages/ReportOutput.page.test.tsx src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx src/tests/unit/pages/reportBuilder/hooks/useReportBuilderState.test.tsx`
- `cd app && bun run vitest --testTimeout 20000 src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx src/tests/unit/pages/ReportOutput.page.test.tsx`
