### PR TITLE
Show model and data versions on report output

### DIFF
--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -13,6 +13,7 @@ import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import { useSaveSharedReport } from '@/hooks/useSaveSharedReport';
 import { useSharedReportData } from '@/hooks/useSharedReportData';
 import { useUserReportById } from '@/hooks/useUserReports';
+import type { EconomyOutput, Report } from '@/types/ingredients/Report';
 import { formatReportTimestamp } from '@/utils/dateUtils';
 import { resolveDefaultReportOutputSubpage } from '@/utils/reportOutputSubpage';
 import {
@@ -29,6 +30,29 @@ import { SocietyWideReportOutput } from './report-output/SocietyWideReportOutput
  * Type discriminator for output types
  */
 export type ReportOutputType = 'household' | 'societyWide';
+
+interface ReportVersionMetadata {
+  modelVersion: string | null;
+  dataVersion: string | null;
+}
+
+function extractReportVersionMetadata(output: Report['output']): ReportVersionMetadata | null {
+  if (!output || typeof output !== 'object') {
+    return null;
+  }
+
+  if (!('model_version' in output) && !('data_version' in output)) {
+    return null;
+  }
+
+  const economyOutput = output as Partial<EconomyOutput>;
+
+  return {
+    modelVersion:
+      typeof economyOutput.model_version === 'string' ? economyOutput.model_version : null,
+    dataVersion: typeof economyOutput.data_version === 'string' ? economyOutput.data_version : null,
+  };
+}
 
 /**
  * ReportOutputPage - Orchestration layer for report output pages
@@ -116,6 +140,7 @@ export default function ReportOutputPage({
   // Active subpage and view from URL params
   const activeTab = resolveDefaultReportOutputSubpage(outputType, subpage);
   const activeView = view || '';
+  const versionMetadata = extractReportVersionMetadata(report?.output);
 
   // Format the report creation timestamp using the current country's locale
   const timestamp = formatReportTimestamp(userReport?.createdAt, countryId);
@@ -296,6 +321,8 @@ export default function ReportOutputPage({
         reportId={displayReportId ?? ''}
         reportLabel={displayLabel ?? undefined}
         reportYear={report?.year}
+        modelVersion={versionMetadata?.modelVersion ?? undefined}
+        dataVersion={versionMetadata?.dataVersion ?? undefined}
         timestamp={timestamp}
         isSharedView={isSharedView}
         onShare={handleShare}

--- a/app/src/pages/report-output/ReportOutputLayout.story.tsx
+++ b/app/src/pages/report-output/ReportOutputLayout.story.tsx
@@ -33,6 +33,8 @@ export const SocietyWide: Story = {
     reportId: 'rpt-abc123',
     reportLabel: 'Expand Child Tax Credit to $4,000',
     reportYear: '2026',
+    modelVersion: '1.0.0',
+    dataVersion: '2024.1.0',
     timestamp: 'Ran today at 14:23:41',
     isSharedView: false,
     children: <PlaceholderContent text="Society-wide overview content" />,

--- a/app/src/pages/report-output/ReportOutputLayout.tsx
+++ b/app/src/pages/report-output/ReportOutputLayout.tsx
@@ -10,6 +10,8 @@ interface ReportOutputLayoutProps {
   reportId: string;
   reportLabel?: string;
   reportYear?: string;
+  modelVersion?: string;
+  dataVersion?: string;
   timestamp?: string;
   isSharedView?: boolean;
   onShare?: () => void;
@@ -33,6 +35,8 @@ export default function ReportOutputLayout({
   reportId,
   reportLabel,
   reportYear,
+  modelVersion,
+  dataVersion,
   timestamp = 'Ran today at 05:23:41',
   isSharedView = false,
   onShare,
@@ -106,6 +110,11 @@ export default function ReportOutputLayout({
               {timestamp}
             </Text>
           </Group>
+          {(modelVersion || dataVersion) && (
+            <Text className="tw:text-sm tw:mt-1" style={{ color: colors.text.secondary }}>
+              Model version: {modelVersion ?? '—'} • Data version: {dataVersion ?? '—'}
+            </Text>
+          )}
         </div>
 
         {/* Content */}

--- a/app/src/tests/fixtures/pages/ReportOutputPageMocks.ts
+++ b/app/src/tests/fixtures/pages/ReportOutputPageMocks.ts
@@ -26,6 +26,9 @@ export const MOCK_USER_REPORT_UK = {
   createdAt: '2024-01-01T00:00:00Z',
 };
 
