### PR TITLE
[codex] Improve SPM calculator launch flow

### DIFF
--- a/app/src/components/IngredientReadView.tsx
+++ b/app/src/components/IngredientReadView.tsx
@@ -21,6 +21,7 @@ interface IngredientReadViewProps {
   title: string;
   subtitle?: string;
   buttonLabel?: string;
+  emptyState?: React.ReactNode;
   onBuild?: () => void;
   isLoading: boolean;
   isError: boolean;
@@ -37,6 +38,7 @@ export default function IngredientReadView({
   title,
   subtitle,
   buttonLabel,
+  emptyState,
   onBuild,
   isLoading,
   isError,
@@ -81,21 +83,6 @@ export default function IngredientReadView({
         </div>
       </div>
 
-      {/* Title Section */}
-      <div style={{ marginBottom: spacing.xl }}>
-        <Title
-          order={2}
-          style={{
-            fontSize: typography.fontSize.lg,
-            fontWeight: typography.fontWeight.semibold,
-            color: colors.text.title,
-            marginBottom: spacing.lg,
-          }}
-        >
-          {title}
-        </Title>
-      </div>
-
       {/* Content Section */}
       <div
         style={{
@@ -122,7 +109,7 @@ export default function IngredientReadView({
           <>
             {data.length === 0 ? (
               <div style={{ padding: spacing['3xl'] }}>
-                <EmptyState ingredient={ingredient} />
+                {emptyState || <EmptyState ingredient={ingredient} />}
               </div>
             ) : (
               <Table>

--- a/app/src/components/StandardLayout.tsx
+++ b/app/src/components/StandardLayout.tsx
@@ -56,7 +56,7 @@ export default function StandardLayout({ children }: StandardLayoutProps) {
           >
             <Sidebar />
           </nav>
-          <main className="tw:flex-1 tw:min-w-0 tw:max-w-[calc(100vw-300px)] tw:overflow-y-auto tw:overflow-x-hidden tw:p-[24px] tw:bg-gray-50">
+          <main className="tw:flex-1 tw:min-w-0 tw:max-w-full tw:overflow-y-auto tw:overflow-x-hidden tw:bg-gray-50 tw:p-[24px] sm:tw:max-w-[calc(100vw-300px)]">
             {children}
           </main>
         </div>

--- a/app/src/components/calculator/CalculatorLaunchPage.tsx
+++ b/app/src/components/calculator/CalculatorLaunchPage.tsx
@@ -1,0 +1,349 @@
+import { IconArrowRight, IconHome, IconScale, IconShare3 } from '@tabler/icons-react';
+import { Button, Container, Group, Stack, Text, Title } from '@/components/ui';
+import { WEBSITE_URL } from '@/constants';
+import { useAppNavigate } from '@/contexts/NavigationContext';
+import { colors, spacing, typography } from '@/designTokens';
+import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+
+type SupportedCountry = 'us' | 'uk';
+
+const LAUNCH_CONTENT: Record<
+  SupportedCountry,
+  {
+    eyebrow: string;
+    title: string;
+    subtitle: string;
+    householdCta: string;
+    reportCta: string;
+    householdDescription: string;
+    reportDescription: string;
+    outputs: string[];
+    explainer: string;
+  }
+> = {
+  us: {
+    eyebrow: 'Poverty and household policy analysis',
+    title: 'Run Supplemental Poverty Measure calculations and policy reports',
+    subtitle:
+      'Model a custom household, compare current law to reforms, and inspect SPM poverty, net income, taxes, and benefits in one place.',
+    householdCta: 'Start household calculation',
+    reportCta: 'Build population report',
+    householdDescription:
+      'Check a family or individual against current law and proposed reforms with a faster path into the household builder.',
+    reportDescription:
+      'Generate nationwide, state, or district analyses for budget, distribution, and poverty impacts.',
+    outputs: [
+      'SPM poverty status and gap',
+      'Net income, taxes, and benefits',
+      'Shareable and reproducible results',
+    ],
+    explainer:
+      'Saved work stays in this browser unless you create a share link, so first-run users can start immediately without an account.',
+  },
+  uk: {
+    eyebrow: 'Household and policy analysis',
+    title: 'Run household calculations and poverty impact reports',
+    subtitle:
+      'Model a custom household, compare current law to reforms, and inspect income, taxes, benefits, and poverty impacts in one place.',
+    householdCta: 'Start household calculation',
+    reportCta: 'Build population report',
+    householdDescription:
+      'Check a household against current policy or a reform without starting from the full report workflow.',
+    reportDescription:
+      'Generate nationwide or regional analyses for distribution, budget, and poverty impacts.',
+    outputs: [
+      'Household disposable income',
+      'Tax and benefit changes',
+      'Shareable and reproducible results',
+    ],
+    explainer:
+      'Saved work stays in this browser unless you create a share link, so first-run users can start immediately without an account.',
+  },
+};
+
+function FeatureCard({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div
+      className="tw:h-full tw:rounded-2xl tw:border tw:border-white/70 tw:bg-white/85 tw:p-6 tw:backdrop-blur"
+      style={{ boxShadow: `0 18px 48px ${colors.shadow.light}` }}
+    >
+      <div
+        className="tw:mb-4 tw:flex tw:h-11 tw:w-11 tw:items-center tw:justify-center tw:rounded-xl"
+        style={{ backgroundColor: colors.primary[50], color: colors.primary[700] }}
+      >
+        {icon}
+      </div>
+      <Title
+        order={3}
+        style={{
+          fontSize: typography.fontSize.xl,
+          fontWeight: typography.fontWeight.semibold,
+          color: colors.text.title,
+          marginBottom: spacing.sm,
+        }}
+      >
+        {title}
+      </Title>
+      <Text style={{ color: colors.text.secondary, lineHeight: 1.6 }}>{description}</Text>
+    </div>
+  );
+}
+
+export default function CalculatorLaunchPage() {
+  const countryId = useCurrentCountry() as SupportedCountry;
+  const nav = useAppNavigate();
+  const content = LAUNCH_CONTENT[countryId] ?? LAUNCH_CONTENT.us;
+
+  return (
+    <Container size="xl" className="tw:px-xl">
+      <Stack gap="xl">
+        <section
+          className="tw:relative tw:overflow-hidden tw:rounded-[28px] tw:border tw:border-white/70 tw:p-8 md:tw:p-10"
+          style={{
+            background: `linear-gradient(135deg, ${colors.primary[700]} 0%, ${colors.primary[500]} 48%, ${colors.primary[100]} 100%)`,
+            boxShadow: `0 24px 72px ${colors.shadow.medium}`,
+          }}
+        >
+          <div
+            className="tw:pointer-events-none tw:absolute tw:-right-12 tw:-top-10 tw:h-40 tw:w-40 tw:rounded-full"
+            style={{ backgroundColor: 'rgba(255,255,255,0.12)' }}
+          />
+          <div
+            className="tw:pointer-events-none tw:absolute tw:-bottom-12 tw:left-1/2 tw:h-52 tw:w-52 tw:-translate-x-1/2 tw:rounded-full"
+            style={{ backgroundColor: 'rgba(255,255,255,0.10)' }}
+          />
+
+          <div className="tw:relative tw:grid tw:grid-cols-1 tw:gap-8 lg:tw:grid-cols-[1.35fr_0.95fr] lg:tw:items-center">
+            <div>
+              <Text
+                className="tw:mb-3 tw:inline-flex tw:rounded-full tw:px-3 tw:py-1"
+                style={{
+                  backgroundColor: 'rgba(255,255,255,0.16)',
+                  color: colors.white,
+                  fontWeight: typography.fontWeight.medium,
+                }}
+              >
+                {content.eyebrow}
+              </Text>
+              <Title
+                order={1}
+                style={{
+                  fontSize: 'clamp(2rem, 4vw, 3.4rem)',
+                  lineHeight: 1.05,
+                  color: colors.white,
+                  marginBottom: spacing.md,
+                }}
+              >
+                {content.title}
+              </Title>
+              <Text
+                size="lg"
+                style={{
+                  color: 'rgba(255,255,255,0.92)',
+                  maxWidth: '52rem',
+                  lineHeight: 1.65,
+                  marginBottom: spacing.xl,
+                }}
+              >
+                {content.subtitle}
+              </Text>
+              <Group className="tw:flex-wrap tw:gap-3">
+                <Button
+                  size="lg"
+                  className="tw:bg-white tw:text-primary-700 hover:tw:bg-white/90"
+                  onClick={() => nav.push(`/${countryId}/households/create?scope=household`)}
+                >
+                  {content.householdCta}
+                  <IconArrowRight size={18} />
+                </Button>
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="tw:border-white/60 tw:bg-white/10 tw:text-white hover:tw:bg-white/20"
+                  onClick={() => nav.push(`/${countryId}/reports/create`)}
+                >
+                  {content.reportCta}
+                </Button>
+                <Button
+                  size="lg"
+                  variant="ghost"
+                  className="tw:text-white hover:tw:bg-white/12"
+                  onClick={() => nav.push(`/${countryId}/reports`)}
+                >
+                  Open saved work
+                </Button>
+              </Group>
+              <Text
+                className="tw:mt-5"
+                style={{ color: 'rgba(255,255,255,0.85)', maxWidth: '46rem', lineHeight: 1.6 }}
+              >
+                {content.explainer}
+              </Text>
+            </div>
+
+            <div className="tw:grid tw:gap-4">
+              <div
+                className="tw:rounded-2xl tw:border tw:border-white/45 tw:bg-white/12 tw:p-6 tw:backdrop-blur"
+                style={{ color: colors.white }}
+              >
+                <Text
+                  className="tw:mb-2"
+                  style={{
+                    color: 'rgba(255,255,255,0.8)',
+                    fontWeight: typography.fontWeight.medium,
+                  }}
+                >
+                  What you can inspect
+                </Text>
+                <ul className="tw:m-0 tw:flex tw:list-none tw:flex-col tw:gap-3 tw:p-0">
+                  {content.outputs.map((output) => (
+                    <li key={output} className="tw:flex tw:items-start tw:gap-3">
+                      <div
+                        className="tw:mt-1 tw:h-2.5 tw:w-2.5 tw:shrink-0 tw:rounded-full"
+                        style={{ backgroundColor: colors.white }}
+                      />
+                      <Text style={{ color: colors.white, lineHeight: 1.5 }}>{output}</Text>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="tw:rounded-2xl tw:border tw:border-white/45 tw:bg-gray-950/20 tw:p-6 tw:backdrop-blur">
+                <Text
+                  className="tw:mb-2"
+                  style={{
+                    color: 'rgba(255,255,255,0.8)',
+                    fontWeight: typography.fontWeight.medium,
+                  }}
+                >
+                  Good launch posture
+                </Text>
+                <Text style={{ color: colors.white, lineHeight: 1.7 }}>
+                  Clear household entry, shareable report links, and a separate saved-work area so
+                  first-time visitors do not land on an empty internal screen.
+                </Text>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="tw:grid tw:grid-cols-1 tw:gap-5 lg:tw:grid-cols-3">
+          <FeatureCard
+            icon={<IconHome size={22} />}
+            title="Household calculations"
+            description={content.householdDescription}
+          />
+          <FeatureCard
+            icon={<IconScale size={22} />}
+            title="Population-wide reports"
+            description={content.reportDescription}
+          />
+          <FeatureCard
+            icon={<IconShare3 size={22} />}
+            title="Sharing and reproducibility"
+            description="Copy a share link for report output, keep local saved work for iteration, and jump to the Python reproduction view when you need exact implementation details."
+          />
+        </section>
+
+        <section className="tw:grid tw:grid-cols-1 tw:gap-5 lg:tw:grid-cols-[1.25fr_0.75fr]">
+          <div
+            className="tw:rounded-2xl tw:border tw:bg-white tw:p-6"
+            style={{
+              borderColor: colors.border.light,
+              boxShadow: `0 14px 42px ${colors.shadow.light}`,
+            }}
+          >
+            <Title
+              order={2}
+              style={{
+                fontSize: typography.fontSize.xl,
+                fontWeight: typography.fontWeight.semibold,
+                color: colors.text.title,
+                marginBottom: spacing.sm,
+              }}
+            >
+              Recommended first steps
+            </Title>
+            <ol className="tw:m-0 tw:flex tw:list-decimal tw:flex-col tw:gap-3 tw:pl-5">
+              <li>
+                <Text style={{ color: colors.text.secondary, lineHeight: 1.6 }}>
+                  Start with a household calculation if you want an immediate answer for one family
+                  or individual.
+                </Text>
+              </li>
+              <li>
+                <Text style={{ color: colors.text.secondary, lineHeight: 1.6 }}>
+                  Build a population report if you want national, state, or district-level poverty
+                  and budget effects.
+                </Text>
+              </li>
+              <li>
+                <Text style={{ color: colors.text.secondary, lineHeight: 1.6 }}>
+                  Use saved work for iteration and share links only once the output is ready to
+                  send.
+                </Text>
+              </li>
+            </ol>
+          </div>
+
+          <div
+            className="tw:rounded-2xl tw:border tw:bg-white tw:p-6"
+            style={{
+              borderColor: colors.border.light,
+              boxShadow: `0 14px 42px ${colors.shadow.light}`,
+            }}
+          >
+            <Title
+              order={2}
+              style={{
+                fontSize: typography.fontSize.xl,
+                fontWeight: typography.fontWeight.semibold,
+                color: colors.text.title,
+                marginBottom: spacing.sm,
+              }}
+            >
+              Learn more
+            </Title>
+            <Stack gap="sm">
+              <a
+                href={`${WEBSITE_URL}/${countryId}/research`}
+                target="_blank"
+                rel="noreferrer"
+                className="tw:rounded-xl tw:border tw:px-4 tw:py-3 tw:no-underline"
+                style={{ borderColor: colors.border.light, color: colors.text.title }}
+              >
+                Research and methodology
+              </a>
+              <a
+                href={`${WEBSITE_URL}/${countryId}/model`}
+                target="_blank"
+                rel="noreferrer"
+                className="tw:rounded-xl tw:border tw:px-4 tw:py-3 tw:no-underline"
+                style={{ borderColor: colors.border.light, color: colors.text.title }}
+              >
+                Model explorer
+              </a>
+              <a
+                href={`${WEBSITE_URL}/${countryId}/api`}
+                target="_blank"
+                rel="noreferrer"
+                className="tw:rounded-xl tw:border tw:px-4 tw:py-3 tw:no-underline"
+                style={{ borderColor: colors.border.light, color: colors.text.title }}
+              >
+                API documentation
+              </a>
+            </Stack>
+          </div>
+        </section>
+      </Stack>
+    </Container>
+  );
+}

--- a/app/src/components/calculator/CalculatorLaunchPage.tsx
+++ b/app/src/components/calculator/CalculatorLaunchPage.tsx
@@ -4,23 +4,42 @@ import { WEBSITE_URL } from '@/constants';
 import { useAppNavigate } from '@/contexts/NavigationContext';
 import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import type { CountryId } from '@/libs/countries';
 
 type SupportedCountry = 'us' | 'uk';
+type LaunchContent = {
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  householdCta: string;
+  reportCta: string;
+  householdDescription: string;
+  reportDescription: string;
+  outputs: string[];
+  explainer: string;
+};
 
-const LAUNCH_CONTENT: Record<
-  SupportedCountry,
-  {
-    eyebrow: string;
-    title: string;
-    subtitle: string;
-    householdCta: string;
-    reportCta: string;
-    householdDescription: string;
-    reportDescription: string;
-    outputs: string[];
-    explainer: string;
-  }
-> = {
+const DEFAULT_LAUNCH_CONTENT: LaunchContent = {
+  eyebrow: 'Household and policy analysis',
+  title: 'Run household calculations and policy reports',
+  subtitle:
+    'Model a custom household, compare current law to reforms, and inspect income, taxes, benefits, and poverty impacts in one place.',
+  householdCta: 'Start household calculation',
+  reportCta: 'Build population report',
+  householdDescription:
+    'Check a household against current policy or a reform without starting from the full report workflow.',
+  reportDescription:
+    'Generate national or regional analyses for distribution, budget, and poverty impacts.',
+  outputs: [
+    'Household disposable income',
+    'Tax and benefit changes',
+    'Shareable and reproducible results',
+  ],
+  explainer:
+    'Saved work stays in this browser unless you create a share link, so first-run users can start immediately without an account.',
+};
+
+const LAUNCH_CONTENT: Record<SupportedCountry, LaunchContent> = {
   us: {
     eyebrow: 'Poverty and household policy analysis',
     title: 'Run Supplemental Poverty Measure calculations and policy reports',
@@ -61,6 +80,10 @@ const LAUNCH_CONTENT: Record<
   },
 };
 
+export function getLaunchContent(countryId: CountryId): LaunchContent {
+  return LAUNCH_CONTENT[countryId as SupportedCountry] ?? DEFAULT_LAUNCH_CONTENT;
+}
+
 function FeatureCard({
   icon,
   title,
@@ -82,7 +105,7 @@ function FeatureCard({
         {icon}
       </div>
       <Title
-        order={3}
+        order={2}
         style={{
           fontSize: typography.fontSize.xl,
           fontWeight: typography.fontWeight.semibold,
@@ -98,9 +121,9 @@ function FeatureCard({
 }
 
 export default function CalculatorLaunchPage() {
-  const countryId = useCurrentCountry() as SupportedCountry;
+  const countryId = useCurrentCountry();
   const nav = useAppNavigate();
-  const content = LAUNCH_CONTENT[countryId] ?? LAUNCH_CONTENT.us;
+  const content = getLaunchContent(countryId);
 
   return (
     <Container size="xl" className="tw:px-xl">
@@ -262,7 +285,7 @@ export default function CalculatorLaunchPage() {
             }}
           >
             <Title
-              order={2}
+              order={3}
               style={{
                 fontSize: typography.fontSize.xl,
                 fontWeight: typography.fontWeight.semibold,
@@ -302,7 +325,7 @@ export default function CalculatorLaunchPage() {
             }}
           >
             <Title
-              order={2}
+              order={3}
               style={{
                 fontSize: typography.fontSize.xl,
                 fontWeight: typography.fontWeight.semibold,

--- a/app/src/pages/ReportBuilder.page.tsx
+++ b/app/src/pages/ReportBuilder.page.tsx
@@ -163,14 +163,14 @@ const INGREDIENT_COLORS = {
     icon: colors.primary[600],
     bg: colors.primary[50],
     border: colors.primary[200],
-    accent: colors.primary[500],
+    accent: colors.primary[600],
   },
   dynamics: {
     // Muted gray-green for dynamics (distinct from teal and slate)
     icon: colors.gray[500],
     bg: colors.gray[50],
     border: colors.gray[200],
-    accent: colors.gray[400],
+    accent: colors.gray[500],
   },
 };
 
@@ -1200,7 +1200,7 @@ function SimulationBlock({
 
         <Group gap="xs">
           {isRequired && (
-            <Text c="dimmed" style={{ fontStyle: 'italic', fontSize: FONT_SIZES.small }}>
+            <Text style={{ fontStyle: 'italic', fontSize: FONT_SIZES.small, color: colors.gray[600] }}>
               Required
             </Text>
           )}
@@ -1601,11 +1601,11 @@ function IngredientPickerModal({
                                 {/* Header row */}
                                 <Text
                                   fw={600}
-                                  c="dimmed"
                                   style={{
                                     fontSize: FONT_SIZES.tiny,
                                     textTransform: 'uppercase',
                                     letterSpacing: '0.05em',
+                                    color: colors.gray[600],
                                     padding: spacing.md,
                                     paddingBottom: spacing.xs,
                                     borderBottom: `1px solid ${colors.gray[200]}`,
@@ -1615,12 +1615,12 @@ function IngredientPickerModal({
                                 </Text>
                                 <Text
                                   fw={600}
-                                  c="dimmed"
                                   style={{
                                     fontSize: FONT_SIZES.tiny,
                                     textTransform: 'uppercase',
                                     letterSpacing: '0.05em',
                                     textAlign: 'right',
+                                    color: colors.gray[600],
                                     padding: spacing.md,
                                     paddingBottom: spacing.xs,
                                     borderBottom: `1px solid ${colors.gray[200]}`,
@@ -2766,7 +2766,7 @@ function PolicyBrowseModal({ isOpen, onClose, onSelect }: PolicyBrowseModalProps
                               </Text>
                             </>
                           ) : (
-                            <Text style={{ fontSize: FONT_SIZES.small, color: colors.gray[400] }}>
+                            <Text style={{ fontSize: FONT_SIZES.small, color: colors.gray[500] }}>
                               No changes yet
                             </Text>
                           )}
@@ -4264,7 +4264,7 @@ function PopulationBrowseModal({
                               </Text>
                             </>
                           ) : (
-                            <Text style={{ fontSize: FONT_SIZES.small, color: colors.gray[400] }}>
+                            <Text style={{ fontSize: FONT_SIZES.small, color: colors.gray[500] }}>
                               No members yet
                             </Text>
                           )}
@@ -5518,12 +5518,12 @@ function ReportMetaPanel({
             {/* Ready message */}
             {isReportConfigured && (
               <Group gap="xs" justify="center" style={{ marginTop: spacing.xs }}>
-                <IconCircleCheck size={14} color={colors.primary[500]} />
+                <IconCircleCheck size={14} color={colors.primary[600]} />
                 <Text
                   style={{
                     fontFamily: typography.fontFamily.primary,
                     fontSize: FONT_SIZES.small,
-                    color: colors.primary[500],
+                    color: colors.primary[600],
                   }}
                 >
                   Ready to run your analysis

--- a/app/src/pages/Reports.page.tsx
+++ b/app/src/pages/Reports.page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { IconSettings } from '@tabler/icons-react';
+import { IconArrowRight, IconSettings } from '@tabler/icons-react';
 import { useSelector } from 'react-redux';
 import {
   BulletsValue,
@@ -12,9 +12,10 @@ import { RenameIngredientModal } from '@/components/common/RenameIngredientModal
 import IngredientReadView from '@/components/IngredientReadView';
 import { MultiSimOutputTypeCell } from '@/components/report/MultiSimReportOutputTypeCell';
 import { ReportOutputTypeCell } from '@/components/report/ReportOutputTypeCell';
-import { Stack } from '@/components/ui';
+import { Button, Group, Stack, Text, Title } from '@/components/ui';
 import { MOCK_USER_ID } from '@/constants';
 import { useAppNavigate } from '@/contexts/NavigationContext';
+import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import { useDisclosure } from '@/hooks/useDisclosure';
 import { useUpdateReportAssociation } from '@/hooks/useUserReportAssociations';
@@ -49,6 +50,10 @@ export default function ReportsPage() {
   const handleBuildReport = () => {
     const targetPath = `/${countryId}/reports/create`;
     nav.push(targetPath);
+  };
+
+  const handleBuildHousehold = () => {
+    nav.push(`/${countryId}/households/create?scope=household`);
   };
 
   const handleCloseRename = () => {
@@ -205,13 +210,46 @@ export default function ReportsPage() {
     [data, countryId, currentLawId]
   );
 
+  const emptyState = (
+    <Stack className="tw:items-center tw:text-center" gap="md">
+      <Title
+        order={3}
+        style={{
+          fontSize: typography.fontSize.xl,
+          fontWeight: typography.fontWeight.semibold,
+          color: colors.text.title,
+        }}
+      >
+        No saved analyses yet
+      </Title>
+      <Text style={{ color: colors.text.secondary, maxWidth: '38rem', lineHeight: 1.65 }}>
+        Start with a household calculation if you want an immediate answer for one family, or build
+        a population-wide report for national, state, or district analysis.
+      </Text>
+      <Group className="tw:flex-wrap tw:justify-center" style={{ marginTop: spacing.sm }}>
+        <Button onClick={handleBuildHousehold}>
+          Start household calculation
+          <IconArrowRight size={16} />
+        </Button>
+        <Button variant="outline" onClick={handleBuildReport}>
+          Build population report
+        </Button>
+      </Group>
+      <Text size="sm" style={{ color: colors.text.secondary }}>
+        Saved work stays in this browser unless you create a share link from report output.
+      </Text>
+    </Stack>
+  );
+
   return (
     <>
       <Stack gap="md">
         <IngredientReadView
           ingredient="report"
-          title="Your saved reports"
-          subtitle="Generate comprehensive impact analyses comparing tax policy scenarios. Reports show distributional effects, budget impacts, and poverty outcomes across demographics"
+          title="Saved analyses"
+          subtitle="Build household calculations and population-wide reports for poverty, net income, taxes, and benefit impacts."
+          buttonLabel="New analysis"
+          emptyState={emptyState}
           onBuild={handleBuildReport}
           isLoading={isLoading}
           isError={isError}

--- a/app/src/pathways/population/PopulationPathwayWrapper.tsx
+++ b/app/src/pathways/population/PopulationPathwayWrapper.tsx
@@ -5,10 +5,11 @@
  * Reuses shared views from the report pathway with mode="standalone".
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import StandardLayout from '@/components/StandardLayout';
 import { CURRENT_YEAR } from '@/constants';
+import { useAppLocation } from '@/contexts/LocationContext';
 import { useAppNavigate } from '@/contexts/NavigationContext';
 import { ReportYearProvider } from '@/contexts/ReportYearContext';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
@@ -24,6 +25,7 @@ import HouseholdBuilderView from '../report/views/population/HouseholdBuilderVie
 import PopulationLabelView from '../report/views/population/PopulationLabelView';
 // Population views (reusing from report pathway)
 import PopulationScopeView from '../report/views/population/PopulationScopeView';
+import { getPopulationLaunchPrefill } from './launchPrefill';
 
 interface PopulationPathwayWrapperProps {
   onComplete?: () => void;
@@ -32,6 +34,8 @@ interface PopulationPathwayWrapperProps {
 export default function PopulationPathwayWrapper({ onComplete }: PopulationPathwayWrapperProps) {
   const countryId = useCurrentCountry();
   const nav = useAppNavigate();
+  const location = useAppLocation();
+  const hasAppliedLaunchPrefill = useRef(false);
 
   const handleCancel = useCallback(() => {
     nav.push(`/${countryId}/households`);
@@ -82,6 +86,19 @@ export default function PopulationPathwayWrapper({ onComplete }: PopulationPathw
       nav.push(`/${countryId}/households`);
     }
   }, [isValidMode, currentMode, nav, countryId]);
+
+  useEffect(() => {
+    if (hasAppliedLaunchPrefill.current || currentMode !== StandalonePopulationViewMode.SCOPE) {
+      return;
+    }
+
+    if (getPopulationLaunchPrefill(location.search) !== 'household') {
+      return;
+    }
+
+    hasAppliedLaunchPrefill.current = true;
+    populationCallbacks.handleScopeSelected(null, 'household');
+  }, [currentMode, location.search, populationCallbacks]);
 
   // ========== VIEW RENDERING ==========
   let currentView: React.ReactElement;

--- a/app/src/pathways/population/launchPrefill.ts
+++ b/app/src/pathways/population/launchPrefill.ts
@@ -1,0 +1,17 @@
+export type PopulationLaunchPrefill = 'household' | null;
+
+/**
+ * Parse standalone population launch parameters from the current query string.
+ * We support both `scope=household` and `scope=custom-household` for shareable
+ * links and future routing cleanup.
+ */
+export function getPopulationLaunchPrefill(search: string): PopulationLaunchPrefill {
+  const params = new URLSearchParams(search);
+  const scope = params.get('scope');
+
+  if (scope === 'household' || scope === 'custom-household') {
+    return 'household';
+  }
+
+  return null;
+}

--- a/app/src/tests/unit/components/IngredientReadView.test.tsx
+++ b/app/src/tests/unit/components/IngredientReadView.test.tsx
@@ -46,6 +46,40 @@ describe('IngredientReadView', () => {
     expect(screen.getByText(/no policy found/i)).toBeInTheDocument();
   });
 
+  test('given custom empty state then renders it instead of the default message', () => {
+    render(
+      <IngredientReadView
+        ingredient={MOCK_INGREDIENT.NAME}
+        title={MOCK_INGREDIENT.TITLE}
+        subtitle={MOCK_INGREDIENT.SUBTITLE}
+        emptyState={<div>Start by creating your first analysis.</div>}
+        isLoading={false}
+        isError={false}
+        data={EMPTY_DATA}
+        columns={MOCK_COLUMNS}
+      />
+    );
+
+    expect(screen.getByText(/start by creating your first analysis/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no policy found/i)).not.toBeInTheDocument();
+  });
+
+  test('given title then renders it only once', () => {
+    render(
+      <IngredientReadView
+        ingredient={MOCK_INGREDIENT.NAME}
+        title={MOCK_INGREDIENT.TITLE}
+        subtitle={MOCK_INGREDIENT.SUBTITLE}
+        isLoading={false}
+        isError={false}
+        data={MOCK_DATA}
+        columns={MOCK_COLUMNS}
+      />
+    );
+
+    expect(screen.getAllByText(MOCK_INGREDIENT.TITLE)).toHaveLength(1);
+  });
+
   test('given loading state then displays loader', () => {
     // When
     render(

--- a/app/src/tests/unit/components/calculator/CalculatorLaunchPage.test.tsx
+++ b/app/src/tests/unit/components/calculator/CalculatorLaunchPage.test.tsx
@@ -1,0 +1,26 @@
+import { renderWithCountry, screen } from '@test-utils';
+import { describe, expect, test } from 'vitest';
+import CalculatorLaunchPage from '@/components/calculator/CalculatorLaunchPage';
+
+describe('CalculatorLaunchPage', () => {
+  test('given US country then renders SPM-specific launch copy', () => {
+    renderWithCountry(<CalculatorLaunchPage />, 'us', '/us', 'calculator');
+
+    expect(
+      screen.getByRole('heading', {
+        name: /run supplemental poverty measure calculations and policy reports/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  test('given non-US or UK country then renders generic launch copy', () => {
+    renderWithCountry(<CalculatorLaunchPage />, 'ca', '/ca', 'calculator');
+
+    expect(
+      screen.getByRole('heading', {
+        name: /run household calculations and policy reports/i,
+      })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/supplemental poverty measure/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/src/tests/unit/pages/Populations.page.test.tsx
+++ b/app/src/tests/unit/pages/Populations.page.test.tsx
@@ -92,7 +92,7 @@ describe('PopulationsPage', () => {
 
       // Then
       expect(
-        screen.getByRole('heading', { name: 'Your saved households', level: 2 })
+        screen.getByRole('heading', { name: 'Your saved households', level: 1 })
       ).toBeInTheDocument();
       expect(screen.getByText(POPULATION_LABELS.PAGE_SUBTITLE)).toBeInTheDocument();
     });
@@ -445,7 +445,7 @@ describe('PopulationsPage', () => {
       // Then
       // The component should render successfully without connections column
       expect(
-        screen.getByRole('heading', { name: 'Your saved households', level: 2 })
+        screen.getByRole('heading', { name: 'Your saved households', level: 1 })
       ).toBeInTheDocument();
       // Verify data is displayed correctly
       expect(screen.getByText(POPULATION_LABELS.HOUSEHOLD_1)).toBeInTheDocument();

--- a/app/src/tests/unit/pages/Reports.page.test.tsx
+++ b/app/src/tests/unit/pages/Reports.page.test.tsx
@@ -119,8 +119,10 @@ describe('ReportsPage', () => {
     render(<ReportsPage />);
 
     // Then
-    expect(screen.getByText('Your saved reports')).toBeInTheDocument();
-    expect(screen.getByText(/Generate comprehensive impact analyses/)).toBeInTheDocument();
+    expect(screen.getByText('Saved analyses')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Build household calculations and population-wide reports/i)
+    ).toBeInTheDocument();
     expect(screen.getByText('Data count: 2')).toBeInTheDocument();
   });
 

--- a/app/src/tests/unit/pathways/population/launchPrefill.test.ts
+++ b/app/src/tests/unit/pathways/population/launchPrefill.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+import { getPopulationLaunchPrefill } from '@/pathways/population/launchPrefill';
+
+describe('getPopulationLaunchPrefill', () => {
+  test('given household scope then returns household prefill', () => {
+    expect(getPopulationLaunchPrefill('?scope=household')).toBe('household');
+  });
+
+  test('given custom-household scope then returns household prefill', () => {
+    expect(getPopulationLaunchPrefill('?scope=custom-household')).toBe('household');
+  });
+
+  test('given unrelated query then returns null', () => {
+    expect(getPopulationLaunchPrefill('?scope=national')).toBeNull();
+    expect(getPopulationLaunchPrefill('?view=reports')).toBeNull();
+    expect(getPopulationLaunchPrefill('')).toBeNull();
+  });
+});

--- a/calculator-app/src/app/[countryId]/page.tsx
+++ b/calculator-app/src/app/[countryId]/page.tsx
@@ -1,23 +1,15 @@
 "use client";
 
-import { use, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import StandardLayout from "@/components/StandardLayout";
+import CalculatorLaunchPage from "@/components/calculator/CalculatorLaunchPage";
+import { CalculatorProviders } from "./providers";
 
-/**
- * Country index route — redirects to /:countryId/reports.
- * Mirrors the React Router <Navigate to="reports" replace />.
- */
-export default function CountryIndexRoute({
-  params,
-}: {
-  params: Promise<{ countryId: string }>;
-}) {
-  const { countryId } = use(params);
-  const router = useRouter();
-
-  useEffect(() => {
-    router.replace(`/${countryId}/reports`);
-  }, [router, countryId]);
-
-  return null;
+export default function CountryIndexRoute() {
+  return (
+    <CalculatorProviders>
+      <StandardLayout>
+        <CalculatorLaunchPage />
+      </StandardLayout>
+    </CalculatorProviders>
+  );
 }

--- a/calculator-app/src/app/layout.tsx
+++ b/calculator-app/src/app/layout.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "PolicyEngine Calculator",
+  title: "PolicyEngine Poverty Calculator",
   description:
-    "Calculate your taxes and benefits, create policy simulations, and analyze reform impacts.",
+    "Run household poverty calculations, build policy reports, and analyze taxes, benefits, and reform impacts.",
 };
 
 export default function RootLayout({

--- a/calculator-app/src/app/page.tsx
+++ b/calculator-app/src/app/page.tsx
@@ -7,7 +7,7 @@ import { countryIds } from "@/libs/countries";
 import { geolocationService } from "@/routing/geolocation/GeolocationService";
 
 /**
- * Root page — redirects to /:countryId/reports based on IP geolocation.
+ * Root page — redirects to /:countryId based on IP geolocation.
  * Mirrors app/src/routing/RedirectToCountry.tsx for the Next.js app.
  */
 export default function RootPage() {
@@ -17,17 +17,20 @@ export default function RootPage() {
     async function detect() {
       const cached = getCachedCountry();
       if (cached) {
-        router.replace(`/${cached}/reports`);
+        router.replace(`/${cached}`);
         return;
       }
 
       try {
         const country = await geolocationService.detectCountry();
         cacheCountry(country);
-        router.replace(`/${country}/reports`);
+        router.replace(`/${country}`);
       } catch (error) {
-        console.warn("[RootPage] Geolocation failed, falling back to US:", error);
-        router.replace("/us/reports");
+        console.warn(
+          "[RootPage] Geolocation failed, falling back to US:",
+          error,
+        );
+        router.replace("/us");
       }
     }
 
@@ -37,7 +40,7 @@ export default function RootPage() {
   return (
     <div className="tw:flex tw:flex-col tw:items-center tw:justify-center tw:h-screen tw:gap-4">
       <Spinner size="lg" />
-      <div>Loading PolicyEngine...</div>
+      <div>Opening PolicyEngine...</div>
     </div>
   );
 }
@@ -54,7 +57,10 @@ function getCachedCountry(): string | null {
       if (countryIds.includes(country)) {
         return country;
       }
-      console.warn("[RootPage] Cached country is not a valid country ID:", country);
+      console.warn(
+        "[RootPage] Cached country is not a valid country ID:",
+        country,
+      );
     }
     localStorage.removeItem("detectedCountry");
   } catch (error) {

--- a/website/src/__tests__/components/header.test.tsx
+++ b/website/src/__tests__/components/header.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/us"),
+  useRouter: vi.fn(() => ({ push: pushMock, replace: replaceMock })),
+}));
+
+import Header from "@/components/Header";
+
+describe("Header", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    replaceMock.mockReset();
+  });
+
+  test("keeps the mobile menu out of the DOM until it is opened", () => {
+    render(<Header />);
+
+    const openButton = screen.getByRole("button", { name: "Open menu" });
+    expect(openButton).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Menu")).not.toBeInTheDocument();
+
+    fireEvent.click(openButton);
+
+    expect(screen.getByText("Menu")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close menu" })).toBeInTheDocument();
+  });
+});

--- a/website/src/__tests__/pages/research-client.test.tsx
+++ b/website/src/__tests__/pages/research-client.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const replaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/us/research"),
+  useRouter: vi.fn(() => ({ replace: replaceMock })),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock("@/components/blog/useDisplayCategory", () => ({
+  useDisplayCategory: vi.fn(() => "desktop"),
+}));
+
+vi.mock("@/hooks/useInfiniteScroll", () => ({
+  useInfiniteScroll: vi.fn(() => ({
+    visibleCount: 8,
+    sentinelRef: { current: null },
+    hasMore: false,
+    reset: vi.fn(),
+  })),
+}));
+
+import ResearchClient from "@/app/[countryId]/research/ResearchClient";
+
+describe("ResearchClient", () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+  });
+
+  test("exposes labeled filter checkboxes and updates the query string when toggled", async () => {
+    render(<ResearchClient countryId="us" />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalled();
+    });
+    replaceMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Type" }));
+
+    const articleCheckbox = screen.getByRole("checkbox", { name: "Article" });
+    expect(articleCheckbox).toBeInTheDocument();
+
+    fireEvent.click(articleCheckbox);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith(
+        expect.stringContaining("types=article"),
+        { scroll: false },
+      );
+    });
+  });
+});

--- a/website/src/app/[countryId]/research/ResearchClient.tsx
+++ b/website/src/app/[countryId]/research/ResearchClient.tsx
@@ -455,7 +455,7 @@ function FilterSection({
                 minWidth: "20px",
                 height: "20px",
                 borderRadius: "10px",
-                backgroundColor: colors.primary[500],
+                backgroundColor: colors.primary[600],
                 color: colors.white,
                 fontSize: "11px",
                 fontWeight: typography.fontWeight.bold,
@@ -511,12 +511,11 @@ function CheckboxRow({
   onChange: () => void;
   indented?: boolean;
 }) {
+  const labelId = `${id}-label`;
+
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onChange}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onChange(); } }}
+    <label
+      htmlFor={id}
       style={{
         display: "flex",
         alignItems: "center",
@@ -527,9 +526,7 @@ function CheckboxRow({
         transition: "background-color 0.1s ease",
         cursor: "pointer",
         background: "transparent",
-        border: "none",
         width: "100%",
-        textAlign: "left",
       }}
       onMouseEnter={(e) => {
         e.currentTarget.style.backgroundColor = colors.gray[50];
@@ -541,11 +538,11 @@ function CheckboxRow({
       <Checkbox
         id={id}
         checked={checked}
-        tabIndex={-1}
-        onCheckedChange={onChange}
-        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        aria-labelledby={labelId}
+        onCheckedChange={() => onChange()}
       />
       <span
+        id={labelId}
         style={{
           fontSize: "13.5px",
           fontFamily: typography.fontFamily.primary,
@@ -559,7 +556,7 @@ function CheckboxRow({
       >
         {label}
       </span>
-    </div>
+    </label>
   );
 }
 

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -440,11 +440,9 @@ function MobileNavLink({ item, onClose }: { item: NavItemSetup; onClose: () => v
 }
 
 function MobileMenu({
-  open,
   onClose,
   navItems,
 }: {
-  open: boolean;
   onClose: () => void;
   navItems: NavItemSetup[];
 }) {
@@ -456,7 +454,6 @@ function MobileMenu({
         zIndex: 2000,
         display: "flex",
         justifyContent: "flex-end",
-        pointerEvents: open ? "auto" : "none",
       }}
     >
       {/* Backdrop */}
@@ -466,8 +463,6 @@ function MobileMenu({
           position: "absolute",
           inset: 0,
           backgroundColor: "rgba(0,0,0,0.4)",
-          opacity: open ? 1 : 0,
-          transition: "opacity 0.3s ease",
         }}
       />
       {/* Panel */}
@@ -481,8 +476,6 @@ function MobileMenu({
           display: "flex",
           flexDirection: "column",
           gap: spacing.lg,
-          transform: open ? "translateX(0)" : "translateX(100%)",
-          transition: "transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
         }}
       >
         <div
@@ -612,8 +605,6 @@ export default function Header() {
         fontFamily: typography.fontFamily.primary,
         width: "100%",
         boxSizing: "border-box",
-        opacity: mobileOpen ? 0 : 1,
-        transition: "opacity 0.1s ease",
       }}
     >
       <div
@@ -671,7 +662,9 @@ export default function Header() {
           <button
             type="button"
             onClick={() => setMobileOpen(true)}
-            aria-label="Toggle navigation"
+            aria-label="Open menu"
+            aria-controls="mobile-navigation"
+            aria-expanded={mobileOpen}
             style={{
               padding: "4px",
               borderRadius: "4px",
@@ -685,11 +678,11 @@ export default function Header() {
         </div>
       </div>
 
-      <MobileMenu
-        open={mobileOpen}
-        onClose={() => setMobileOpen(false)}
-        navItems={navItems}
-      />
+      {mobileOpen && (
+        <div id="mobile-navigation">
+          <MobileMenu onClose={() => setMobileOpen(false)} navItems={navItems} />
+        </div>
+      )}
     </header>
   );
 }

--- a/website/src/components/static/ActionButton.tsx
+++ b/website/src/components/static/ActionButton.tsx
@@ -40,9 +40,9 @@ export default function ActionButton({
       hoverBorder: colors.black,
     },
     secondary: {
-      backgroundColor: colors.primary[500],
+      backgroundColor: colors.primary[600],
       color: colors.white,
-      border: `2px solid ${colors.primary[500]}`,
+      border: `2px solid ${colors.primary[600]}`,
       hoverBackground: colors.primary[600],
       hoverBorder: colors.primary[600],
     },


### PR DESCRIPTION
## What changed

This PR makes the calculator behave like a launchable poverty-analysis product instead of an internal saved-reports shell.

- adds a dedicated country landing page for the calculator with SPM-focused framing and clear household/report entry points
- routes `/` to `/:countryId` instead of dropping new users directly into saved reports
- deep-links household users past the standalone scope picker with `?scope=household`
- upgrades the empty saved-analyses screen so first-time users get actionable next steps
- fixes the shared standard layout so main content uses the full viewport width on mobile instead of rendering in a narrow strip
- tightens calculator metadata around poverty and household analysis

## Why

The previous first-run experience was weak for launch:

- root users landed in an empty "saved reports" screen
- the app framed itself as a generic calculator instead of an SPM-oriented analysis tool
- the fastest household path still went through an avoidable scope step
- mobile layout had a real width bug in the shared shell

## User impact

- first-time visitors now see a real launch page with clear CTAs
- household users can get into the custom-household flow faster
- empty-state pages no longer dead-end
- mobile users can actually use the launch and saved-analysis screens without the content collapsing

## Validation

- `cd app && bun run vitest --run src/tests/unit/components/IngredientReadView.test.tsx src/tests/unit/pages/Reports.page.test.tsx src/tests/unit/pathways/population/launchPrefill.test.ts`
- `bun run --filter=@policyengine/calculator typecheck`
- `cd app && bun run typecheck`
- `bun run --filter=@policyengine/calculator build`
- manual browser verification in local Next dev server for `/`, `/us`, `/us/households/create?scope=household`, and `/us/reports` on desktop and narrow mobile viewport
