### PR TITLE
[codex] Fix audited accessibility issues on website and calculator

### DIFF
--- a/app/src/components/calculator/CalculatorLaunchPage.tsx
+++ b/app/src/components/calculator/CalculatorLaunchPage.tsx
@@ -82,7 +82,7 @@ function FeatureCard({
         {icon}
       </div>
       <Title
-        order={3}
+        order={2}
         style={{
           fontSize: typography.fontSize.xl,
           fontWeight: typography.fontWeight.semibold,
@@ -262,7 +262,7 @@ export default function CalculatorLaunchPage() {
             }}
           >
             <Title
-              order={2}
+              order={3}
               style={{
                 fontSize: typography.fontSize.xl,
                 fontWeight: typography.fontWeight.semibold,
@@ -302,7 +302,7 @@ export default function CalculatorLaunchPage() {
             }}
           >
             <Title
-              order={2}
+              order={3}
               style={{
                 fontSize: typography.fontSize.xl,
                 fontWeight: typography.fontWeight.semibold,

--- a/app/src/components/calculator/CalculatorLaunchPage.tsx
+++ b/app/src/components/calculator/CalculatorLaunchPage.tsx
@@ -4,23 +4,42 @@ import { WEBSITE_URL } from '@/constants';
 import { useAppNavigate } from '@/contexts/NavigationContext';
 import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import type { CountryId } from '@/libs/countries';
 
 type SupportedCountry = 'us' | 'uk';
+type LaunchContent = {
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  householdCta: string;
+  reportCta: string;
+  householdDescription: string;
+  reportDescription: string;
+  outputs: string[];
+  explainer: string;
+};
 
-const LAUNCH_CONTENT: Record<
-  SupportedCountry,
-  {
-    eyebrow: string;
-    title: string;
-    subtitle: string;
-    householdCta: string;
-    reportCta: string;
-    householdDescription: string;
-    reportDescription: string;
-    outputs: string[];
-    explainer: string;
-  }
-> = {
+const DEFAULT_LAUNCH_CONTENT: LaunchContent = {
+  eyebrow: 'Household and policy analysis',
+  title: 'Run household calculations and policy reports',
+  subtitle:
+    'Model a custom household, compare current law to reforms, and inspect income, taxes, benefits, and poverty impacts in one place.',
+  householdCta: 'Start household calculation',
+  reportCta: 'Build population report',
+  householdDescription:
+    'Check a household against current policy or a reform without starting from the full report workflow.',
+  reportDescription:
+    'Generate national or regional analyses for distribution, budget, and poverty impacts.',
+  outputs: [
+    'Household disposable income',
+    'Tax and benefit changes',
+    'Shareable and reproducible results',
+  ],
+  explainer:
+    'Saved work stays in this browser unless you create a share link, so first-run users can start immediately without an account.',
+};
+
+const LAUNCH_CONTENT: Record<SupportedCountry, LaunchContent> = {
   us: {
     eyebrow: 'Poverty and household policy analysis',
     title: 'Run Supplemental Poverty Measure calculations and policy reports',
@@ -61,6 +80,10 @@ const LAUNCH_CONTENT: Record<
   },
 };
 
+export function getLaunchContent(countryId: CountryId): LaunchContent {
+  return LAUNCH_CONTENT[countryId as SupportedCountry] ?? DEFAULT_LAUNCH_CONTENT;
+}
+
 function FeatureCard({
   icon,
   title,
@@ -98,9 +121,9 @@ function FeatureCard({
 }
 
 export default function CalculatorLaunchPage() {
-  const countryId = useCurrentCountry() as SupportedCountry;
+  const countryId = useCurrentCountry();
   const nav = useAppNavigate();
-  const content = LAUNCH_CONTENT[countryId] ?? LAUNCH_CONTENT.us;
+  const content = getLaunchContent(countryId);
 
   return (
     <Container size="xl" className="tw:px-xl">

--- a/app/src/pages/ReportBuilder.page.tsx
+++ b/app/src/pages/ReportBuilder.page.tsx
@@ -163,14 +163,14 @@ const INGREDIENT_COLORS = {
     icon: colors.primary[600],
     bg: colors.primary[50],
     border: colors.primary[200],
-    accent: colors.primary[500],
+    accent: colors.primary[600],
   },
   dynamics: {
     // Muted gray-green for dynamics (distinct from teal and slate)
     icon: colors.gray[500],
     bg: colors.gray[50],
     border: colors.gray[200],
-    accent: colors.gray[400],
+    accent: colors.gray[500],
   },
 };
 
@@ -1200,7 +1200,7 @@ function SimulationBlock({
 
         <Group gap="xs">
           {isRequired && (
-            <Text c="dimmed" style={{ fontStyle: 'italic', fontSize: FONT_SIZES.small }}>
+            <Text style={{ fontStyle: 'italic', fontSize: FONT_SIZES.small, color: colors.gray[600] }}>
               Required
             </Text>
           )}
@@ -1601,11 +1601,11 @@ function IngredientPickerModal({
                                 {/* Header row */}
                                 <Text
                                   fw={600}
-                                  c="dimmed"
                                   style={{
                                     fontSize: FONT_SIZES.tiny,
                                     textTransform: 'uppercase',
                                     letterSpacing: '0.05em',
+                                    color: colors.gray[600],
                                     padding: spacing.md,
                                     paddingBottom: spacing.xs,
                                     borderBottom: `1px solid ${colors.gray[200]}`,
@@ -1615,12 +1615,12 @@ function IngredientPickerModal({
                                 </Text>
                                 <Text
                                   fw={600}
-                                  c="dimmed"
                                   style={{
                                     fontSize: FONT_SIZES.tiny,
                                     textTransform: 'uppercase',
                                     letterSpacing: '0.05em',
                                     textAlign: 'right',
+                                    color: colors.gray[600],
                                     padding: spacing.md,
                                     paddingBottom: spacing.xs,
                                     borderBottom: `1px solid ${colors.gray[200]}`,
@@ -2766,7 +2766,7 @@ function PolicyBrowseModal({ isOpen, onClose, onSelect }: PolicyBrowseModalProps
                               </Text>
                             </>
                           ) : (
-                            <Text style={{ fontSize: FONT_SIZES.small, color: colors.gray[400] }}>
+                            <Text style={{ fontSize: FONT_SIZES.small, color: colors.gray[500] }}>
                               No changes yet
                             </Text>
                           )}
@@ -4264,7 +4264,7 @@ function PopulationBrowseModal({
                               </Text>
                             </>
                           ) : (
-                            <Text style={{ fontSize: FONT_SIZES.small, color: colors.gray[400] }}>
+                            <Text style={{ fontSize: FONT_SIZES.small, color: colors.gray[500] }}>
                               No members yet
                             </Text>
                           )}
@@ -5518,12 +5518,12 @@ function ReportMetaPanel({
             {/* Ready message */}
             {isReportConfigured && (
               <Group gap="xs" justify="center" style={{ marginTop: spacing.xs }}>
-                <IconCircleCheck size={14} color={colors.primary[500]} />
+                <IconCircleCheck size={14} color={colors.primary[600]} />
                 <Text
                   style={{
                     fontFamily: typography.fontFamily.primary,
                     fontSize: FONT_SIZES.small,
-                    color: colors.primary[500],
+                    color: colors.primary[600],
                   }}
                 >
                   Ready to run your analysis

--- a/app/src/tests/unit/components/calculator/CalculatorLaunchPage.test.tsx
+++ b/app/src/tests/unit/components/calculator/CalculatorLaunchPage.test.tsx
@@ -1,0 +1,26 @@
+import { renderWithCountry, screen } from '@test-utils';
+import { describe, expect, test } from 'vitest';
+import CalculatorLaunchPage from '@/components/calculator/CalculatorLaunchPage';
+
+describe('CalculatorLaunchPage', () => {
+  test('given US country then renders SPM-specific launch copy', () => {
+    renderWithCountry(<CalculatorLaunchPage />, 'us', '/us', 'calculator');
+
+    expect(
+      screen.getByRole('heading', {
+        name: /run supplemental poverty measure calculations and policy reports/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  test('given non-US or UK country then renders generic launch copy', () => {
+    renderWithCountry(<CalculatorLaunchPage />, 'ca', '/ca', 'calculator');
+
+    expect(
+      screen.getByRole('heading', {
+        name: /run household calculations and policy reports/i,
+      })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/supplemental poverty measure/i)).not.toBeInTheDocument();
+  });
+});

--- a/website/src/__tests__/components/header.test.tsx
+++ b/website/src/__tests__/components/header.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/us"),
+  useRouter: vi.fn(() => ({ push: pushMock, replace: replaceMock })),
+}));
+
+import Header from "@/components/Header";
+
+describe("Header", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    replaceMock.mockReset();
+  });
+
+  test("keeps the mobile menu out of the DOM until it is opened", () => {
+    render(<Header />);
+
+    const openButton = screen.getByRole("button", { name: "Open menu" });
+    expect(openButton).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Menu")).not.toBeInTheDocument();
+
+    fireEvent.click(openButton);
+
+    expect(screen.getByText("Menu")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close menu" })).toBeInTheDocument();
+  });
+});

--- a/website/src/__tests__/pages/research-client.test.tsx
+++ b/website/src/__tests__/pages/research-client.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const replaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/us/research"),
+  useRouter: vi.fn(() => ({ replace: replaceMock })),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock("@/components/blog/useDisplayCategory", () => ({
+  useDisplayCategory: vi.fn(() => "desktop"),
+}));
+
+vi.mock("@/hooks/useInfiniteScroll", () => ({
+  useInfiniteScroll: vi.fn(() => ({
+    visibleCount: 8,
+    sentinelRef: { current: null },
+    hasMore: false,
+    reset: vi.fn(),
+  })),
+}));
+
+import ResearchClient from "@/app/[countryId]/research/ResearchClient";
+
+describe("ResearchClient", () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+  });
+
+  test("exposes labeled filter checkboxes and updates the query string when toggled", async () => {
+    render(<ResearchClient countryId="us" />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalled();
+    });
+    replaceMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Type" }));
+
+    const articleCheckbox = screen.getByRole("checkbox", { name: "Article" });
+    expect(articleCheckbox).toBeInTheDocument();
+
+    fireEvent.click(articleCheckbox);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith(
+        expect.stringContaining("types=article"),
+        { scroll: false },
+      );
+    });
+  });
+});

--- a/website/src/app/[countryId]/research/ResearchClient.tsx
+++ b/website/src/app/[countryId]/research/ResearchClient.tsx
@@ -455,7 +455,7 @@ function FilterSection({
                 minWidth: "20px",
                 height: "20px",
                 borderRadius: "10px",
-                backgroundColor: colors.primary[500],
+                backgroundColor: colors.primary[600],
                 color: colors.white,
                 fontSize: "11px",
                 fontWeight: typography.fontWeight.bold,
@@ -511,12 +511,11 @@ function CheckboxRow({
   onChange: () => void;
   indented?: boolean;
 }) {
+  const labelId = `${id}-label`;
+
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onChange}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onChange(); } }}
+    <label
+      htmlFor={id}
       style={{
         display: "flex",
         alignItems: "center",
@@ -527,9 +526,7 @@ function CheckboxRow({
         transition: "background-color 0.1s ease",
         cursor: "pointer",
         background: "transparent",
-        border: "none",
         width: "100%",
-        textAlign: "left",
       }}
       onMouseEnter={(e) => {
         e.currentTarget.style.backgroundColor = colors.gray[50];
@@ -541,11 +538,11 @@ function CheckboxRow({
       <Checkbox
         id={id}
         checked={checked}
-        tabIndex={-1}
-        onCheckedChange={onChange}
-        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        aria-labelledby={labelId}
+        onCheckedChange={() => onChange()}
       />
       <span
+        id={labelId}
         style={{
           fontSize: "13.5px",
           fontFamily: typography.fontFamily.primary,
@@ -559,7 +556,7 @@ function CheckboxRow({
       >
         {label}
       </span>
-    </div>
+    </label>
   );
 }
 

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -440,11 +440,9 @@ function MobileNavLink({ item, onClose }: { item: NavItemSetup; onClose: () => v
 }
 
 function MobileMenu({
-  open,
   onClose,
   navItems,
 }: {
-  open: boolean;
   onClose: () => void;
   navItems: NavItemSetup[];
 }) {
@@ -456,7 +454,6 @@ function MobileMenu({
         zIndex: 2000,
         display: "flex",
         justifyContent: "flex-end",
-        pointerEvents: open ? "auto" : "none",
       }}
     >
       {/* Backdrop */}
@@ -466,8 +463,6 @@ function MobileMenu({
           position: "absolute",
           inset: 0,
           backgroundColor: "rgba(0,0,0,0.4)",
-          opacity: open ? 1 : 0,
-          transition: "opacity 0.3s ease",
         }}
       />
       {/* Panel */}
@@ -481,8 +476,6 @@ function MobileMenu({
           display: "flex",
           flexDirection: "column",
           gap: spacing.lg,
-          transform: open ? "translateX(0)" : "translateX(100%)",
-          transition: "transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
         }}
       >
         <div
@@ -612,8 +605,6 @@ export default function Header() {
         fontFamily: typography.fontFamily.primary,
         width: "100%",
         boxSizing: "border-box",
-        opacity: mobileOpen ? 0 : 1,
-        transition: "opacity 0.1s ease",
       }}
     >
       <div
@@ -671,7 +662,9 @@ export default function Header() {
           <button
             type="button"
             onClick={() => setMobileOpen(true)}
-            aria-label="Toggle navigation"
+            aria-label="Open menu"
+            aria-controls="mobile-navigation"
+            aria-expanded={mobileOpen}
             style={{
               padding: "4px",
               borderRadius: "4px",
@@ -685,11 +678,11 @@ export default function Header() {
         </div>
       </div>
 
-      <MobileMenu
-        open={mobileOpen}
-        onClose={() => setMobileOpen(false)}
-        navItems={navItems}
-      />
+      {mobileOpen && (
+        <div id="mobile-navigation">
+          <MobileMenu onClose={() => setMobileOpen(false)} navItems={navItems} />
+        </div>
+      )}
     </header>
   );
 }

--- a/website/src/components/static/ActionButton.tsx
+++ b/website/src/components/static/ActionButton.tsx
@@ -40,9 +40,9 @@ export default function ActionButton({
       hoverBorder: colors.black,
     },
     secondary: {
-      backgroundColor: colors.primary[500],
+      backgroundColor: colors.primary[600],
       color: colors.white,
-      border: `2px solid ${colors.primary[500]}`,
+      border: `2px solid ${colors.primary[600]}`,
       hoverBackground: colors.primary[600],
       hoverBorder: colors.primary[600],
     },


### PR DESCRIPTION
## Summary
- only render the mobile navigation drawer while it is open so hidden controls drop out of the tab order
- replace the research filter wrapper/button pattern with a single labeled checkbox control
- darken the audited website CTA, filter badge, and calculator/report status treatments that were below AA contrast
- repair the calculator launch page heading hierarchy so feature cards no longer skip levels

## Why
The accessibility audit found keyboard-focus leakage, unnamed checkbox semantics, contrast failures, and heading-level skips on the audited website and calculator surfaces.

## Impact
Keyboard users no longer tab into hidden menu controls, filter checkboxes are announced with labels, and the audited CTA/status treatments use stronger contrast.

## Validation
- bun run design-system:build
- bun run --filter=@policyengine/website typecheck
- bun run --filter=@policyengine/website lint
- bun run --filter=policyengine-app-v2 typecheck

Refs #951
Refs #952
Refs #953
Refs #954
Builds on #947