+export const MOCK_MODEL_VERSION = '1.0.0';
+export const MOCK_DATA_VERSION = '2024.1.0';
+
 export const MOCK_REPORT_WITH_YEAR: Report = {
   id: MOCK_REPORT_ID,
   countryId: 'us',
@@ -34,7 +37,10 @@ export const MOCK_REPORT_WITH_YEAR: Report = {
   simulationIds: ['sim-1', 'sim-2'],
   apiVersion: '1.0.0',
   status: 'complete',
-  output: null,
+  output: {
+    model_version: MOCK_MODEL_VERSION,
+    data_version: MOCK_DATA_VERSION,
+  } as any,
 };
 
 export const MOCK_REPORT_UK_NATIONAL: Report = {
@@ -116,12 +122,16 @@ export const MOCK_GEOGRAPHY_UK_LOCAL_AUTHORITY: Geography = {
 };
 
 export const MOCK_SOCIETY_WIDE_OUTPUT = {
+  model_version: MOCK_MODEL_VERSION,
+  data_version: MOCK_DATA_VERSION,
   budget: { budgetary_impact: 1000000 },
   poverty: { poverty: { all: { baseline: 0.1, reform: 0.09 } } },
   intra_decile: { all: { 'Gain more than 5%': 0.2, 'No change': 0.8 } },
 };
 
 export const MOCK_SOCIETY_WIDE_OUTPUT_UK = {
+  model_version: MOCK_MODEL_VERSION,
+  data_version: MOCK_DATA_VERSION,
   budget: { budgetary_impact: 1000000 },
   poverty: { poverty: { all: { baseline: 0.1, reform: 0.09 } } },
   intra_decile: { all: { 'Gain more than 5%': 0.2, 'No change': 0.8 } },

--- a/app/src/tests/fixtures/pages/report-output/ReportOutputLayoutMocks.ts
+++ b/app/src/tests/fixtures/pages/report-output/ReportOutputLayoutMocks.ts
@@ -5,4 +5,6 @@
 export const MOCK_REPORT_ID = 'test-report-123';
 export const MOCK_REPORT_LABEL = 'Test Economic Impact Report';
 export const MOCK_REPORT_YEAR = '2024';
+export const MOCK_MODEL_VERSION = '1.0.0';
+export const MOCK_DATA_VERSION = '2024.1.0';
 export const MOCK_TIMESTAMP = 'Ran today at 05:23:41';

--- a/app/src/tests/unit/pages/ReportOutput.page.test.tsx
+++ b/app/src/tests/unit/pages/ReportOutput.page.test.tsx
@@ -3,10 +3,12 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { useUserReportById } from '@/hooks/useUserReports';
 import ReportOutputPage from '@/pages/ReportOutput.page';
 import {
+  MOCK_DATA_VERSION,
   MOCK_GEOGRAPHY_UK_CONSTITUENCY,
   MOCK_GEOGRAPHY_UK_COUNTRY,
   MOCK_GEOGRAPHY_UK_LOCAL_AUTHORITY,
   MOCK_GEOGRAPHY_UK_NATIONAL,
+  MOCK_MODEL_VERSION,
   MOCK_REPORT_UK_NATIONAL,
   MOCK_REPORT_UK_SUBNATIONAL,
   MOCK_REPORT_WITH_YEAR,
@@ -116,6 +118,14 @@ describe('ReportOutputPage', () => {
 
     // Then
     expect(screen.getByRole('heading', { name: 'Test Report' })).toBeInTheDocument();
+  });
+
+  test('given society-wide report output versions then version metadata is displayed in the header', () => {
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    expect(
+      screen.getByText(`Model version: ${MOCK_MODEL_VERSION} • Data version: ${MOCK_DATA_VERSION}`)
+    ).toBeInTheDocument();
   });
 
   test('given society-wide report with complete calculation then renders without error', () => {

--- a/app/src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx
+++ b/app/src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@test-utils';
 import { describe, expect, test, vi } from 'vitest';
 import ReportOutputLayout from '@/pages/report-output/ReportOutputLayout';
 import {
+  MOCK_DATA_VERSION,
+  MOCK_MODEL_VERSION,
   MOCK_REPORT_ID,
   MOCK_REPORT_LABEL,
   MOCK_REPORT_YEAR,
@@ -116,6 +118,40 @@ describe('ReportOutputLayout', () => {
 
     // Then
     expect(screen.getByText(MOCK_TIMESTAMP)).toBeInTheDocument();
+  });
+
+  test('given model and data versions then version metadata is displayed below header metadata', () => {
+    render(
+      <ReportOutputLayout
+        reportId={MOCK_REPORT_ID}
+        reportLabel={MOCK_REPORT_LABEL}
+        reportYear={MOCK_REPORT_YEAR}
+        modelVersion={MOCK_MODEL_VERSION}
+        dataVersion={MOCK_DATA_VERSION}
+        timestamp={MOCK_TIMESTAMP}
+      >
+        <div>Test Content</div>
+      </ReportOutputLayout>
+    );
+
+    expect(
+      screen.getByText(`Model version: ${MOCK_MODEL_VERSION} • Data version: ${MOCK_DATA_VERSION}`)
+    ).toBeInTheDocument();
+  });
+
+  test('given no model and data versions then version metadata is not displayed', () => {
+    render(
+      <ReportOutputLayout
+        reportId={MOCK_REPORT_ID}
+        reportLabel={MOCK_REPORT_LABEL}
+        reportYear={MOCK_REPORT_YEAR}
+        timestamp={MOCK_TIMESTAMP}
+      >
+        <div>Test Content</div>
+      </ReportOutputLayout>
+    );
+
+    expect(screen.queryByText(/Model version:/)).not.toBeInTheDocument();
   });
 
   test('given children then children are rendered', () => {

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,7 +2,3 @@
   changes:
     added:
       - Add Scotland income tax reform analysis dashboard at /uk/scotland-income-tax-reform
-- bump: patch
-  changes:
-    changed:
-      - Show model and data version metadata in the report output header for completed economy reports

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,3 +2,7 @@
   changes:
     added:
       - Add Scotland income tax reform analysis dashboard at /uk/scotland-income-tax-reform
+- bump: patch
+  changes:
+    changed:
+      - Show model and data version metadata in the report output header for completed economy reports


### PR DESCRIPTION
Fixes #943

## Summary
- show `model_version` and `data_version` in the report output header when they are present on completed economy reports
- keep the header unchanged for report types that do not carry version metadata
- add tests for the new header metadata line

## Verification
- formatted changed files with Prettier
- ran eslint for the app package successfully
- checked the repo CI/CD and found no workflow or release automation that uses `changelog_entry.yaml`
- `bun run --cwd app vitest app/src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx app/src/tests/unit/pages/ReportOutput.page.test.tsx` could not be executed in this workspace because the local `vitest` binary is missing
- `bunx vitest --run ...` also failed before test execution due to a transient runtime mismatch in the ad hoc environment