### PR TITLE
Add rerun support for legacy report output pages

### DIFF
--- a/app/src/api/report.ts
+++ b/app/src/api/report.ts
@@ -9,6 +9,13 @@ import { ReportCreationPayload, ReportSetOutputPayload } from '@/types/payloads'
 
 export type CountryId = (typeof countryIds)[number];
 
+export interface ReportRerunResult {
+  report_id: number;
+  report_type: 'household' | 'geography';
+  simulation_ids: number[];
+  economy_cache_rows_deleted: number;
+}
+
 export async function fetchReportById(
   countryId: (typeof countryIds)[number],
   reportId: string
@@ -66,6 +73,38 @@ export async function createReport(
 
   if (json.status !== 'ok') {
     throw new Error(json.message || 'Failed to create report');
+  }
+
+  return json.result;
+}
+
+export async function rerunReport(
+  countryId: (typeof countryIds)[number],
+  reportId: string
+): Promise<ReportRerunResult> {
+  const url = `${BASE_URL}/${countryId}/report/${reportId}/rerun`;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to rerun report ${reportId}: ${res.status} ${res.statusText}`);
+  }
+
+  let json;
+  try {
+    json = await res.json();
+  } catch (error) {
+    throw new Error(`Failed to parse report rerun response: ${error}`);
+  }
+
+  if (json.status !== 'ok') {
+    throw new Error(json.message || `Failed to rerun report ${reportId}`);
   }
 
   return json.result;

--- a/app/src/components/report/ReportActionButtons.tsx
+++ b/app/src/components/report/ReportActionButtons.tsx
@@ -1,4 +1,4 @@
-import { IconBookmark, IconCode, IconSettings } from '@tabler/icons-react';
+import { IconBookmark, IconCode, IconReload, IconSettings } from '@tabler/icons-react';
 import { ShareButton } from '@/components/common/ActionButtons';
 import { Group } from '@/components/ui';
 import { Button } from '@/components/ui/button';
@@ -6,6 +6,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 
 interface ReportActionButtonsProps {
   isSharedView: boolean;
+  isRerunning?: boolean;
+  onRerun?: () => void;
   onShare?: () => void;
   onSave?: () => void;
   onView?: () => void;
@@ -16,11 +18,13 @@ interface ReportActionButtonsProps {
  * ReportActionButtons - Action buttons for report output header
  *
  * Renders different buttons based on view type:
- * - Normal view: Reproduce + View/edit + Share buttons
+ * - Normal view: Rerun + Reproduce + View/edit + Share buttons
  * - Shared view: Save button with tooltip
  */
 export function ReportActionButtons({
   isSharedView,
+  isRerunning = false,
+  onRerun,
   onShare,
   onSave,
   onView,
@@ -46,6 +50,22 @@ export function ReportActionButtons({
 
   return (
     <Group gap="xs" className="tw:ml-1.5">
+      {onRerun && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Rerun report"
+              onClick={onRerun}
+              disabled={isRerunning}
+            >
+              <IconReload size={18} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Rerun report</TooltipContent>
+        </Tooltip>
+      )}
       <Tooltip>
         <TooltipTrigger asChild>
           <Button variant="ghost" size="icon" aria-label="View/edit report" onClick={onView}>

--- a/app/src/hooks/useCalculationStatus.ts
+++ b/app/src/hooks/useCalculationStatus.ts
@@ -8,6 +8,25 @@ import {
 } from './useAggregatedCalculationStatus';
 import { useSyntheticProgress } from './useSyntheticProgress';
 
+function createInitializingStatus(
+  calcId: string,
+  targetType: 'report' | 'simulation'
+): CalcStatus {
+  return {
+    status: 'initializing',
+    metadata: {
+      calcId,
+      targetType,
+      calcType: targetType === 'report' ? 'societyWide' : 'household',
+      startedAt: Date.now(),
+    },
+  };
+}
+
+function queryKeysEqual(a: readonly unknown[], b: readonly unknown[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
 /**
  * Internal hook to read single calculation status from cache
  * Subscribes to calculation query updates via QueryObserver
@@ -39,15 +58,7 @@ function useSingleCalculationStatus(calcId: string, targetType: 'report' | 'simu
       return cached;
     }
 
-    return {
-      status: 'initializing' as const,
-      metadata: {
-        calcId,
-        targetType,
-        calcType: 'societyWide' as const,
-        startedAt: Date.now(),
-      },
-    };
+    return createInitializingStatus(calcId, targetType);
   });
 
   const [isLoading, setIsLoading] = useState(false);
@@ -67,6 +78,8 @@ function useSingleCalculationStatus(calcId: string, targetType: 'report' | 'simu
     const unsubscribe = observer.subscribe((result) => {
       if (result.data) {
         setStatus(result.data);
+      } else {
+        setStatus(createInitializingStatus(calcId, targetType));
       }
       setIsLoading(result.isLoading);
     });
@@ -75,10 +88,26 @@ function useSingleCalculationStatus(calcId: string, targetType: 'report' | 'simu
     const current = queryClient.getQueryData<CalcStatus>(queryKey);
     if (current) {
       setStatus(current);
+    } else {
+      setStatus(createInitializingStatus(calcId, targetType));
     }
+
+    const unsubscribeQueryCache = queryClient.getQueryCache().subscribe((event) => {
+      if (!event || event.type !== 'removed') {
+        return;
+      }
+
+      if (!queryKeysEqual(event.query.queryKey, queryKey)) {
+        return;
+      }
+
+      setStatus(createInitializingStatus(calcId, targetType));
+      setIsLoading(false);
+    });
 
     return () => {
       unsubscribe();
+      unsubscribeQueryCache();
     };
   }, [queryClient, queryKey, calcId]);
 

--- a/app/src/hooks/useRerunReport.ts
+++ b/app/src/hooks/useRerunReport.ts
@@ -2,6 +2,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { rerunReport, type ReportRerunResult } from '@/api/report';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import { calculationKeys, reportKeys, simulationKeys } from '@/libs/queryKeys';
+import type { Report } from '@/types/ingredients/Report';
+import type { Simulation } from '@/types/ingredients/Simulation';
 
 export interface RerunReportParams {
   reportId: string;
@@ -10,6 +12,30 @@ export interface RerunReportParams {
 
 function getUniqueSimulationIds(simulationIds: string[] | undefined): string[] {
   return [...new Set((simulationIds || []).filter(Boolean))];
+}
+
+function resetCachedReport(report: Report | undefined): Report | undefined {
+  if (!report) {
+    return report;
+  }
+
+  return {
+    ...report,
+    status: 'pending',
+    output: null,
+  };
+}
+
+function resetCachedSimulation(simulation: Simulation | undefined): Simulation | undefined {
+  if (!simulation) {
+    return simulation;
+  }
+
+  return {
+    ...simulation,
+    status: 'pending',
+    output: null,
+  };
 }
 
 export function useRerunReport() {
@@ -22,6 +48,18 @@ export function useRerunReport() {
 
     onSuccess: async (_result, variables) => {
       const simulationIds = getUniqueSimulationIds(variables.simulationIds);
+
+      queryClient.setQueryData<Report | undefined>(
+        reportKeys.byId(variables.reportId),
+        resetCachedReport
+      );
+
+      for (const simulationId of simulationIds) {
+        queryClient.setQueryData<Simulation | undefined>(
+          simulationKeys.byId(simulationId),
+          resetCachedSimulation
+        );
+      }
 
       queryClient.removeQueries({
         queryKey: calculationKeys.byReportId(variables.reportId),

--- a/app/src/hooks/useRerunReport.ts
+++ b/app/src/hooks/useRerunReport.ts
@@ -1,0 +1,56 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { rerunReport, type ReportRerunResult } from '@/api/report';
+import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import { calculationKeys, reportKeys, simulationKeys } from '@/libs/queryKeys';
+
+export interface RerunReportParams {
+  reportId: string;
+  simulationIds?: string[];
+}
+
+function getUniqueSimulationIds(simulationIds: string[] | undefined): string[] {
+  return [...new Set((simulationIds || []).filter(Boolean))];
+}
+
+export function useRerunReport() {
+  const countryId = useCurrentCountry();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({ reportId }: RerunReportParams): Promise<ReportRerunResult> =>
+      rerunReport(countryId, reportId),
+
+    onSuccess: async (_result, variables) => {
+      const simulationIds = getUniqueSimulationIds(variables.simulationIds);
+
+      queryClient.removeQueries({
+        queryKey: calculationKeys.byReportId(variables.reportId),
+        exact: true,
+      });
+
+      for (const simulationId of simulationIds) {
+        queryClient.removeQueries({
+          queryKey: calculationKeys.bySimulationId(simulationId),
+          exact: true,
+        });
+      }
+
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: reportKeys.byId(variables.reportId),
+        }),
+        ...simulationIds.map((simulationId) =>
+          queryClient.invalidateQueries({
+            queryKey: simulationKeys.byId(simulationId),
+          })
+        ),
+      ]);
+    },
+  });
+
+  return {
+    rerunReport: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    error: mutation.error,
+  };
+}

--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -10,6 +10,7 @@ import { useAppNavigate } from '@/contexts/NavigationContext';
 import { ReportYearProvider } from '@/contexts/ReportYearContext';
 import { colors, spacing } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import { useRerunReport } from '@/hooks/useRerunReport';
 import { useSaveSharedReport } from '@/hooks/useSaveSharedReport';
 import { useSharedReportData } from '@/hooks/useSharedReportData';
 import { useUserReportById } from '@/hooks/useUserReports';
@@ -122,6 +123,7 @@ export default function ReportOutputPage({
 
   // Hook for saving shared reports with all ingredients
   const { saveSharedReport, saveResult, setSaveResult } = useSaveSharedReport();
+  const { rerunReport, isPending: isRerunning } = useRerunReport();
 
   // Handle share button click - copy share URL to clipboard
   const handleShare = async () => {
@@ -193,6 +195,36 @@ export default function ReportOutputPage({
       } else {
         nav.push(basePath);
       }
+    }
+  };
+
+  const handleRerun = async () => {
+    if (isSharedView || !report?.id) {
+      return;
+    }
+
+    const shouldRerun = window.confirm(
+      'Rerun this report? Existing saved results will be cleared before recalculation starts.'
+    );
+
+    if (!shouldRerun) {
+      return;
+    }
+
+    const simulationIds = [...new Set([
+      ...(report.simulationIds ?? []),
+      ...(simulations ?? [])
+        .map((simulation) => simulation.id)
+        .filter((simulationId): simulationId is string => Boolean(simulationId)),
+    ])];
+
+    try {
+      await rerunReport({
+        reportId: report.id,
+        simulationIds,
+      });
+    } catch (error) {
+      console.error('[ReportOutputPage] Failed to rerun report:', error);
     }
   };
 
@@ -298,6 +330,8 @@ export default function ReportOutputPage({
         reportYear={report?.year}
         timestamp={timestamp}
         isSharedView={isSharedView}
+        isRerunning={isRerunning}
+        onRerun={!isSharedView ? handleRerun : undefined}
         onShare={handleShare}
         onSave={handleSave}
         onView={!isSharedView ? handleView : undefined}

--- a/app/src/pages/report-output/ReportOutputLayout.tsx
+++ b/app/src/pages/report-output/ReportOutputLayout.tsx
@@ -12,6 +12,8 @@ interface ReportOutputLayoutProps {
   reportYear?: string;
   timestamp?: string;
   isSharedView?: boolean;
+  isRerunning?: boolean;
+  onRerun?: () => void;
   onShare?: () => void;
   onSave?: () => void;
   onView?: () => void;
@@ -35,6 +37,8 @@ export default function ReportOutputLayout({
   reportYear,
   timestamp = 'Ran today at 05:23:41',
   isSharedView = false,
+  isRerunning = false,
+  onRerun,
   onShare,
   onSave,
   onView,
@@ -81,6 +85,8 @@ export default function ReportOutputLayout({
             </Group>
             <ReportActionButtons
               isSharedView={isSharedView}
+              isRerunning={isRerunning}
+              onRerun={onRerun}
               onShare={onShare}
               onSave={onSave}
               onView={onView}

--- a/app/src/tests/unit/api/report.test.ts
+++ b/app/src/tests/unit/api/report.test.ts
@@ -5,6 +5,7 @@ import {
   fetchReportById,
   markReportCompleted,
   markReportError,
+  rerunReport,
 } from '@/api/report';
 import { LocalStorageReportStore } from '@/api/reportAssociation';
 import { BASE_URL, MOCK_USER_ID } from '@/constants';
@@ -108,6 +109,53 @@ describe('report API', () => {
 
       // When & Then
       await expect(createReport(countryId, payload)).rejects.toThrow('Failed to create report');
+    });
+  });
+
+  describe('rerunReport', () => {
+    test('given valid report ID then reruns report successfully', async () => {
+      const countryId = 'us';
+      const reportId = 'report-123';
+      const mockApiResponse = {
+        status: 'ok',
+        result: {
+          report_id: 123,
+          report_type: 'household',
+          simulation_ids: [456, 789],
+          economy_cache_rows_deleted: 0,
+        },
+      };
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue(mockApiResponse),
+      };
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      const result = await rerunReport(countryId, reportId);
+
+      expect(global.fetch).toHaveBeenCalledWith(`${BASE_URL}/${countryId}/report/${reportId}/rerun`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      });
+      expect(result).toEqual(mockApiResponse.result);
+    });
+
+    test('given HTTP error then throws rerun error', async () => {
+      const countryId = 'us';
+      const reportId = 'report-123';
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      };
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      await expect(rerunReport(countryId, reportId)).rejects.toThrow(
+        'Failed to rerun report report-123: 500 Internal Server Error'
+      );
     });
   });
 

--- a/app/src/tests/unit/components/report/ReportActionButtons.test.tsx
+++ b/app/src/tests/unit/components/report/ReportActionButtons.test.tsx
@@ -13,11 +13,12 @@ describe('ReportActionButtons', () => {
     expect(screen.queryByRole('button', { name: /view/i })).not.toBeInTheDocument();
   });
 
-  test('given isSharedView=false then renders reproduce, view, and share buttons', () => {
+  test('given isSharedView=false then renders rerun, reproduce, view, and share buttons', () => {
     // Given
     render(
       <ReportActionButtons
         isSharedView={false}
+        onRerun={vi.fn()}
         onShare={vi.fn()}
         onView={vi.fn()}
         onReproduce={vi.fn()}
@@ -25,6 +26,7 @@ describe('ReportActionButtons', () => {
     );
 
     // Then
+    expect(screen.getByRole('button', { name: /rerun report/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /reproduce in python/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /share/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /view/i })).toBeInTheDocument();
@@ -55,6 +57,27 @@ describe('ReportActionButtons', () => {
 
     // Then
     expect(handleShare).toHaveBeenCalledOnce();
+  });
+
+  test('given onRerun callback then calls it when rerun clicked', async () => {
+    // Given
+    const user = userEvent.setup();
+    const handleRerun = vi.fn();
+    render(<ReportActionButtons isSharedView={false} onRerun={handleRerun} />);
+
+    // When
+    await user.click(screen.getByRole('button', { name: /rerun report/i }));
+
+    // Then
+    expect(handleRerun).toHaveBeenCalledOnce();
+  });
+
+  test('given isRerunning=true then rerun button is disabled', () => {
+    // Given
+    render(<ReportActionButtons isSharedView={false} onRerun={vi.fn()} isRerunning />);
+
+    // Then
+    expect(screen.getByRole('button', { name: /rerun report/i })).toBeDisabled();
   });
 
   test('given onReproduce callback then calls it when reproduce clicked', async () => {

--- a/app/src/tests/unit/hooks/useCalculationStatus.test.tsx
+++ b/app/src/tests/unit/hooks/useCalculationStatus.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { useCalculationStatus } from '@/hooks/useCalculationStatus';
 import { calculationKeys } from '@/libs/queryKeys';
@@ -267,6 +267,48 @@ describe('useCalculationStatus', () => {
         expect(result.current.status).toBe('complete');
         expect(result.current.isComplete).toBe(true);
         expect(result.current.result).toEqual(completeStatus.result);
+      });
+    });
+
+    test('given complete cache entry removed then hook returns to initializing state', async () => {
+      // Given
+      const completeStatus = mockCalcStatusComplete({
+        metadata: {
+          calcId: HOOK_TEST_CONSTANTS.TEST_REPORT_ID,
+          calcType: 'societyWide',
+          targetType: 'report',
+          startedAt: Date.now(),
+        },
+      });
+      queryClient.setQueryData<CalcStatus>(
+        calculationKeys.byReportId(HOOK_TEST_CONSTANTS.TEST_REPORT_ID),
+        completeStatus
+      );
+
+      const { result } = renderHook(
+        () => useCalculationStatus(HOOK_TEST_CONSTANTS.TEST_REPORT_ID, 'report'),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('complete');
+        expect(result.current.isComplete).toBe(true);
+      });
+
+      // When
+      await act(async () => {
+        queryClient.removeQueries({
+          queryKey: calculationKeys.byReportId(HOOK_TEST_CONSTANTS.TEST_REPORT_ID),
+          exact: true,
+        });
+      });
+
+      // Then
+      await waitFor(() => {
+        expect(result.current.status).toBe('initializing');
+        expect(result.current.isInitializing).toBe(true);
+        expect(result.current.isComplete).toBe(false);
+        expect(result.current.result).toBeUndefined();
       });
     });
   });

--- a/app/src/tests/unit/hooks/useRerunReport.test.tsx
+++ b/app/src/tests/unit/hooks/useRerunReport.test.tsx
@@ -7,6 +7,8 @@ import { CountryProvider } from '@/contexts/CountryContext';
 import { useRerunReport } from '@/hooks/useRerunReport';
 import type { CountryId } from '@/libs/countries';
 import { calculationKeys, reportKeys, simulationKeys } from '@/libs/queryKeys';
+import type { Report } from '@/types/ingredients/Report';
+import type { Simulation } from '@/types/ingredients/Simulation';
 
 vi.mock('@/api/report', () => ({
   rerunReport: vi.fn(),
@@ -53,9 +55,39 @@ describe('useRerunReport', () => {
   test('given cached report and simulation state when rerun succeeds then clears calculation cache and invalidates metadata queries', async () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
-    queryClient.setQueryData(reportKeys.byId('report-123'), { status: 'complete' });
-    queryClient.setQueryData(simulationKeys.byId('sim-1'), { status: 'complete' });
-    queryClient.setQueryData(simulationKeys.byId('sim-2'), { status: 'complete' });
+    queryClient.setQueryData<Report>(reportKeys.byId('report-123'), {
+      id: 'report-123',
+      countryId: 'us',
+      year: '2024',
+      apiVersion: '1.0.0',
+      simulationIds: ['sim-1', 'sim-2'],
+      status: 'complete',
+      output: { budget: { budgetary_impact: 1 } } as never,
+    });
+    queryClient.setQueryData<Simulation>(simulationKeys.byId('sim-1'), {
+      id: 'sim-1',
+      countryId: 'us',
+      apiVersion: '1.0.0',
+      policyId: 'policy-1',
+      populationId: 'household-1',
+      populationType: 'household',
+      label: null,
+      isCreated: true,
+      status: 'complete',
+      output: { household_net_income: { 2024: 1 } },
+    });
+    queryClient.setQueryData<Simulation>(simulationKeys.byId('sim-2'), {
+      id: 'sim-2',
+      countryId: 'us',
+      apiVersion: '1.0.0',
+      policyId: 'policy-2',
+      populationId: 'household-1',
+      populationType: 'household',
+      label: null,
+      isCreated: true,
+      status: 'complete',
+      output: { household_net_income: { 2024: 2 } },
+    });
     queryClient.setQueryData(calculationKeys.byReportId('report-123'), { status: 'complete' });
     queryClient.setQueryData(calculationKeys.bySimulationId('sim-1'), { status: 'complete' });
     queryClient.setQueryData(calculationKeys.bySimulationId('sim-2'), { status: 'complete' });
@@ -71,6 +103,22 @@ describe('useRerunReport', () => {
       expect(queryClient.getQueryData(calculationKeys.byReportId('report-123'))).toBeUndefined();
       expect(queryClient.getQueryData(calculationKeys.bySimulationId('sim-1'))).toBeUndefined();
       expect(queryClient.getQueryData(calculationKeys.bySimulationId('sim-2'))).toBeUndefined();
+    });
+
+    expect(queryClient.getQueryData<Report>(reportKeys.byId('report-123'))).toMatchObject({
+      id: 'report-123',
+      status: 'pending',
+      output: null,
+    });
+    expect(queryClient.getQueryData<Simulation>(simulationKeys.byId('sim-1'))).toMatchObject({
+      id: 'sim-1',
+      status: 'pending',
+      output: null,
+    });
+    expect(queryClient.getQueryData<Simulation>(simulationKeys.byId('sim-2'))).toMatchObject({
+      id: 'sim-2',
+      status: 'pending',
+      output: null,
     });
 
     expect(invalidateSpy).toHaveBeenCalledWith({

--- a/app/src/tests/unit/hooks/useRerunReport.test.tsx
+++ b/app/src/tests/unit/hooks/useRerunReport.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { rerunReport } from '@/api/report';
+import { CountryProvider } from '@/contexts/CountryContext';
+import { useRerunReport } from '@/hooks/useRerunReport';
+import type { CountryId } from '@/libs/countries';
+import { calculationKeys, reportKeys, simulationKeys } from '@/libs/queryKeys';
+
+vi.mock('@/api/report', () => ({
+  rerunReport: vi.fn(),
+}));
+
+describe('useRerunReport', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    vi.mocked(rerunReport).mockResolvedValue({
+      report_id: 123,
+      report_type: 'household',
+      simulation_ids: [456, 789],
+      economy_cache_rows_deleted: 0,
+    });
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <CountryProvider value={'us' as CountryId}>{children}</CountryProvider>
+    </QueryClientProvider>
+  );
+
+  test('given report ID when rerunReport is called then calls legacy rerun API', async () => {
+    const { result } = renderHook(() => useRerunReport(), { wrapper });
+
+    await result.current.rerunReport({
+      reportId: 'report-123',
+      simulationIds: ['sim-1', 'sim-2'],
+    });
+
+    expect(rerunReport).toHaveBeenCalledWith('us', 'report-123');
+  });
+
+  test('given cached report and simulation state when rerun succeeds then clears calculation cache and invalidates metadata queries', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    queryClient.setQueryData(reportKeys.byId('report-123'), { status: 'complete' });
+    queryClient.setQueryData(simulationKeys.byId('sim-1'), { status: 'complete' });
+    queryClient.setQueryData(simulationKeys.byId('sim-2'), { status: 'complete' });
+    queryClient.setQueryData(calculationKeys.byReportId('report-123'), { status: 'complete' });
+    queryClient.setQueryData(calculationKeys.bySimulationId('sim-1'), { status: 'complete' });
+    queryClient.setQueryData(calculationKeys.bySimulationId('sim-2'), { status: 'complete' });
+
+    const { result } = renderHook(() => useRerunReport(), { wrapper });
+
+    await result.current.rerunReport({
+      reportId: 'report-123',
+      simulationIds: ['sim-1', 'sim-2', 'sim-1'],
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(calculationKeys.byReportId('report-123'))).toBeUndefined();
+      expect(queryClient.getQueryData(calculationKeys.bySimulationId('sim-1'))).toBeUndefined();
+      expect(queryClient.getQueryData(calculationKeys.bySimulationId('sim-2'))).toBeUndefined();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: reportKeys.byId('report-123'),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: simulationKeys.byId('sim-1'),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: simulationKeys.byId('sim-2'),
+    });
+    expect(invalidateSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test('given API error when rerunReport is called then exposes the error', async () => {
+    const error = new Error('rerun failed');
+    vi.mocked(rerunReport).mockRejectedValue(error);
+
+    const { result } = renderHook(() => useRerunReport(), { wrapper });
+
+    await expect(
+      result.current.rerunReport({
+        reportId: 'report-123',
+        simulationIds: ['sim-1'],
+      })
+    ).rejects.toThrow('rerun failed');
+
+    await waitFor(() => {
+      expect(result.current.error).toEqual(error);
+    });
+  });
+});

--- a/app/src/tests/unit/pages/ReportOutput.page.test.tsx
+++ b/app/src/tests/unit/pages/ReportOutput.page.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@test-utils';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { render, screen, userEvent } from '@test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { useUserReportById } from '@/hooks/useUserReports';
 import ReportOutputPage from '@/pages/ReportOutput.page';
 import {
@@ -7,6 +7,7 @@ import {
   MOCK_GEOGRAPHY_UK_COUNTRY,
   MOCK_GEOGRAPHY_UK_LOCAL_AUTHORITY,
   MOCK_GEOGRAPHY_UK_NATIONAL,
+  MOCK_REPORT_ID,
   MOCK_REPORT_UK_NATIONAL,
   MOCK_REPORT_UK_SUBNATIONAL,
   MOCK_REPORT_WITH_YEAR,
@@ -17,6 +18,10 @@ import {
   MOCK_USER_REPORT_ID,
   MOCK_USER_REPORT_UK,
 } from '@/tests/fixtures/pages/ReportOutputPageMocks';
+
+const { mockRerunReport } = vi.hoisted(() => ({
+  mockRerunReport: vi.fn(),
+}));
 
 // Mock dependencies
 vi.mock('@/hooks/useCurrentCountry', () => ({
@@ -97,9 +102,23 @@ vi.mock('@/hooks/useSaveSharedReport', () => ({
   })),
 }));
 
+vi.mock('@/hooks/useRerunReport', () => ({
+  useRerunReport: vi.fn(() => ({
+    rerunReport: mockRerunReport,
+    isPending: false,
+    error: null,
+  })),
+}));
+
 describe('ReportOutputPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRerunReport.mockResolvedValue(undefined);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   test('given report with year then year is passed to layout', () => {
@@ -125,6 +144,24 @@ describe('ReportOutputPage', () => {
     // Then - page renders layout and delegates to society-wide output
     expect(screen.queryByText('Loading report...')).not.toBeInTheDocument();
     expect(screen.queryByText(/Error loading report/)).not.toBeInTheDocument();
+  });
+
+  test('given owned report then rerun uses the base report id and linked simulation ids', async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    // When
+    await user.click(screen.getByRole('button', { name: /rerun report/i }));
+
+    // Then
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Rerun this report? Existing saved results will be cleared before recalculation starts.'
+    );
+    expect(mockRerunReport).toHaveBeenCalledWith({
+      reportId: MOCK_REPORT_ID,
+      simulationIds: ['sim-1', 'sim-2'],
+    });
   });
 
   test('given UK national report then renders without error', () => {

--- a/app/src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx
+++ b/app/src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx
@@ -156,7 +156,7 @@ describe('ReportOutputLayout', () => {
     expect(screen.getByRole('button', { name: /save report to my reports/i })).toBeInTheDocument();
   });
 
-  test('given isSharedView=false then shows view, edit, and share buttons', () => {
+  test('given isSharedView=false then shows rerun, view, edit, and share buttons', () => {
     // Given
     render(
       <ReportOutputLayout
@@ -165,6 +165,7 @@ describe('ReportOutputLayout', () => {
         reportYear={MOCK_REPORT_YEAR}
         timestamp={MOCK_TIMESTAMP}
         isSharedView={false}
+        onRerun={vi.fn()}
         onShare={vi.fn()}
         onView={vi.fn()}
         onReproduce={vi.fn()}
@@ -175,6 +176,7 @@ describe('ReportOutputLayout', () => {
 
     // Then
     expect(screen.queryByTestId('shared-report-tag')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /rerun report/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /reproduce in python/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /share/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /view/i })).toBeInTheDocument();


### PR DESCRIPTION
Fixes #957

## Summary
- add a legacy rerun API client and React Query mutation hook
- add a rerun action to the owned report output header and wire it to the base legacy report id
- reset stale report, simulation, and calculation cache state so the page falls back to pending/loading before recalculation resumes

## Testing
- `cd app && bun run vitest src/tests/unit/api/report.test.ts src/tests/unit/hooks/useRerunReport.test.tsx`
- `cd app && bun run vitest src/tests/unit/components/report/ReportActionButtons.test.tsx src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx src/tests/unit/pages/ReportOutput.page.test.tsx`
- `cd app && bun run vitest src/tests/unit/hooks/useRerunReport.test.tsx`
- `cd app && bun run vitest src/tests/unit/hooks/useCalculationStatus.test.tsx -t "given complete cache entry removed then hook returns to initializing state"`
- `cd app && bun run vitest src/tests/unit/pages/ReportOutput.page.test.tsx`

## Notes
- this app work depends on the legacy backend rerun endpoint in `PolicyEngine/policyengine-api` draft PR #3392