### PR TITLE
Preserve bundle provenance in the reproduce flow

### DIFF
--- a/app/src/api/householdCalculation.ts
+++ b/app/src/api/householdCalculation.ts
@@ -1,3 +1,4 @@
+import type { PolicyEngineBundle } from '@/api/societyWideCalculation';
 import { BASE_URL } from '@/constants';
 import { HouseholdData } from '@/types/ingredients/Household';
 
@@ -5,13 +6,19 @@ export interface HouseholdCalculationResponse {
   status: 'ok' | 'error';
   result: HouseholdData | null;
   error?: string;
+  policyengine_bundle?: PolicyEngineBundle | null;
 }
 
-export async function fetchHouseholdCalculation(
+export interface HouseholdCalculationResult {
+  result: HouseholdData;
+  policyengine_bundle?: PolicyEngineBundle | null;
+}
+
+export async function fetchHouseholdCalculationWithBundle(
   countryId: string,
   householdId: string,
   policyId: string
-): Promise<HouseholdData> {
+): Promise<HouseholdCalculationResult> {
   const url = `${BASE_URL}/${countryId}/household/${householdId}/policy/${policyId}`;
 
   const controller = new AbortController();
@@ -37,7 +44,10 @@ export async function fetchHouseholdCalculation(
       throw new Error(data.error || 'Household calculation failed');
     }
 
-    return data.result;
+    return {
+      result: data.result,
+      policyengine_bundle: data.policyengine_bundle ?? null,
+    };
   } catch (error) {
     clearTimeout(timeoutId);
 
@@ -48,4 +58,13 @@ export async function fetchHouseholdCalculation(
 
     throw error;
   }
+}
+
+export async function fetchHouseholdCalculation(
+  countryId: string,
+  householdId: string,
+  policyId: string
+): Promise<HouseholdData> {
+  const data = await fetchHouseholdCalculationWithBundle(countryId, householdId, policyId);
+  return data.result;
 }

--- a/app/src/api/societyWideCalculation.ts
+++ b/app/src/api/societyWideCalculation.ts
@@ -4,6 +4,13 @@ import { ReportOutputSocietyWideUS } from '@/types/metadata/ReportOutputSocietyW
 
 export type SocietyWideReportOutput = ReportOutputSocietyWideUS | ReportOutputSocietyWideUK;
 
+export interface PolicyEngineBundle {
+  model_version?: string | null;
+  policyengine_version?: string | null;
+  data_version?: string | null;
+  dataset?: string | null;
+}
+
 // NOTE: Need to add other params at later point
 export interface SocietyWideCalculationParams {
   region: string; // Must include a region; "us" for US nationwide, two-letter state code for US states
@@ -17,6 +24,29 @@ export interface SocietyWideCalculationResponse {
   average_time?: number;
   result: SocietyWideReportOutput | null;
   error?: string;
+  policyengine_bundle?: PolicyEngineBundle | null;
+}
+
+function mergePolicyEngineBundle(
+  response: SocietyWideCalculationResponse
+): SocietyWideCalculationResponse {
+  if (!response.result || !response.policyengine_bundle) {
+    return response;
+  }
+
+  const { policyengine_bundle: bundle } = response;
+
+  return {
+    ...response,
+    result: {
+      ...response.result,
+      model_version: bundle.model_version ?? response.result.model_version,
+      policyengine_version:
+        bundle.policyengine_version ?? response.result.policyengine_version ?? null,
+      data_version: bundle.data_version ?? response.result.data_version,
+      dataset: bundle.dataset ?? response.result.dataset ?? null,
+    },
+  };
 }
 
 export async function fetchSocietyWideCalculation(
@@ -59,6 +89,6 @@ export async function fetchSocietyWideCalculation(
     );
   }
 
-  const data = await response.json();
-  return data;
+  const data: SocietyWideCalculationResponse = await response.json();
+  return mergePolicyEngineBundle(data);
 }

--- a/app/src/libs/calculations/household/HouseholdReportOrchestrator.ts
+++ b/app/src/libs/calculations/household/HouseholdReportOrchestrator.ts
@@ -128,7 +128,7 @@ export class HouseholdReportOrchestrator {
       // Execute the long-running calculation
       // This makes ONE blocking API call and waits for response (30-45s)
       // NO POLLING HAPPENS HERE
-      const result = await calculator.execute({
+      const calculation = await calculator.execute({
         countryId,
         populationId,
         policyId,
@@ -137,14 +137,14 @@ export class HouseholdReportOrchestrator {
       // Store result for report output aggregation
       const reportResults = this.simulationResults.get(reportId);
       if (reportResults) {
-        reportResults.set(simulationId, result as HouseholdData);
+        reportResults.set(simulationId, calculation.result);
       }
 
       // Notify progress coordinator that this simulation completed
       progressCoordinator.completeSimulation(simulationId);
 
       // Persist result to simulation.output
-      await this.persistSimulation(countryId, simulationId, result);
+      await this.persistSimulation(countryId, simulationId, calculation);
     } catch (error) {
       console.error('[HouseholdReportOrchestrator] Simulation failed:', error);
 

--- a/app/src/libs/calculations/household/HouseholdSimCalculator.ts
+++ b/app/src/libs/calculations/household/HouseholdSimCalculator.ts
@@ -1,5 +1,8 @@
 import type { QueryClient } from '@tanstack/react-query';
-import { fetchHouseholdCalculation } from '@/api/householdCalculation';
+import {
+  fetchHouseholdCalculationWithBundle,
+  type HouseholdCalculationResult,
+} from '@/api/householdCalculation';
 import { calculationKeys } from '@/libs/queryKeys';
 import type { CalcStatus } from '@/types/calculation';
 
@@ -37,7 +40,7 @@ export class HouseholdSimCalculator {
     countryId: string;
     populationId: string;
     policyId: string;
-  }): Promise<any> {
+  }): Promise<HouseholdCalculationResult> {
     const calcKey = calculationKeys.bySimulationId(this.simulationId);
 
     // Set initial pending status (no progress field - coordinator handles it)
@@ -58,7 +61,7 @@ export class HouseholdSimCalculator {
     try {
       // Execute the LONG-RUNNING API call (30-50s)
       // This blocks but that's OK - runs in background Promise
-      const result = await fetchHouseholdCalculation(
+      const calculation = await fetchHouseholdCalculationWithBundle(
         params.countryId,
         params.populationId,
         params.policyId
@@ -67,7 +70,7 @@ export class HouseholdSimCalculator {
       // Set final complete status
       const completeStatus: CalcStatus = {
         status: 'complete',
-        result,
+        result: calculation.result,
         message: 'Complete',
         metadata: {
           calcId: this.simulationId,
@@ -80,7 +83,7 @@ export class HouseholdSimCalculator {
 
       this.queryClient.setQueryData(calcKey, completeStatus);
 
-      return result;
+      return calculation;
     } catch (error) {
       console.error('[HouseholdSimCalculator] API call failed:', error);
 

--- a/app/src/pages/report-output/HouseholdReportOutput.tsx
+++ b/app/src/pages/report-output/HouseholdReportOutput.tsx
@@ -64,22 +64,6 @@ const INPUT_ONLY_TABS: Record<string, (props: InputTabProps) => React.ReactEleme
   dynamics: ({ policies, userPolicies }) => (
     <DynamicsSubPage policies={policies} userPolicies={userPolicies} reportType="household" />
   ),
-
-  reproduce: ({ report, policies, households }) => {
-    const householdInput = households?.[0]?.householdData || {};
-    const policyV1 = convertPoliciesToV1Format(policies);
-    const reportOutput = report.output as { policyengine_version?: string | null } | null;
-    return (
-      <HouseholdReproducibility
-        countryId={report.countryId}
-        policy={policyV1}
-        householdInput={householdInput}
-        region={report.countryId}
-        dataset={null}
-        policyengineVersion={reportOutput?.policyengine_version ?? null}
-      />
-    );
-  },
 };
 
 /**
@@ -189,6 +173,21 @@ export function HouseholdReportOutput({
   }
 
   // 3. Data loaded - render input-only tabs immediately (no calculation needed)
+  if (normalizedSubpage === 'reproduce') {
+    const householdInput = households?.[0]?.householdData || {};
+    const policyV1 = convertPoliciesToV1Format(policies);
+    return (
+      <HouseholdReproducibility
+        countryId={report.countryId}
+        policy={policyV1}
+        householdInput={householdInput}
+        region={report.countryId}
+        dataset={null}
+        policyengineVersion={viewModel.getResolvedPolicyengineVersion()}
+      />
+    );
+  }
+
   const InputTabRenderer = INPUT_ONLY_TABS[normalizedSubpage];
   if (InputTabRenderer) {
     return InputTabRenderer({

--- a/app/src/pages/report-output/HouseholdReportOutput.tsx
+++ b/app/src/pages/report-output/HouseholdReportOutput.tsx
@@ -68,6 +68,7 @@ const INPUT_ONLY_TABS: Record<string, (props: InputTabProps) => React.ReactEleme
   reproduce: ({ report, policies, households }) => {
     const householdInput = households?.[0]?.householdData || {};
     const policyV1 = convertPoliciesToV1Format(policies);
+    const reportOutput = report.output as { policyengine_version?: string | null } | null;
     return (
       <HouseholdReproducibility
         countryId={report.countryId}
@@ -75,6 +76,7 @@ const INPUT_ONLY_TABS: Record<string, (props: InputTabProps) => React.ReactEleme
         householdInput={householdInput}
         region={report.countryId}
         dataset={null}
+        policyengineVersion={reportOutput?.policyengine_version ?? null}
       />
     );
   },

--- a/app/src/pages/report-output/HouseholdReportViewModel.ts
+++ b/app/src/pages/report-output/HouseholdReportViewModel.ts
@@ -116,12 +116,64 @@ export class HouseholdReportViewModel {
     }
 
     return this.simulations
-      .filter((sim) => sim.output)
       .map((sim) => ({
-        id: sim.id,
+        simulation: sim,
+        householdData: this.getHouseholdData(sim.output),
+      }))
+      .filter(
+        (entry): entry is { simulation: Simulation; householdData: HouseholdData } =>
+          !!entry.householdData
+      )
+      .map(({ simulation, householdData }) => ({
+        id: simulation.id,
         countryId: this.report!.countryId,
-        householdData: sim.output as HouseholdData,
+        householdData,
       }));
+  }
+
+  getResolvedPolicyengineVersion(): string | null {
+    for (const simulation of this.simulations || []) {
+      const output = simulation.output;
+      if (
+        output &&
+        typeof output === 'object' &&
+        'policyengine_bundle' in output &&
+        output.policyengine_bundle &&
+        typeof output.policyengine_bundle === 'object' &&
+        'policyengine_version' in output.policyengine_bundle &&
+        typeof output.policyengine_bundle.policyengine_version === 'string'
+      ) {
+        return output.policyengine_bundle.policyengine_version;
+      }
+    }
+
+    const reportOutput = this.report?.output;
+    if (
+      reportOutput &&
+      typeof reportOutput === 'object' &&
+      'policyengine_version' in reportOutput &&
+      typeof reportOutput.policyengine_version === 'string'
+    ) {
+      return reportOutput.policyengine_version;
+    }
+
+    return null;
+  }
+
+  private getHouseholdData(output: unknown): HouseholdData | null {
+    if (!output || typeof output !== 'object') {
+      return null;
+    }
+
+    if ('result' in output && output.result && typeof output.result === 'object') {
+      return output.result as HouseholdData;
+    }
+
+    if ('people' in output && output.people && typeof output.people === 'object') {
+      return output as HouseholdData;
+    }
+
+    return null;
   }
 
   /**
@@ -133,7 +185,7 @@ export class HouseholdReportViewModel {
     }
 
     return this.simulations
-      .filter((sim) => sim.output)
+      .filter((sim) => this.getHouseholdData(sim.output))
       .map((sim) => {
         const userPolicy = this.userPolicies!.find((up) => up.policyId === sim.policyId);
         return userPolicy?.label || `Policy ${sim.policyId}`;

--- a/app/src/pages/report-output/SocietyWideReportOutput.tsx
+++ b/app/src/pages/report-output/SocietyWideReportOutput.tsx
@@ -83,14 +83,19 @@ const INPUT_ONLY_TABS: Record<string, (props: InputTabProps) => React.ReactEleme
   reproduce: ({ report, policies, simulations, datasets }) => {
     const policyV1 = convertPoliciesToV1Format(policies);
     const defaultDataset = datasets?.find((d) => d.default);
-    const datasetName = defaultDataset?.name || null;
+    const reportOutput = report.output as Partial<SocietyWideOutput> | null;
+    const datasetName = reportOutput?.dataset || defaultDataset?.name || null;
+    const isResolvedDataset = typeof datasetName === 'string' && datasetName.includes('://');
     return (
       <PolicyReproducibility
         countryId={report.countryId}
         policy={policyV1}
         region={simulations?.[0]?.populationId || report.countryId}
         dataset={datasetName}
-        isDefaultDataset
+        policyengineVersion={reportOutput?.policyengine_version ?? null}
+        isDefaultDataset={
+          !datasetName || (!isResolvedDataset && datasetName === defaultDataset?.name)
+        }
       />
     );
   },

--- a/app/src/pages/report-output/SocietyWideReportOutput.tsx
+++ b/app/src/pages/report-output/SocietyWideReportOutput.tsx
@@ -49,6 +49,7 @@ interface InputTabProps {
   geographies?: Geography[];
   userGeographies?: UserGeographyPopulation[];
   datasets?: DatasetEntry[];
+  reportOutput?: Partial<SocietyWideOutput> | null;
 }
 
 /**
@@ -80,10 +81,9 @@ const INPUT_ONLY_TABS: Record<string, (props: InputTabProps) => React.ReactEleme
     <DynamicsSubPage policies={policies} userPolicies={userPolicies} reportType="economy" />
   ),
 
-  reproduce: ({ report, policies, simulations, datasets }) => {
+  reproduce: ({ report, policies, simulations, datasets, reportOutput }) => {
     const policyV1 = convertPoliciesToV1Format(policies);
     const defaultDataset = datasets?.find((d) => d.default);
-    const reportOutput = report.output as Partial<SocietyWideOutput> | null;
     const datasetName = reportOutput?.dataset || defaultDataset?.name || null;
     const isResolvedDataset = typeof datasetName === 'string' && datasetName.includes('://');
     return (
@@ -236,6 +236,9 @@ export function SocietyWideReportOutput({
   // 2. Data loaded - render input-only tabs immediately (no calculation needed)
   const InputTabRenderer = INPUT_ONLY_TABS[normalizedSubpage];
   if (InputTabRenderer) {
+    const liveOrStoredOutput =
+      (calcStatus.result as Partial<SocietyWideOutput> | null) ||
+      (report.output as Partial<SocietyWideOutput> | null);
     return InputTabRenderer({
       report,
       simulations,
@@ -243,6 +246,7 @@ export function SocietyWideReportOutput({
       userPolicies,
       geographies,
       datasets,
+      reportOutput: liveOrStoredOutput,
     });
   }
 

--- a/app/src/pages/report-output/reproduce-in-python/HouseholdReproducibility.tsx
+++ b/app/src/pages/report-output/reproduce-in-python/HouseholdReproducibility.tsx
@@ -56,7 +56,9 @@ export default function HouseholdReproducibility({
     year,
     dataset,
     householdInput,
-    earningVariation
+    earningVariation,
+    true,
+    policyengineVersion
   );
 
   const codeText = lines.join('\n');

--- a/app/src/pages/report-output/reproduce-in-python/HouseholdReproducibility.tsx
+++ b/app/src/pages/report-output/reproduce-in-python/HouseholdReproducibility.tsx
@@ -32,6 +32,7 @@ interface HouseholdReproducibilityProps {
   householdInput: any;
   region?: string;
   dataset?: string | null;
+  policyengineVersion?: string | null;
 }
 
 export default function HouseholdReproducibility({
@@ -40,6 +41,7 @@ export default function HouseholdReproducibility({
   householdInput,
   region = 'us',
   dataset = null,
+  policyengineVersion = null,
 }: HouseholdReproducibilityProps) {
   const [earningVariation, setEarningVariation] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -120,6 +122,11 @@ export default function HouseholdReproducibility({
                 )}{' '}
                 to reproduce the results.
               </Text>
+              {policyengineVersion ? (
+                <Text className="tw:text-sm tw:mb-xs" style={{ color: colors.text.secondary }}>
+                  Resolved with policyengine.py {policyengineVersion}
+                </Text>
+              ) : null}
               <Group className="tw:gap-sm tw:items-center">
                 <Text className="tw:text-sm" style={{ color: colors.text.secondary }}>
                   Include earning variation

--- a/app/src/pages/report-output/reproduce-in-python/PolicyReproducibility.tsx
+++ b/app/src/pages/report-output/reproduce-in-python/PolicyReproducibility.tsx
@@ -31,6 +31,7 @@ interface PolicyReproducibilityProps {
   region?: string;
   dataset?: string | null;
   isDefaultDataset?: boolean;
+  policyengineVersion?: string | null;
 }
 
 export default function PolicyReproducibility({
@@ -39,6 +40,7 @@ export default function PolicyReproducibility({
   region = 'us',
   dataset = null,
   isDefaultDataset = true,
+  policyengineVersion = null,
 }: PolicyReproducibilityProps) {
   const [copied, setCopied] = useState(false);
   const reportYear = useReportYear();
@@ -118,6 +120,11 @@ export default function PolicyReproducibility({
               )}{' '}
               to reproduce the microsimulation results.
             </Text>
+            {policyengineVersion ? (
+              <Text className="tw:text-sm" style={{ color: colors.text.secondary }}>
+                Resolved with policyengine.py {policyengineVersion}
+              </Text>
+            ) : null}
           </Group>
         </div>
 

--- a/app/src/pages/report-output/reproduce-in-python/PolicyReproducibility.tsx
+++ b/app/src/pages/report-output/reproduce-in-python/PolicyReproducibility.tsx
@@ -55,7 +55,8 @@ export default function PolicyReproducibility({
     dataset,
     null,
     false,
-    isDefaultDataset
+    isDefaultDataset,
+    policyengineVersion
   );
 
   const codeText = codeLines.join('\n');

--- a/app/src/tests/fixtures/api/householdCalculationMocks.ts
+++ b/app/src/tests/fixtures/api/householdCalculationMocks.ts
@@ -153,6 +153,12 @@ export const mockLargeHouseholdResult: Household = {
 export const mockSuccessfulCalculationResponse: HouseholdCalculationResponse = {
   status: 'ok',
   result: mockHouseholdResult.householdData,
+  policyengine_bundle: {
+    model_version: '1.602.0',
+    policyengine_version: '3.4.1',
+    data_version: null,
+    dataset: null,
+  },
 };
 
 export const mockErrorCalculationResponse: HouseholdCalculationResponse = {
@@ -164,6 +170,12 @@ export const mockErrorCalculationResponse: HouseholdCalculationResponse = {
 export const mockUKCalculationResponse: HouseholdCalculationResponse = {
   status: 'ok',
   result: mockHouseholdResultUK.householdData,
+  policyengine_bundle: {
+    model_version: '2.74.0',
+    policyengine_version: '3.4.1',
+    data_version: null,
+    dataset: null,
+  },
 };
 
 // Network error mock

--- a/app/src/tests/fixtures/pages/report-output/reproduce-in-python/reproducibilityMocks.ts
+++ b/app/src/tests/fixtures/pages/report-output/reproduce-in-python/reproducibilityMocks.ts
@@ -132,6 +132,7 @@ export const EXPECTED_TEXT = {
  * Note: Use regex-safe patterns (escape special chars like parentheses)
  */
 export const EXPECTED_CODE_SNIPPETS = {
+  POLICYENGINE_INSTALL: '%pip install policyengine==3.4.0',
   US_HOUSEHOLD_IMPORT: 'from policyengine_us import Simulation',
   UK_HOUSEHOLD_IMPORT: 'from policyengine_uk import Simulation',
   US_POLICY_IMPORT: 'from policyengine_us import Microsimulation',

--- a/app/src/tests/fixtures/pages/report-output/reproduce-in-python/reproducibilityMocks.ts
+++ b/app/src/tests/fixtures/pages/report-output/reproduce-in-python/reproducibilityMocks.ts
@@ -73,6 +73,7 @@ export const DEFAULT_HOUSEHOLD_REPRODUCIBILITY_PROPS = {
   householdInput: MOCK_HOUSEHOLD_INPUT,
   region: TEST_COUNTRIES.US,
   dataset: null,
+  policyengineVersion: null,
 };
 
 /**
@@ -84,6 +85,7 @@ export const DEFAULT_POLICY_REPRODUCIBILITY_PROPS = {
   region: TEST_COUNTRIES.US,
   dataset: null,
   isDefaultDataset: true,
+  policyengineVersion: null,
 };
 
 /**
@@ -95,6 +97,7 @@ export const UK_HOUSEHOLD_REPRODUCIBILITY_PROPS = {
   householdInput: MOCK_HOUSEHOLD_INPUT,
   region: TEST_COUNTRIES.UK,
   dataset: null,
+  policyengineVersion: null,
 };
 
 /**
@@ -106,6 +109,7 @@ export const UK_POLICY_REPRODUCIBILITY_PROPS = {
   region: TEST_COUNTRIES.UK,
   dataset: null,
   isDefaultDataset: true,
+  policyengineVersion: null,
 };
 
 /**
@@ -120,6 +124,7 @@ export const EXPECTED_TEXT = {
   COPIED_LABEL: 'Copied!',
   PYTHON_LABEL: 'Python',
   MICROSIMULATION_INSTRUCTION: 'microsimulation results',
+  POLICYENGINE_VERSION_PREFIX: 'Resolved with policyengine.py',
 } as const;
 
 /**
@@ -141,6 +146,7 @@ export const EXPECTED_CODE_SNIPPETS = {
  * Mock report year hook return value
  */
 export const MOCK_REPORT_YEAR = '2024';
+export const MOCK_POLICYENGINE_VERSION = '3.4.0';
 
 /**
  * Mock clipboard API

--- a/app/src/tests/fixtures/pages/report-output/reproduce-in-python/reproducibilityMocks.ts
+++ b/app/src/tests/fixtures/pages/report-output/reproduce-in-python/reproducibilityMocks.ts
@@ -132,7 +132,7 @@ export const EXPECTED_TEXT = {
  * Note: Use regex-safe patterns (escape special chars like parentheses)
  */
 export const EXPECTED_CODE_SNIPPETS = {
-  POLICYENGINE_INSTALL: '%pip install policyengine==3.4.0',
+  POLICYENGINE_INSTALL: '%pip install "policyengine\\[[a-z]+\\]==3\\.4\\.0"',
   US_HOUSEHOLD_IMPORT: 'from policyengine_us import Simulation',
   UK_HOUSEHOLD_IMPORT: 'from policyengine_uk import Simulation',
   US_POLICY_IMPORT: 'from policyengine_us import Microsimulation',

--- a/app/src/tests/fixtures/utils/reproducibilityCodeMocks.ts
+++ b/app/src/tests/fixtures/utils/reproducibilityCodeMocks.ts
@@ -297,6 +297,8 @@ export const V2_POLICIES_BOTH_CUSTOM = [
 export const TEST_DATASETS = {
   CPS: 'cps',
   ENHANCED_CPS: 'enhanced_cps',
+  ENHANCED_FRS_PRIVATE_URL:
+    'hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5@1.40.3',
   UNKNOWN_DATASET: 'unknown_dataset',
 } as const;
 

--- a/app/src/tests/unit/api/householdCalculation.test.ts
+++ b/app/src/tests/unit/api/householdCalculation.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { fetchHouseholdCalculation } from '@/api/householdCalculation';
+import {
+  fetchHouseholdCalculation,
+  fetchHouseholdCalculationWithBundle,
+} from '@/api/householdCalculation';
 import { BASE_URL } from '@/constants';
 import {
   ERROR_MESSAGES,
@@ -49,6 +52,24 @@ describe('household_calculation API', () => {
         })
       );
       expect(result).toEqual(mockSuccessfulCalculationResponse.result);
+    });
+
+    test('given bundle metadata then preserves it for callers that need provenance', async () => {
+      // Given
+      const countryId = TEST_COUNTRIES.US;
+      const householdId = TEST_HOUSEHOLD_IDS.EXISTING;
+      const policyId = TEST_POLICY_IDS.BASELINE;
+      const mockResponse = mockSuccessResponse(mockSuccessfulCalculationResponse);
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      // When
+      const result = await fetchHouseholdCalculationWithBundle(countryId, householdId, policyId);
+
+      // Then
+      expect(result).toEqual({
+        result: mockSuccessfulCalculationResponse.result,
+        policyengine_bundle: mockSuccessfulCalculationResponse.policyengine_bundle,
+      });
     });
 
     test('given UK parameters then returns UK household data', async () => {

--- a/app/src/tests/unit/api/societyWideCalculation.test.ts
+++ b/app/src/tests/unit/api/societyWideCalculation.test.ts
@@ -131,6 +131,45 @@ describe('societyWide API', () => {
       expect(result.result?.budget.budgetary_impact).toBe(75000);
     });
 
+    test('given completed status with policyengine bundle then merges bundle into result', async () => {
+      // Given
+      const countryId = TEST_COUNTRIES.US;
+      const reformPolicyId = TEST_POLICY_IDS.REFORM;
+      const baselinePolicyId = TEST_POLICY_IDS.BASELINE;
+      const mockResponse = mockSuccessResponse({
+        ...mockCompletedResponse,
+        result: {
+          ...mockCompletedResponse.result!,
+          model_version: 'old-model-version',
+          data_version: 'old-data-version',
+        },
+        policyengine_bundle: {
+          model_version: '1.634.4',
+          policyengine_version: '3.4.0',
+          data_version: '1.77.0',
+          dataset: 'hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.77.0',
+        },
+      });
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      // When
+      const params = { region: 'us', time_period: CURRENT_YEAR };
+      const result = await fetchSocietyWideCalculation(
+        countryId,
+        reformPolicyId,
+        baselinePolicyId,
+        params
+      );
+
+      // Then
+      expect(result.result?.model_version).toBe('1.634.4');
+      expect(result.result?.policyengine_version).toBe('3.4.0');
+      expect(result.result?.data_version).toBe('1.77.0');
+      expect(result.result?.dataset).toBe(
+        'hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.77.0'
+      );
+    });
+
     test('given error status then returns error message with null result', async () => {
       // Given
       const countryId = TEST_COUNTRIES.US;

--- a/app/src/tests/unit/pages/report-output/HouseholdReportViewModel.test.ts
+++ b/app/src/tests/unit/pages/report-output/HouseholdReportViewModel.test.ts
@@ -1,8 +1,82 @@
 import { describe, expect, it } from 'vitest';
 import { HouseholdReportViewModel } from '@/pages/report-output/HouseholdReportViewModel';
+import { mockHouseholdResult } from '@/tests/fixtures/api/householdCalculationMocks';
+import type { Report } from '@/types/ingredients/Report';
 import type { Simulation } from '@/types/ingredients/Simulation';
 
 describe('HouseholdReportViewModel', () => {
+  it('unwraps persisted household calculation wrappers for report output', () => {
+    const report: Report = {
+      id: 'report-1',
+      countryId: 'us',
+      year: '2025',
+      apiVersion: '1.0',
+      simulationIds: ['sim-1'],
+      status: 'complete',
+      outputType: 'household',
+      output: null,
+    };
+    const simulations: Simulation[] = [
+      {
+        id: 'sim-1',
+        countryId: 'us',
+        label: 'Baseline',
+        isCreated: true,
+        status: 'complete',
+        output: {
+          result: mockHouseholdResult.householdData,
+          policyengine_bundle: {
+            policyengine_version: '3.4.1',
+          },
+        },
+      },
+    ];
+
+    const viewModel = new HouseholdReportViewModel(report, simulations, undefined, undefined);
+
+    expect(viewModel.getHouseholdOutputs()).toEqual([
+      {
+        id: 'sim-1',
+        countryId: 'us',
+        householdData: mockHouseholdResult.householdData,
+      },
+    ]);
+  });
+
+  it('prefers simulation bundle provenance over report-level fallback', () => {
+    const report: Report = {
+      id: 'report-1',
+      countryId: 'us',
+      year: '2025',
+      apiVersion: '1.0',
+      simulationIds: ['sim-1'],
+      status: 'complete',
+      outputType: 'household',
+      output: {
+        policyengine_version: 'stale-version',
+      } as never,
+    };
+    const simulations: Simulation[] = [
+      {
+        id: 'sim-1',
+        countryId: 'us',
+        label: 'Baseline',
+        isCreated: true,
+        status: 'complete',
+        output: {
+          result: mockHouseholdResult.householdData,
+          policyengine_bundle: {
+            policyengine_version: '3.4.1',
+          },
+        },
+      },
+    ];
+
+    const viewModel = new HouseholdReportViewModel(report, simulations, undefined, undefined);
+
+    expect(viewModel.getResolvedPolicyengineVersion()).toBe('3.4.1');
+  });
+
   it('given persisted household output without a complete status then treats the simulation as complete', () => {
     const simulation: Simulation = {
       id: 'sim-1',

--- a/app/src/tests/unit/pages/report-output/SocietyWideReportOutput.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideReportOutput.test.tsx
@@ -305,6 +305,36 @@ describe('SocietyWideReportOutput', () => {
     expect(screen.getByText(/Resolved with policyengine\.py 3\.4\.0/)).toBeInTheDocument();
   });
 
+  test('given reproduce subpage with resolved live result then prefers live bundle over stored output', () => {
+    mockUseCalculationStatus.mockReturnValue({
+      ...MOCK_CALC_STATUS_COMPLETE,
+      result: {
+        ...MOCK_CALC_STATUS_COMPLETE.result,
+        dataset: 'hf://policyengine/policyengine-us-data/states/CA.h5@1.77.0',
+        policyengine_version: '3.5.0',
+      },
+    });
+    const reportWithoutBundleOutput = {
+      ...MOCK_REPORT,
+      output: null,
+    };
+
+    render(
+      <SocietyWideReportOutput
+        reportId="test-report-123"
+        subpage="reproduce"
+        report={reportWithoutBundleOutput}
+        simulations={[MOCK_SIMULATION_BASELINE]}
+        policies={[MOCK_POLICY_BASELINE, MOCK_POLICY_REFORM]}
+      />
+    );
+
+    expect(
+      screen.getByText(/hf:\/\/policyengine\/policyengine-us-data\/states\/CA\.h5@1\.77\.0/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Resolved with policyengine\.py 3\.5\.0/)).toBeInTheDocument();
+  });
+
   test('given invalid subpage then shows not found page', () => {
     // Given
     mockUseCalculationStatus.mockReturnValue(MOCK_CALC_STATUS_COMPLETE);

--- a/app/src/tests/unit/pages/report-output/SocietyWideReportOutput.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideReportOutput.test.tsx
@@ -274,6 +274,37 @@ describe('SocietyWideReportOutput', () => {
     expect(screen.getByTestId('dynamics-page')).toBeInTheDocument();
   });
 
+  test('given reproduce subpage with resolved dataset in report output then uses exact dataset url', () => {
+    // Given
+    mockUseCalculationStatus.mockReturnValue(MOCK_CALC_STATUS_IDLE);
+    const reportWithBundleOutput = {
+      ...MOCK_REPORT,
+      output: {
+        dataset: 'hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.77.0',
+        policyengine_version: '3.4.0',
+        model_version: '1.634.4',
+        data_version: '1.77.0',
+      },
+    };
+
+    // When
+    render(
+      <SocietyWideReportOutput
+        reportId="test-report-123"
+        subpage="reproduce"
+        report={reportWithBundleOutput}
+        simulations={[MOCK_SIMULATION_BASELINE]}
+        policies={[MOCK_POLICY_BASELINE, MOCK_POLICY_REFORM]}
+      />
+    );
+
+    // Then
+    expect(
+      screen.getByText(/hf:\/\/policyengine\/policyengine-us-data\/enhanced_cps_2024\.h5@1\.77\.0/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Resolved with policyengine\.py 3\.4\.0/)).toBeInTheDocument();
+  });
+
   test('given invalid subpage then shows not found page', () => {
     // Given
     mockUseCalculationStatus.mockReturnValue(MOCK_CALC_STATUS_COMPLETE);

--- a/app/src/tests/unit/pages/report-output/SocietyWideReportOutput.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideReportOutput.test.tsx
@@ -18,6 +18,7 @@ import {
   MOCK_SIMULATION_REFORM,
   MOCK_USER_POLICY,
 } from '@/tests/fixtures/pages/report-output/SocietyWideReportOutput';
+import { mockUSReportOutput } from '@/tests/fixtures/api/societyWideMocks';
 
 // Mock hooks
 vi.mock('@/hooks/useCalculationStatus');
@@ -280,6 +281,7 @@ describe('SocietyWideReportOutput', () => {
     const reportWithBundleOutput = {
       ...MOCK_REPORT,
       output: {
+        ...mockUSReportOutput,
         dataset: 'hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.77.0',
         policyengine_version: '3.4.0',
         model_version: '1.634.4',

--- a/app/src/tests/unit/pages/report-output/SocietyWideReportOutput.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideReportOutput.test.tsx
@@ -4,6 +4,7 @@ import { useCalculationStatus } from '@/hooks/useCalculationStatus';
 import { useReportProgressDisplay } from '@/hooks/useReportProgressDisplay';
 import { useStartCalculationOnLoad } from '@/hooks/useStartCalculationOnLoad';
 import { SocietyWideReportOutput } from '@/pages/report-output/SocietyWideReportOutput';
+import { mockUSReportOutput } from '@/tests/fixtures/api/societyWideMocks';
 import {
   MOCK_CALC_STATUS_COMPLETE,
   MOCK_CALC_STATUS_ERROR,
@@ -18,7 +19,6 @@ import {
   MOCK_SIMULATION_REFORM,
   MOCK_USER_POLICY,
 } from '@/tests/fixtures/pages/report-output/SocietyWideReportOutput';
-import { mockUSReportOutput } from '@/tests/fixtures/api/societyWideMocks';
 
 // Mock hooks
 vi.mock('@/hooks/useCalculationStatus');
@@ -278,6 +278,8 @@ describe('SocietyWideReportOutput', () => {
   test('given reproduce subpage with resolved dataset in report output then uses exact dataset url', () => {
     // Given
     mockUseCalculationStatus.mockReturnValue(MOCK_CALC_STATUS_IDLE);
+    // Preserve the exact pinned artifact so notebook reproduction does not
+    // silently fall back to a floating default dataset.
     const reportWithBundleOutput = {
       ...MOCK_REPORT,
       output: {

--- a/app/src/tests/unit/pages/report-output/reproduce-in-python/HouseholdReproducibility.test.tsx
+++ b/app/src/tests/unit/pages/report-output/reproduce-in-python/HouseholdReproducibility.test.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_HOUSEHOLD_REPRODUCIBILITY_PROPS,
   EXPECTED_CODE_SNIPPETS,
   EXPECTED_TEXT,
+  MOCK_POLICYENGINE_VERSION,
   MOCK_REPORT_YEAR,
   UK_HOUSEHOLD_REPRODUCIBILITY_PROPS,
 } from '@/tests/fixtures/pages/report-output/reproduce-in-python/reproducibilityMocks';
@@ -57,6 +58,23 @@ describe('HouseholdReproducibility', () => {
 
       // Then
       expect(screen.getByRole('button', { name: /Copy code to clipboard/i })).toBeInTheDocument();
+    });
+
+    test('given policyengine version then renders resolved bundle metadata', () => {
+      // When
+      render(
+        <HouseholdReproducibility
+          {...DEFAULT_HOUSEHOLD_REPRODUCIBILITY_PROPS}
+          policyengineVersion={MOCK_POLICYENGINE_VERSION}
+        />
+      );
+
+      // Then
+      expect(
+        screen.getByText(
+          new RegExp(`${EXPECTED_TEXT.POLICYENGINE_VERSION_PREFIX} ${MOCK_POLICYENGINE_VERSION}`)
+        )
+      ).toBeInTheDocument();
     });
 
     test('given US country then generates US-specific code', () => {

--- a/app/src/tests/unit/pages/report-output/reproduce-in-python/HouseholdReproducibility.test.tsx
+++ b/app/src/tests/unit/pages/report-output/reproduce-in-python/HouseholdReproducibility.test.tsx
@@ -75,6 +75,9 @@ describe('HouseholdReproducibility', () => {
           new RegExp(`${EXPECTED_TEXT.POLICYENGINE_VERSION_PREFIX} ${MOCK_POLICYENGINE_VERSION}`)
         )
       ).toBeInTheDocument();
+      expect(
+        screen.getByText(new RegExp(EXPECTED_CODE_SNIPPETS.POLICYENGINE_INSTALL))
+      ).toBeInTheDocument();
     });
 
     test('given US country then generates US-specific code', () => {

--- a/app/src/tests/unit/pages/report-output/reproduce-in-python/PolicyReproducibility.test.tsx
+++ b/app/src/tests/unit/pages/report-output/reproduce-in-python/PolicyReproducibility.test.tsx
@@ -67,6 +67,9 @@ describe('PolicyReproducibility', () => {
           new RegExp(`${EXPECTED_TEXT.POLICYENGINE_VERSION_PREFIX} ${MOCK_POLICYENGINE_VERSION}`)
         )
       ).toBeInTheDocument();
+      expect(
+        screen.getByText(new RegExp(EXPECTED_CODE_SNIPPETS.POLICYENGINE_INSTALL))
+      ).toBeInTheDocument();
     });
 
     test('given valid props then renders copy button', () => {

--- a/app/src/tests/unit/pages/report-output/reproduce-in-python/PolicyReproducibility.test.tsx
+++ b/app/src/tests/unit/pages/report-output/reproduce-in-python/PolicyReproducibility.test.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_POLICY_REPRODUCIBILITY_PROPS,
   EXPECTED_CODE_SNIPPETS,
   EXPECTED_TEXT,
+  MOCK_POLICYENGINE_VERSION,
   MOCK_REPORT_YEAR,
   UK_POLICY_REPRODUCIBILITY_PROPS,
 } from '@/tests/fixtures/pages/report-output/reproduce-in-python/reproducibilityMocks';
@@ -48,6 +49,23 @@ describe('PolicyReproducibility', () => {
       // Then
       expect(
         screen.getByText(new RegExp(EXPECTED_TEXT.MICROSIMULATION_INSTRUCTION))
+      ).toBeInTheDocument();
+    });
+
+    test('given policyengine version then renders resolved bundle metadata', () => {
+      // When
+      render(
+        <PolicyReproducibility
+          {...DEFAULT_POLICY_REPRODUCIBILITY_PROPS}
+          policyengineVersion={MOCK_POLICYENGINE_VERSION}
+        />
+      );
+
+      // Then
+      expect(
+        screen.getByText(
+          new RegExp(`${EXPECTED_TEXT.POLICYENGINE_VERSION_PREFIX} ${MOCK_POLICYENGINE_VERSION}`)
+        )
       ).toBeInTheDocument();
     });
 

--- a/app/src/tests/unit/utils/reproducibilityCode.test.ts
+++ b/app/src/tests/unit/utils/reproducibilityCode.test.ts
@@ -237,6 +237,25 @@ describe('reproducibilityCode', () => {
         expect(code).toContain('reform=reform');
       });
 
+      test('given policyengine version then adds pinned install line', () => {
+        const lines = getReproducibilityCodeBlock(
+          'policy',
+          TEST_COUNTRIES.US,
+          EMPTY_POLICY,
+          TEST_REGIONS.US_NATIONAL,
+          TEST_YEARS.DEFAULT,
+          null,
+          null,
+          false,
+          true,
+          '3.4.0'
+        );
+        const code = lines.join('\n');
+
+        expect(code).toContain('%pip install policyengine==3.4.0');
+        expect(code).toContain(EXPECTED_IMPORTS.US_POLICY);
+      });
+
       test('given household with earning variation then adds axes', () => {
         // When
         const lines = getReproducibilityCodeBlock(

--- a/app/src/tests/unit/utils/reproducibilityCode.test.ts
+++ b/app/src/tests/unit/utils/reproducibilityCode.test.ts
@@ -425,6 +425,24 @@ describe('reproducibilityCode', () => {
         expect(code).toContain('districts/CA-01.h5');
       });
 
+      test('given pinned state dataset url then uses it verbatim instead of floating state path', () => {
+        const datasetUrl = 'hf://policyengine/policyengine-us-data/states/CA.h5@1.77.0';
+        const lines = getReproducibilityCodeBlock(
+          'policy',
+          TEST_COUNTRIES.US,
+          EMPTY_POLICY,
+          TEST_REGIONS.CA_STATE,
+          TEST_YEARS.DEFAULT,
+          datasetUrl,
+          null,
+          false,
+          false
+        );
+        const code = lines.join('\n');
+
+        expect(code).toContain(`dataset="${datasetUrl}"`);
+      });
+
       test('given place region then uses state dataset with place_fips filtering', () => {
         // When
         const lines = getReproducibilityCodeBlock(
@@ -448,6 +466,24 @@ describe('reproducibilityCode', () => {
         expect(code).toContain('Microsimulation(dataset=subset_df');
         // Includes pandas import for filtering
         expect(code).toContain('import pandas as pd');
+      });
+
+      test('given pinned place dataset url then uses it verbatim for filtering', () => {
+        const datasetUrl = 'hf://policyengine/policyengine-us-data/states/NJ.h5@1.77.0';
+        const lines = getReproducibilityCodeBlock(
+          'policy',
+          TEST_COUNTRIES.US,
+          EMPTY_POLICY,
+          TEST_REGIONS.NJ_PLACE,
+          TEST_YEARS.DEFAULT,
+          datasetUrl,
+          null,
+          false,
+          false
+        );
+        const code = lines.join('\n');
+
+        expect(code).toContain(`Microsimulation(dataset="${datasetUrl}")`);
       });
 
       test('given non-default dataset then includes dataset URL', () => {

--- a/app/src/tests/unit/utils/reproducibilityCode.test.ts
+++ b/app/src/tests/unit/utils/reproducibilityCode.test.ts
@@ -237,7 +237,7 @@ describe('reproducibilityCode', () => {
         expect(code).toContain('reform=reform');
       });
 
-      test('given policyengine version then adds pinned install line', () => {
+      test('given policyengine version then adds pinned install line with country extra', () => {
         const lines = getReproducibilityCodeBlock(
           'policy',
           TEST_COUNTRIES.US,
@@ -252,8 +252,27 @@ describe('reproducibilityCode', () => {
         );
         const code = lines.join('\n');
 
-        expect(code).toContain('%pip install policyengine==3.4.0');
+        expect(code).toContain('%pip install "policyengine[us]==3.4.0"');
         expect(code).toContain(EXPECTED_IMPORTS.US_POLICY);
+      });
+
+      test('given UK policyengine version then installs UK extra before import', () => {
+        const lines = getReproducibilityCodeBlock(
+          'household',
+          TEST_COUNTRIES.UK,
+          EMPTY_POLICY,
+          TEST_REGIONS.UK_NATIONAL,
+          TEST_YEARS.DEFAULT,
+          null,
+          SIMPLE_HOUSEHOLD_INPUT,
+          false,
+          true,
+          '3.4.0'
+        );
+        const code = lines.join('\n');
+
+        expect(code).toContain('%pip install "policyengine[uk]==3.4.0"');
+        expect(code).toContain(EXPECTED_IMPORTS.UK_HOUSEHOLD);
       });
 
       test('given household with earning variation then adds axes', () => {
@@ -525,6 +544,26 @@ describe('reproducibilityCode', () => {
         expect(code).toContain(
           'dataset="hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.77.0"'
         );
+      });
+
+      test('given UK private dataset url then rewrites it to the public repo for reproduction', () => {
+        const lines = getReproducibilityCodeBlock(
+          'policy',
+          TEST_COUNTRIES.UK,
+          EMPTY_POLICY,
+          TEST_REGIONS.UK_NATIONAL,
+          TEST_YEARS.DEFAULT,
+          TEST_DATASETS.ENHANCED_FRS_PRIVATE_URL,
+          null,
+          false,
+          false
+        );
+        const code = lines.join('\n');
+
+        expect(code).toContain(
+          'dataset="hf://policyengine/policyengine-uk-data/enhanced_frs_2023_24.h5@1.40.3"'
+        );
+        expect(code).not.toContain('policyengine-uk-data-private');
       });
 
       test('given default dataset then omits dataset specifier', () => {

--- a/app/src/tests/unit/utils/reproducibilityCode.test.ts
+++ b/app/src/tests/unit/utils/reproducibilityCode.test.ts
@@ -451,6 +451,27 @@ describe('reproducibilityCode', () => {
         expect(code).toContain('dataset=');
       });
 
+      test('given full dataset url then uses it verbatim', () => {
+        // When
+        const lines = getReproducibilityCodeBlock(
+          'policy',
+          TEST_COUNTRIES.US,
+          EMPTY_POLICY,
+          TEST_REGIONS.US_NATIONAL,
+          TEST_YEARS.DEFAULT,
+          'hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.77.0',
+          null,
+          false,
+          false
+        );
+        const code = lines.join('\n');
+
+        // Then
+        expect(code).toContain(
+          'dataset="hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.77.0"'
+        );
+      });
+
       test('given default dataset then omits dataset specifier', () => {
         // When
         const lines = getReproducibilityCodeBlock(

--- a/app/src/types/metadata/ReportOutputSocietyWideUK.ts
+++ b/app/src/types/metadata/ReportOutputSocietyWideUK.ts
@@ -55,6 +55,8 @@ export interface ReportOutputSocietyWideUK {
     by_local_authority: ReportOutputSocietyWideByLocalAuthority;
   };
   data_version: string;
+  dataset?: string | null;
+  policyengine_version?: string | null;
   decile: {
     average: Record<string, number>;
     relative: Record<string, number>;

--- a/app/src/types/metadata/ReportOutputSocietyWideUS.ts
+++ b/app/src/types/metadata/ReportOutputSocietyWideUS.ts
@@ -13,6 +13,8 @@ export interface ReportOutputSocietyWideUS {
   congressional_district_impact: USCongressionalDistrictBreakdown | null;
   constituency_impact: null;
   data_version: string;
+  dataset?: string | null;
+  policyengine_version?: string | null;
   decile: {
     average: Record<string, number>;
     relative: Record<string, number>;

--- a/app/src/utils/reproducibilityCode.ts
+++ b/app/src/utils/reproducibilityCode.ts
@@ -18,13 +18,23 @@ const US_REGION_PREFIX_TO_FOLDER: Record<string, string> = {
   'congressional_district/': 'districts',
 };
 
+function normalizeDatasetUrlForReproducibility(countryId: string, datasetName: string): string {
+  if (countryId === 'uk') {
+    return datasetName.replace(
+      'hf://policyengine/policyengine-uk-data-private/',
+      'hf://policyengine/policyengine-uk-data/'
+    );
+  }
+  return datasetName;
+}
+
 /**
  * Build a HuggingFace dataset URL for a US national-level dataset.
  * Dataset files follow the pattern: {name}_{year}.h5
  */
 function getDatasetUrl(countryId: string, datasetName: string, year: number): string | null {
   if (datasetName.includes('://')) {
-    return datasetName;
+    return normalizeDatasetUrlForReproducibility(countryId, datasetName);
   }
 
   if (countryId === 'us') {
@@ -122,9 +132,10 @@ function getHeaderCode(
 ): string[] {
   const lines: string[] = [];
   const packageName = countryId === 'uk' ? 'policyengine_uk' : 'policyengine_us';
+  const policyengineExtra = countryId === 'uk' ? 'uk' : 'us';
 
   if (policyengineVersion) {
-    lines.push(`%pip install policyengine==${policyengineVersion}`, '');
+    lines.push(`%pip install "policyengine[${policyengineExtra}]==${policyengineVersion}"`, '');
   }
 
   // Add lines depending upon type of block

--- a/app/src/utils/reproducibilityCode.ts
+++ b/app/src/utils/reproducibilityCode.ts
@@ -267,20 +267,22 @@ function getImplementationCode(
 
   const isNational = region === countryId;
   const year = timePeriod || DEFAULT_YEAR;
+  const resolvedDatasetUrl =
+    dataset && !isDefaultDataset ? getDatasetUrl(countryId, dataset, year) : null;
 
   // Place regions use state dataset + place_fips filtering
   if (countryId === 'us' && region.startsWith('place/')) {
-    return getPlaceImplementationCode(region, year, hasBaseline, hasReform);
+    return getPlaceImplementationCode(region, year, hasBaseline, hasReform, resolvedDatasetUrl);
   }
 
   let datasetText = '';
 
   if (countryId === 'us' && !isNational) {
-    // US sub-national (state, congressional district): use region-specific dataset
-    datasetText = getSubnationalDatasetUrl(region) || '';
-  } else if (dataset && !isDefaultDataset) {
+    // Prefer an explicitly resolved dataset URL when the backend pinned one.
+    datasetText = resolvedDatasetUrl || getSubnationalDatasetUrl(region) || '';
+  } else if (resolvedDatasetUrl) {
     // Non-default dataset explicitly selected: include the dataset URL
-    datasetText = getDatasetUrl(countryId, dataset, year) || '';
+    datasetText = resolvedDatasetUrl;
   }
   // Default dataset or no dataset: omit dataset= (matches API behavior)
 
@@ -312,9 +314,10 @@ function getPlaceImplementationCode(
   region: string,
   year: number,
   hasBaseline: boolean,
-  hasReform: boolean
+  hasReform: boolean,
+  datasetUrl: string | null = null
 ): string[] {
-  const stateDatasetUrl = getPlaceStateDatasetUrl(region) || '';
+  const stateDatasetUrl = datasetUrl || getPlaceStateDatasetUrl(region) || '';
   const placeFips = getPlaceFips(region) || '';
 
   const baselineReformArg = hasBaseline ? ', reform=baseline' : '';

--- a/app/src/utils/reproducibilityCode.ts
+++ b/app/src/utils/reproducibilityCode.ts
@@ -117,10 +117,15 @@ function getHeaderCode(
   type: 'household' | 'policy',
   countryId: string,
   policy: { baseline: { data: any }; reform: { data: any } },
-  region: string
+  region: string,
+  policyengineVersion: string | null
 ): string[] {
   const lines: string[] = [];
   const packageName = countryId === 'uk' ? 'policyengine_uk' : 'policyengine_us';
+
+  if (policyengineVersion) {
+    lines.push(`%pip install policyengine==${policyengineVersion}`, '');
+  }
 
   // Add lines depending upon type of block
   if (type === 'household') {
@@ -351,10 +356,11 @@ export function getReproducibilityCodeBlock(
   dataset: string | null = null,
   householdInput: any = null,
   earningVariation: boolean = false,
-  isDefaultDataset: boolean = true
+  isDefaultDataset: boolean = true,
+  policyengineVersion: string | null = null
 ): string[] {
   return [
-    ...getHeaderCode(type, countryId, policy, region),
+    ...getHeaderCode(type, countryId, policy, region, policyengineVersion),
     ...getBaselineCode(policy, countryId),
     ...getReformCode(policy, countryId),
     ...getSituationCode(type, policy, year, householdInput, earningVariation),

--- a/app/src/utils/reproducibilityCode.ts
+++ b/app/src/utils/reproducibilityCode.ts
@@ -23,6 +23,10 @@ const US_REGION_PREFIX_TO_FOLDER: Record<string, string> = {
  * Dataset files follow the pattern: {name}_{year}.h5
  */
 function getDatasetUrl(countryId: string, datasetName: string, year: number): string | null {
+  if (datasetName.includes('://')) {
+    return datasetName;
+  }
+
   if (countryId === 'us') {
     return `hf://policyengine/policyengine-us-data/${datasetName}_${year}.h5`;
   }


### PR DESCRIPTION
## Summary
- preserve resolved bundle metadata from society-wide responses
- keep exact dataset URLs in the reproduce flow
- surface the resolved `policyengine.py` version in the Python reproduction panels

Refs #940.