### PR TITLE
Register taxation-of-benefits-reforms dashboard

### DIFF
--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -1,6 +1,15 @@
 [
   {
     "type": "iframe",
+    "slug": "taxation-of-benefits-reforms",
+    "title": "Social Security taxation reform dashboard",
+    "description": "Explore policy options for reforming the taxation of Social Security benefits, with budgetary impacts through 2100 using PolicyEngine microsimulation. Analysis commissioned by the Committee for a Responsible Federal Budget.",
+    "source": "https://crfb-tob-impacts.vercel.app/",
+    "tags": ["us", "policy", "interactives", "tax"],
+    "countryId": "us"
+  },
+  {
+    "type": "iframe",
     "slug": "scotland-income-tax-reform",
     "title": "Scotland income tax analysis dashboard",
     "description": "Reform UK Scotland proposes replacing Scotland's six income tax bands with the simpler rest-of-UK structure, then reducing every rate by 1pp or 4pp. This dashboard estimates the revenue cost and distributional effects using the PolicyEngine UK microsimulation model.",

--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -4,7 +4,7 @@
     "slug": "taxation-of-benefits-reforms",
     "title": "Social Security taxation reform dashboard",
     "description": "Explore policy options for reforming the taxation of Social Security benefits, with budgetary impacts through 2100 using PolicyEngine microsimulation. Analysis commissioned by the Committee for a Responsible Federal Budget.",
-    "source": "https://crfb-tob-impacts.vercel.app/",
+    "source": "https://crfb-tob-impacts.vercel.app/dashboard/",
     "tags": ["us", "policy", "interactives", "tax"],
     "countryId": "us"
   },

--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -4,7 +4,7 @@
     "slug": "taxation-of-benefits-reforms",
     "title": "Social Security taxation reform dashboard",
     "description": "Explore policy options for reforming the taxation of Social Security benefits, with budgetary impacts through 2100 using PolicyEngine microsimulation. Analysis commissioned by the Committee for a Responsible Federal Budget.",
-    "source": "https://crfb-tob-impacts.vercel.app/dashboard/",
+    "source": "https://crfb-tob-impacts.vercel.app/",
     "tags": ["us", "policy", "interactives", "tax"],
     "countryId": "us"
   },


### PR DESCRIPTION
## Summary
- Add `taxation-of-benefits-reforms` entry to `apps.json`
- Embeds `crfb-tob-impacts.vercel.app` as an iframe at `policyengine.org/us/taxation-of-benefits-reforms`
- The parent app provides the full PolicyEngine nav bar; the embedded dashboard hides its own header when iframed

Depends on PolicyEngine/crfb-tob-impacts#72 deploying first.

## Test plan
- [ ] Verify `crfb-tob-impacts.vercel.app` loads in iframe
- [ ] Verify PE header wraps the dashboard at `/us/taxation-of-benefits-reforms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
