### PR TITLE
Enable shared report actions and config view

### DIFF
--- a/app/src/CalculatorRouter.tsx
+++ b/app/src/CalculatorRouter.tsx
@@ -27,6 +27,12 @@ function ModifyReportPageRoute() {
   return <ModifyReportPage userReportId={userReportId} />;
 }
 
+/** Bridges report-output config params to ModifyReportPage's prop interface. */
+function ReportConfigPageRoute() {
+  const { reportId } = useParams<{ reportId: string }>();
+  return <ModifyReportPage userReportId={reportId} />;
+}
+
 /** Bridges react-router useParams to ReportOutputPage's prop interface. */
 function ReportOutputRoute() {
   const { reportId, subpage, view } = useParams<{
@@ -68,6 +74,10 @@ const router = createBrowserRouter(
             {
               element: <StandardLayoutOutlet />,
               children: [
+                {
+                  path: 'report-output/:reportId/config',
+                  element: <ReportConfigPageRoute />,
+                },
                 {
                   path: 'report-output/:reportId/:subpage?/:view?',
                   element: <ReportOutputRoute />,

--- a/app/src/components/common/BackBreadcrumb.tsx
+++ b/app/src/components/common/BackBreadcrumb.tsx
@@ -1,0 +1,36 @@
+import type { CSSProperties } from 'react';
+import { IconChevronLeft } from '@tabler/icons-react';
+import { Group, Text } from '@/components/ui';
+import { useAppNavigate } from '@/contexts/NavigationContext';
+import { colors } from '@/designTokens';
+import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+
+interface BackBreadcrumbProps {
+  backPath?: string;
+  backLabel?: string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function BackBreadcrumb({
+  backPath,
+  backLabel,
+  className = 'tw:gap-xs tw:items-center tw:cursor-pointer',
+  style,
+}: BackBreadcrumbProps) {
+  const nav = useAppNavigate();
+  const countryId = useCurrentCountry();
+
+  return (
+    <Group
+      className={className}
+      style={style}
+      onClick={() => nav.push(backPath || `/${countryId}/reports`)}
+    >
+      <IconChevronLeft size={14} color={colors.text.secondary} />
+      <Text className="tw:text-sm" style={{ color: colors.text.secondary }}>
+        {backLabel ? `Back to ${backLabel}` : 'Back to reports'}
+      </Text>
+    </Group>
+  );
+}

--- a/app/src/components/report/ReportActionButtons.story.tsx
+++ b/app/src/components/report/ReportActionButtons.story.tsx
@@ -5,7 +5,7 @@ const meta: Meta<typeof ReportActionButtons> = {
   title: 'Report output/ReportActionButtons',
   component: ReportActionButtons,
   args: {
-    onShare: () => {},
+    shareUrl: 'https://app.policyengine.org/us/report-output/sur-abc123?share=abc',
     onSave: () => {},
     onView: () => {},
   },

--- a/app/src/components/report/ReportActionButtons.tsx
+++ b/app/src/components/report/ReportActionButtons.tsx
@@ -1,12 +1,12 @@
 import { IconBookmark, IconCode, IconSettings } from '@tabler/icons-react';
-import { ShareButton } from '@/components/common/ActionButtons';
 import { Group } from '@/components/ui';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { ReportShareButton } from './ReportShareButton';
 
 interface ReportActionButtonsProps {
   isSharedView: boolean;
-  onShare?: () => void;
+  shareUrl?: string;
   onSave?: () => void;
   onView?: () => void;
   onReproduce?: () => void;
@@ -21,53 +21,54 @@ interface ReportActionButtonsProps {
  */
 export function ReportActionButtons({
   isSharedView,
-  onShare,
+  shareUrl,
   onSave,
   onView,
   onReproduce,
 }: ReportActionButtonsProps) {
-  if (isSharedView) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Save report to my reports"
-            onClick={onSave}
-          >
-            <IconBookmark size={18} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="right">Save to my reports</TooltipContent>
-      </Tooltip>
-    );
-  }
-
   return (
     <Group gap="xs" className="tw:ml-1.5">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" aria-label="View/edit report" onClick={onView}>
-            <IconSettings size={18} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">View/edit report</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Reproduce in Python"
-            onClick={onReproduce}
-          >
-            <IconCode size={18} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Reproduce in Python</TooltipContent>
-      </Tooltip>
-      <ShareButton onClick={onShare} />
+      {isSharedView && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Save report to my reports"
+              onClick={onSave}
+            >
+              <IconBookmark size={18} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Save to my reports</TooltipContent>
+        </Tooltip>
+      )}
+      {onView && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label="View/edit report" onClick={onView}>
+              <IconSettings size={18} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">View/edit report</TooltipContent>
+        </Tooltip>
+      )}
+      {onReproduce && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Reproduce in Python"
+              onClick={onReproduce}
+            >
+              <IconCode size={18} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Reproduce in Python</TooltipContent>
+        </Tooltip>
+      )}
+      <ReportShareButton shareUrl={shareUrl} />
     </Group>
   );
 }

--- a/app/src/components/report/ReportShareButton.tsx
+++ b/app/src/components/report/ReportShareButton.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from 'react';
+import { IconCheck, IconLink, IconShare } from '@tabler/icons-react';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+} from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+
+interface ReportShareButtonProps {
+  shareUrl?: string;
+}
+
+export function ReportShareButton({ shareUrl }: ReportShareButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [copyState, setCopyState] = useState<'success' | 'error'>('success');
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    if (!shareUrl) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopyState('success');
+    } catch (error) {
+      console.error('[ReportShareButton] Failed to copy share URL:', error);
+      setCopyState('error');
+    }
+
+    setIsOpen(true);
+
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+    }
+
+    closeTimerRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, 3000);
+  };
+
+  const isSuccess = copyState === 'success';
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverAnchor asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Share"
+          title="Share"
+          onClick={handleCopy}
+          disabled={!shareUrl}
+        >
+          <IconShare size={18} />
+        </Button>
+      </PopoverAnchor>
+      <PopoverContent
+        side="bottom"
+        align="end"
+        sideOffset={8}
+        className="tw:w-80 tw:border-0 tw:bg-transparent tw:p-0 tw:shadow-none"
+      >
+        <Card className="tw:gap-0 tw:border-border/70">
+          <CardContent className="tw:px-4 tw:py-4">
+            <div className="tw:flex tw:items-start tw:gap-3">
+              <div
+                className={`tw:flex tw:h-10 tw:w-10 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-full ${
+                  isSuccess
+                    ? 'tw:bg-emerald-100 tw:text-emerald-700'
+                    : 'tw:bg-amber-100 tw:text-amber-700'
+                }`}
+              >
+                {isSuccess ? <IconCheck size={20} /> : <IconLink size={20} />}
+              </div>
+              <PopoverHeader className="tw:gap-1">
+                <PopoverTitle>{isSuccess ? 'Share link copied' : 'Copy failed'}</PopoverTitle>
+                <PopoverDescription className="tw:text-sm">
+                  {isSuccess
+                    ? 'Anyone with the link can view this report.'
+                    : 'The share link could not be copied. Please try again.'}
+                </PopoverDescription>
+              </PopoverHeader>
+            </div>
+          </CardContent>
+        </Card>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/src/components/report/ReportShareButton.tsx
+++ b/app/src/components/report/ReportShareButton.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { IconCheck, IconLink, IconShare } from '@tabler/icons-react';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   Popover,
@@ -9,7 +10,6 @@ import {
   PopoverHeader,
   PopoverTitle,
 } from '@/components/ui/popover';
-import { Button } from '@/components/ui/button';
 
 interface ReportShareButtonProps {
   shareUrl?: string;

--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { SocietyWideReportOutput as SocietyWideOutput } from '@/api/societyWideCalculation';
 import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 import { FloatingAlert } from '@/components/common/FloatingAlert';
@@ -15,6 +14,7 @@ import { useSharedReportData } from '@/hooks/useSharedReportData';
 import { useUserReportById } from '@/hooks/useUserReports';
 import type { EconomyOutput, Report } from '@/types/ingredients/Report';
 import { formatReportTimestamp } from '@/utils/dateUtils';
+import { getReportConfigPath } from '@/utils/reportRouting';
 import { resolveDefaultReportOutputSubpage } from '@/utils/reportOutputSubpage';
 import {
   buildSharePath,
@@ -63,7 +63,7 @@ function extractReportVersionMetadata(output: Report['output']): ReportVersionMe
  * - Delegates to type-specific output components (Household or SocietyWide)
  * - Wraps content in ReportOutputLayout for consistent chrome
  *
- * Both owned and shared views now use the same data shape:
+ * Both owned and shared views use the same data shape:
  * - useUserReportById: fetches from localStorage associations
  * - useSharedReportData: uses ShareData from URL (same shape)
  */
@@ -79,21 +79,22 @@ export default function ReportOutputPage({
   subpage,
   view,
 }: ReportOutputPageProps) {
-  if (import.meta.env.DEV) {
+  if (import.meta.env.DEV && typeof window !== 'undefined') {
     (window as any).__journeyProfiler?.markEvent('report-output-render', 'render');
   }
   const nav = useAppNavigate();
   const countryId = useCurrentCountry();
   const location = useAppLocation();
   const searchParams = new URLSearchParams(location.search);
+  const shareParam = searchParams.get('share');
+  const shareSearch = shareParam
+    ? `?${new URLSearchParams({ share: shareParam }).toString()}`
+    : '';
 
   // Detect shared view from URL
   const shareData = extractShareDataFromUrl(searchParams);
   const isSharedView = shareData !== null;
   const shareDataUserReportId = shareData ? getShareDataUserReportId(shareData) : null;
-
-  // Alert state for clipboard copy notification
-  const [showCopyAlert, setShowCopyAlert] = useState(false);
 
   // If no userReportId and not a shared view, show error
   if (!userReportId && !isSharedView) {
@@ -148,13 +149,20 @@ export default function ReportOutputPage({
   // Hook for saving shared reports with all ingredients
   const { saveSharedReport, saveResult, setSaveResult } = useSaveSharedReport();
 
-  // Handle share button click - copy share URL to clipboard
-  const handleShare = async () => {
-    if (!userReport || !userSimulations?.length) {
-      return;
+  const shareUrl = (() => {
+    if (isSharedView) {
+      const sharedReportId = shareDataUserReportId ?? userReportId;
+      if (!sharedReportId) {
+        return undefined;
+      }
+
+      return `${CALCULATOR_URL}/${countryId}/report-output/${sharedReportId}${shareSearch}`;
     }
 
-    // Create ShareData from user associations
+    if (!userReport || !userSimulations?.length) {
+      return undefined;
+    }
+
     const shareDataToEncode = createShareData(
       userReport,
       userSimulations ?? [],
@@ -163,23 +171,8 @@ export default function ReportOutputPage({
       userGeographies ?? []
     );
 
-    if (!shareDataToEncode) {
-      console.error('[ReportOutputPage] Failed to create share data');
-      return;
-    }
-
-    const sharePath = buildSharePath(shareDataToEncode);
-    const shareUrl = `${CALCULATOR_URL}${sharePath}`;
-
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-      setShowCopyAlert(true);
-      // Auto-hide alert after 3 seconds
-      setTimeout(() => setShowCopyAlert(false), 3000);
-    } catch (error) {
-      console.error('[ReportOutputPage] Failed to copy share URL:', error);
-    }
-  };
+    return shareDataToEncode ? `${CALCULATOR_URL}${buildSharePath(shareDataToEncode)}` : undefined;
+  })();
 
   // Handle save button click - create user associations and navigate to owned view
   const handleSave = async () => {
@@ -199,12 +192,15 @@ export default function ReportOutputPage({
 
   // Handle view button click - navigate to report builder in view mode
   const handleView = () => {
-    if (userReportId) {
-      const params = new URLSearchParams({
-        from: 'report-output',
-        reportPath: `/${countryId}/report-output/${userReportId}`,
-      });
-      nav.push(`/${countryId}/reports/create/${userReportId}?${params}`);
+    const id = isSharedView ? shareDataUserReportId : userReportId;
+    if (!id) {
+      return;
+    }
+
+    if (isSharedView) {
+      nav.push(`${getReportConfigPath(countryId, id)}${shareSearch}`);
+    } else {
+      nav.push(getReportConfigPath(countryId, userReportId!));
     }
   };
 
@@ -214,7 +210,7 @@ export default function ReportOutputPage({
     if (id) {
       const basePath = `/${countryId}/report-output/${id}/reproduce`;
       if (isSharedView) {
-        nav.push(`${basePath}?${searchParams.toString()}`);
+        nav.push(`${basePath}${shareSearch}`);
       } else {
         nav.push(basePath);
       }
@@ -222,7 +218,7 @@ export default function ReportOutputPage({
   };
 
   // Show loading state while fetching data
-  if (import.meta.env.DEV && dataLoading) {
+  if (import.meta.env.DEV && typeof window !== 'undefined' && dataLoading) {
     (window as any).__journeyProfiler?.markEvent('report-output-data-loading', 'render');
   }
   if (dataLoading) {
@@ -251,6 +247,12 @@ export default function ReportOutputPage({
   // Determine the display label and ID for the report
   const displayLabel = userReport?.label;
   const displayReportId = isSharedView ? shareDataUserReportId : userReportId;
+  const reportOutputBackPath =
+    activeTab === 'reproduce' && displayReportId
+      ? `/${countryId}/report-output/${displayReportId}${shareSearch}`
+      : undefined;
+  const reportOutputBackLabel =
+    activeTab === 'reproduce' && displayReportId ? displayLabel ?? 'report output' : undefined;
 
   // Render content based on output type
   // Both shared and owned views now use the same user associations shape
@@ -292,18 +294,12 @@ export default function ReportOutputPage({
     return <Text style={{ color: colors.error }}>Unknown report type</Text>;
   };
 
-  if (import.meta.env.DEV) {
+  if (import.meta.env.DEV && typeof window !== 'undefined') {
     (window as any).__journeyProfiler?.markEvent('report-output-ready', 'render');
   }
 
   return (
     <ReportYearProvider year={report?.year ?? null}>
-      {showCopyAlert && (
-        <FloatingAlert onClose={() => setShowCopyAlert(false)}>
-          Share link copied to clipboard!
-        </FloatingAlert>
-      )}
-
       {saveResult && (
         <FloatingAlert
           type={saveResult === 'success' || saveResult === 'already_saved' ? 'success' : 'warning'}
@@ -324,10 +320,12 @@ export default function ReportOutputPage({
         modelVersion={versionMetadata?.modelVersion ?? undefined}
         dataVersion={versionMetadata?.dataVersion ?? undefined}
         timestamp={timestamp}
+        backPath={reportOutputBackPath}
+        backLabel={reportOutputBackLabel}
         isSharedView={isSharedView}
-        onShare={handleShare}
+        shareUrl={shareUrl}
         onSave={handleSave}
-        onView={!isSharedView ? handleView : undefined}
+        onView={handleView}
         onReproduce={handleReproduce}
       >
         <ErrorBoundary

--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -14,8 +14,8 @@ import { useSharedReportData } from '@/hooks/useSharedReportData';
 import { useUserReportById } from '@/hooks/useUserReports';
 import type { EconomyOutput, Report } from '@/types/ingredients/Report';
 import { formatReportTimestamp } from '@/utils/dateUtils';
-import { getReportConfigPath } from '@/utils/reportRouting';
 import { resolveDefaultReportOutputSubpage } from '@/utils/reportOutputSubpage';
+import { getReportConfigPath } from '@/utils/reportRouting';
 import {
   buildSharePath,
   createShareData,
@@ -87,9 +87,7 @@ export default function ReportOutputPage({
   const location = useAppLocation();
   const searchParams = new URLSearchParams(location.search);
   const shareParam = searchParams.get('share');
-  const shareSearch = shareParam
-    ? `?${new URLSearchParams({ share: shareParam }).toString()}`
-    : '';
+  const shareSearch = shareParam ? `?${new URLSearchParams({ share: shareParam }).toString()}` : '';
 
   // Detect shared view from URL
   const shareData = extractShareDataFromUrl(searchParams);
@@ -252,7 +250,7 @@ export default function ReportOutputPage({
       ? `/${countryId}/report-output/${displayReportId}${shareSearch}`
       : undefined;
   const reportOutputBackLabel =
-    activeTab === 'reproduce' && displayReportId ? displayLabel ?? displayReportId : undefined;
+    activeTab === 'reproduce' && displayReportId ? (displayLabel ?? displayReportId) : undefined;
 
   // Render content based on output type
   // Both shared and owned views now use the same user associations shape

--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -252,7 +252,7 @@ export default function ReportOutputPage({
       ? `/${countryId}/report-output/${displayReportId}${shareSearch}`
       : undefined;
   const reportOutputBackLabel =
-    activeTab === 'reproduce' && displayReportId ? displayLabel ?? 'report output' : undefined;
+    activeTab === 'reproduce' && displayReportId ? displayLabel ?? displayReportId : undefined;
 
   // Render content based on output type
   // Both shared and owned views now use the same user associations shape

--- a/app/src/pages/Reports.page.tsx
+++ b/app/src/pages/Reports.page.tsx
@@ -22,6 +22,7 @@ import { useUserReports } from '@/hooks/useUserReports';
 import { RootState } from '@/store';
 import { useCacheMonitor } from '@/utils/cacheMonitor';
 import { formatDate } from '@/utils/dateUtils';
+import { getReportConfigPath } from '@/utils/reportRouting';
 import { CURRENT_LAW_LABEL } from './reportBuilder/currentLaw';
 
 export default function ReportsPage() {
@@ -122,7 +123,7 @@ export default function ReportsPage() {
       actions: [{ action: 'edit', tooltip: 'View/edit report', icon: <IconSettings size={16} /> }],
       onAction: (action: string, recordId: string) => {
         if (action === 'edit') {
-          nav.push(`/${countryId}/reports/create/${recordId}`);
+          nav.push(getReportConfigPath(countryId, recordId));
         }
       },
     },

--- a/app/src/pages/report-output/ReportOutputLayout.story.tsx
+++ b/app/src/pages/report-output/ReportOutputLayout.story.tsx
@@ -5,7 +5,7 @@ const meta: Meta<typeof ReportOutputLayout> = {
   title: 'Report output/ReportOutputLayout',
   component: ReportOutputLayout,
   args: {
-    onShare: () => {},
+    shareUrl: 'https://app.policyengine.org/us/report-output/sur-abc123?share=abc',
     onSave: () => {},
   },
 };

--- a/app/src/pages/report-output/ReportOutputLayout.tsx
+++ b/app/src/pages/report-output/ReportOutputLayout.tsx
@@ -1,10 +1,9 @@
-import { IconCalendar, IconChevronLeft, IconClock } from '@tabler/icons-react';
+import { IconCalendar, IconClock } from '@tabler/icons-react';
+import { BackBreadcrumb } from '@/components/common/BackBreadcrumb';
 import { ReportActionButtons } from '@/components/report/ReportActionButtons';
 import { SharedReportTag } from '@/components/report/SharedReportTag';
 import { Container, Group, Stack, Text, Title } from '@/components/ui';
-import { useAppNavigate } from '@/contexts/NavigationContext';
 import { colors, spacing, typography } from '@/designTokens';
-import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 
 interface ReportOutputLayoutProps {
   reportId: string;
@@ -49,23 +48,16 @@ export default function ReportOutputLayout({
   onReproduce,
   children,
 }: ReportOutputLayoutProps) {
-  const countryId = useCurrentCountry();
-  const nav = useAppNavigate();
-
   return (
     <Container size="xl" className="tw:px-xl">
       <Stack className="tw:gap-xl">
         {/* Back breadcrumb */}
-        <Group
+        <BackBreadcrumb
           className="tw:gap-xs tw:items-center tw:cursor-pointer"
           style={{ marginBottom: `-${spacing.md}` }}
-          onClick={() => nav.push(backPath || `/${countryId}/reports`)}
-        >
-          <IconChevronLeft size={14} color={colors.text.secondary} />
-          <Text className="tw:text-sm" style={{ color: colors.text.secondary }}>
-            {backLabel ? `Back to ${backLabel}` : 'Back to reports'}
-          </Text>
-        </Group>
+          backPath={backPath}
+          backLabel={backLabel}
+        />
 
         {/* Header Section */}
         <div>

--- a/app/src/pages/report-output/ReportOutputLayout.tsx
+++ b/app/src/pages/report-output/ReportOutputLayout.tsx
@@ -13,8 +13,10 @@ interface ReportOutputLayoutProps {
   modelVersion?: string;
   dataVersion?: string;
   timestamp?: string;
+  backPath?: string;
+  backLabel?: string;
   isSharedView?: boolean;
-  onShare?: () => void;
+  shareUrl?: string;
   onSave?: () => void;
   onView?: () => void;
   onReproduce?: () => void;
@@ -38,8 +40,10 @@ export default function ReportOutputLayout({
   modelVersion,
   dataVersion,
   timestamp = 'Ran today at 05:23:41',
+  backPath,
+  backLabel,
   isSharedView = false,
-  onShare,
+  shareUrl,
   onSave,
   onView,
   onReproduce,
@@ -55,11 +59,11 @@ export default function ReportOutputLayout({
         <Group
           className="tw:gap-xs tw:items-center tw:cursor-pointer"
           style={{ marginBottom: `-${spacing.md}` }}
-          onClick={() => nav.push(`/${countryId}/reports`)}
+          onClick={() => nav.push(backPath || `/${countryId}/reports`)}
         >
           <IconChevronLeft size={14} color={colors.text.secondary} />
           <Text className="tw:text-sm" style={{ color: colors.text.secondary }}>
-            Back to reports
+            {backLabel ? `Back to ${backLabel}` : 'Back to reports'}
           </Text>
         </Group>
 
@@ -85,7 +89,7 @@ export default function ReportOutputLayout({
             </Group>
             <ReportActionButtons
               isSharedView={isSharedView}
-              onShare={onShare}
+              shareUrl={shareUrl}
               onSave={onSave}
               onView={onView}
               onReproduce={onReproduce}

--- a/app/src/pages/reportBuilder/ModifyReportPage.tsx
+++ b/app/src/pages/reportBuilder/ModifyReportPage.tsx
@@ -16,6 +16,7 @@ import { useAppNavigate } from '@/contexts/NavigationContext';
 import { spacing } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import { getReportOutputPath } from '@/utils/reportRouting';
+import { extractShareDataFromUrl } from '@/utils/shareUtils';
 import { ReportBuilderShell, SimulationBlockFull } from './components';
 import { useModifyReportSubmission } from './hooks/useModifyReportSubmission';
 import { useReportBuilderState } from './hooks/useReportBuilderState';
@@ -26,11 +27,16 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
   const nav = useAppNavigate();
   const location = useAppLocation();
   const searchParams = new URLSearchParams(location.search);
-  const cameFromReportOutput = searchParams.get('from') === 'report-output';
-  const reportOutputPath = searchParams.get('reportPath');
+  const shareParam = searchParams.get('share');
+  const shareSearch = shareParam
+    ? `?${new URLSearchParams({ share: shareParam }).toString()}`
+    : '';
+  const shareData = extractShareDataFromUrl(searchParams);
+  const isSharedView = shareData !== null;
 
   const { reportState, setReportState, originalState, isLoading, error } = useReportBuilderState(
-    userReportId ?? ''
+    userReportId ?? '',
+    shareData
   );
 
   const [pickerState, setPickerState] = useState<IngredientPickerState>({
@@ -51,6 +57,7 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
   // View/edit mode state
   const [isEditing, setIsEditing] = useState(false);
   const [showSameNameWarning, setShowSameNameWarning] = useState(false);
+  const isReadOnly = isSharedView || !isEditing;
 
   const isEitherSubmitting = isSavingNew || isReplacing;
 
@@ -67,6 +74,10 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
 
   // Dynamic toolbar actions
   const topBarActions: TopBarAction[] = useMemo(() => {
+    if (isSharedView) {
+      return [];
+    }
+
     if (!isEditing) {
       return [
         {
@@ -114,6 +125,7 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
       },
     ];
   }, [
+    isSharedView,
     isEditing,
     handleSaveAsNewClick,
     handleReplace,
@@ -145,16 +157,16 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
   return (
     <>
       <ReportBuilderShell
-        title={isEditing ? 'Edit report' : 'View report setup'}
-        backPath={cameFromReportOutput ? (reportOutputPath ?? undefined) : undefined}
-        backLabel={cameFromReportOutput ? reportState?.label || 'Report output' : undefined}
+        title={isReadOnly ? 'View report setup' : 'Edit report'}
+        backPath={userReportId ? `/${countryId}/report-output/${userReportId}${shareSearch}` : undefined}
+        backLabel={userReportId ? reportState?.label || 'report output' : undefined}
         actions={topBarActions}
         reportState={reportState}
         setReportState={setReportState as React.Dispatch<React.SetStateAction<ReportBuilderState>>}
         pickerState={pickerState}
         setPickerState={setPickerState}
         BlockComponent={SimulationBlockFull}
-        isReadOnly={!isEditing}
+        isReadOnly={isReadOnly}
       />
 
       <Dialog

--- a/app/src/pages/reportBuilder/ModifyReportPage.tsx
+++ b/app/src/pages/reportBuilder/ModifyReportPage.tsx
@@ -28,9 +28,7 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
   const location = useAppLocation();
   const searchParams = new URLSearchParams(location.search);
   const shareParam = searchParams.get('share');
-  const shareSearch = shareParam
-    ? `?${new URLSearchParams({ share: shareParam }).toString()}`
-    : '';
+  const shareSearch = shareParam ? `?${new URLSearchParams({ share: shareParam }).toString()}` : '';
   const shareData = extractShareDataFromUrl(searchParams);
   const isSharedView = shareData !== null;
 
@@ -158,7 +156,9 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
     <>
       <ReportBuilderShell
         title={isReadOnly ? 'View report setup' : 'Edit report'}
-        backPath={userReportId ? `/${countryId}/report-output/${userReportId}${shareSearch}` : undefined}
+        backPath={
+          userReportId ? `/${countryId}/report-output/${userReportId}${shareSearch}` : undefined
+        }
         backLabel={userReportId ? reportState?.label || userReportId : undefined}
         actions={topBarActions}
         reportState={reportState}

--- a/app/src/pages/reportBuilder/ModifyReportPage.tsx
+++ b/app/src/pages/reportBuilder/ModifyReportPage.tsx
@@ -159,7 +159,7 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
       <ReportBuilderShell
         title={isReadOnly ? 'View report setup' : 'Edit report'}
         backPath={userReportId ? `/${countryId}/report-output/${userReportId}${shareSearch}` : undefined}
-        backLabel={userReportId ? reportState?.label || 'report output' : undefined}
+        backLabel={userReportId ? reportState?.label || userReportId : undefined}
         actions={topBarActions}
         reportState={reportState}
         setReportState={setReportState as React.Dispatch<React.SetStateAction<ReportBuilderState>>}

--- a/app/src/pages/reportBuilder/components/IngredientSectionFull.tsx
+++ b/app/src/pages/reportBuilder/components/IngredientSectionFull.tsx
@@ -130,8 +130,8 @@ export function IngredientSectionFull({
     }
   };
 
-  // Show view/edit gear button for non-current-law policies (in any mode)
-  const showViewEditPolicyButton =
+  // Show policy details action for non-current-law policies.
+  const showViewPolicyButton =
     type === 'policy' && !isCurrentLaw(currentId) && !!currentId && onViewPolicy;
 
   return (
@@ -256,8 +256,8 @@ export function IngredientSectionFull({
               flexShrink: 0,
             }}
           >
-            {/* View/edit policy gear — visible in both view and edit modes */}
-            {showViewEditPolicyButton && (
+            {/* Policy details gear */}
+            {showViewPolicyButton && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
@@ -282,7 +282,9 @@ export function IngredientSectionFull({
                     <IconSettings size={14} />
                   </button>
                 </TooltipTrigger>
-                <TooltipContent side="bottom">View/edit policy</TooltipContent>
+                <TooltipContent side="bottom">
+                  {isReadOnly ? 'View policy' : 'View/edit policy'}
+                </TooltipContent>
               </Tooltip>
             )}
             {/* Swap and remove — only in edit mode */}

--- a/app/src/pages/reportBuilder/components/ReportBuilderShell.tsx
+++ b/app/src/pages/reportBuilder/components/ReportBuilderShell.tsx
@@ -4,11 +4,7 @@
  * Renders the page layout: header + TopBar (with ReportMetaPanel + actions) + SimulationCanvas.
  * Accepts all logic via props so different modes (setup, modify) can compose it.
  */
-import { IconChevronLeft } from '@tabler/icons-react';
-import { Group, Text } from '@/components/ui';
-import { useAppNavigate } from '@/contexts/NavigationContext';
-import { colors } from '@/designTokens';
-import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import { BackBreadcrumb } from '@/components/common/BackBreadcrumb';
 import { styles } from '../styles';
 import type { IngredientPickerState, ReportBuilderState, TopBarAction } from '../types';
 import { ReportMetaPanel } from './ReportMetaPanel';
@@ -42,23 +38,15 @@ export function ReportBuilderShell({
   backPath,
   backLabel,
 }: ReportBuilderShellProps) {
-  const nav = useAppNavigate();
-  const countryId = useCurrentCountry();
-
   return (
     <div style={styles.pageContainer}>
       {/* Back breadcrumb */}
-      <Group
-        gap="xs"
-        align="center"
+      <BackBreadcrumb
+        className="tw:gap-xs tw:items-center tw:cursor-pointer"
         style={{ marginBottom: 8, cursor: 'pointer' }}
-        onClick={() => nav.push(backPath || `/${countryId}/reports`)}
-      >
-        <IconChevronLeft size={14} color={colors.gray[500]} />
-        <Text size="sm" c="dimmed">
-          {backLabel ? `Back to ${backLabel}` : 'Back to reports'}
-        </Text>
-      </Group>
+        backPath={backPath}
+        backLabel={backLabel}
+      />
 
       <div style={styles.headerSection}>
         <h1 style={styles.mainTitle}>{title}</h1>

--- a/app/src/pages/reportBuilder/components/SimulationCanvas.tsx
+++ b/app/src/pages/reportBuilder/components/SimulationCanvas.tsx
@@ -101,7 +101,10 @@ export function SimulationCanvas({
               isReadOnly={isReadOnly}
             />
           ) : (
-            <AddSimulationCard onClick={canvas.handleAddSimulation} disabled={false} />
+            <AddSimulationCard
+              onClick={canvas.handleAddSimulation}
+              disabled={Boolean(isReadOnly)}
+            />
           )}
         </div>
       </div>

--- a/app/src/pages/reportBuilder/components/SimulationCanvas.tsx
+++ b/app/src/pages/reportBuilder/components/SimulationCanvas.tsx
@@ -38,6 +38,8 @@ export function SimulationCanvas({
   isReadOnly,
 }: SimulationCanvasProps) {
   const canvas = useSimulationCanvas({ reportState, setReportState, pickerState, setPickerState });
+  const isViewOnly = Boolean(isReadOnly);
+  const noop = () => {};
 
   if (canvas.isInitialLoading) {
     return <SimulationCanvasSkeleton />;
@@ -61,11 +63,13 @@ export function SimulationCanvas({
             onSelectRecentPopulation={(pop) => canvas.handleSelectRecentPopulation(0, pop)}
             onDeselectPolicy={() => canvas.handleDeselectPolicy(0)}
             onDeselectPopulation={() => canvas.handleDeselectPopulation(0)}
-            onEditPolicy={() => canvas.handleEditPolicy(0)}
+            onEditPolicy={isViewOnly ? noop : () => canvas.handleEditPolicy(0)}
             onViewPolicy={() => canvas.handleViewPolicy(0)}
-            onCreateCustomPolicy={() => canvas.handleCreateCustom(0, 'policy')}
-            onBrowseMorePolicies={() => canvas.handleBrowseMorePolicies(0)}
-            onBrowseMorePopulations={() => canvas.handleBrowseMorePopulations(0)}
+            onCreateCustomPolicy={isViewOnly ? noop : () => canvas.handleCreateCustom(0, 'policy')}
+            onBrowseMorePolicies={isViewOnly ? noop : () => canvas.handleBrowseMorePolicies(0)}
+            onBrowseMorePopulations={
+              isViewOnly ? noop : () => canvas.handleBrowseMorePopulations(0)
+            }
             canRemove={false}
             savedPolicies={canvas.savedPolicies}
             recentPopulations={canvas.recentPopulations}
@@ -86,11 +90,15 @@ export function SimulationCanvas({
               onSelectRecentPopulation={(pop) => canvas.handleSelectRecentPopulation(1, pop)}
               onDeselectPolicy={() => canvas.handleDeselectPolicy(1)}
               onDeselectPopulation={() => canvas.handleDeselectPopulation(1)}
-              onEditPolicy={() => canvas.handleEditPolicy(1)}
+              onEditPolicy={isViewOnly ? noop : () => canvas.handleEditPolicy(1)}
               onViewPolicy={() => canvas.handleViewPolicy(1)}
-              onCreateCustomPolicy={() => canvas.handleCreateCustom(1, 'policy')}
-              onBrowseMorePolicies={() => canvas.handleBrowseMorePolicies(1)}
-              onBrowseMorePopulations={() => canvas.handleBrowseMorePopulations(1)}
+              onCreateCustomPolicy={
+                isViewOnly ? noop : () => canvas.handleCreateCustom(1, 'policy')
+              }
+              onBrowseMorePolicies={isViewOnly ? noop : () => canvas.handleBrowseMorePolicies(1)}
+              onBrowseMorePopulations={
+                isViewOnly ? noop : () => canvas.handleBrowseMorePopulations(1)
+              }
               onRemove={() => canvas.handleRemoveSimulation(1)}
               canRemove={!canvas.isGeographySelected}
               isRequired={canvas.isGeographySelected}
@@ -148,6 +156,7 @@ export function SimulationCanvas({
         initialPolicy={canvas.policyCreationState.initialPolicy}
         initialEditorMode={canvas.policyCreationState.initialEditorMode}
         reportYear={reportYear}
+        forceReadOnly={isViewOnly}
       />
     </>
   );

--- a/app/src/pages/reportBuilder/hooks/useReportBuilderState.ts
+++ b/app/src/pages/reportBuilder/hooks/useReportBuilderState.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useSharedReportData } from '@/hooks/useSharedReportData';
 import { useUserReportById } from '@/hooks/useUserReports';
+import type { ReportIngredientsInput } from '@/hooks/utils/useFetchReportIngredients';
 import { RootState } from '@/store';
 import type { ReportBuilderState } from '../types';
 import { hydrateReportBuilderState } from '../utils/hydrateReportBuilderState';
@@ -13,9 +15,17 @@ interface UseReportBuilderStateReturn {
   error: Error | null;
 }
 
-export function useReportBuilderState(userReportId: string): UseReportBuilderStateReturn {
+export function useReportBuilderState(
+  userReportId: string,
+  shareData: ReportIngredientsInput | null = null
+): UseReportBuilderStateReturn {
   const currentLawId = useSelector((state: RootState) => state.metadata.currentLawId);
-  const data = useUserReportById(userReportId);
+  const isSharedView = shareData !== null;
+  const ownedData = useUserReportById(userReportId, {
+    enabled: !isSharedView && !!userReportId,
+  });
+  const sharedDataResult = useSharedReportData(shareData, { enabled: isSharedView });
+  const data = isSharedView ? sharedDataResult : ownedData;
 
   const [reportState, setReportState] = useState<ReportBuilderState | null>(null);
   const originalStateRef = useRef<ReportBuilderState | null>(null);

--- a/app/src/pages/reportBuilder/modals/PolicyCreationModal.tsx
+++ b/app/src/pages/reportBuilder/modals/PolicyCreationModal.tsx
@@ -132,9 +132,7 @@ export function PolicyCreationModal({
   const resolvedInitialEditorMode: EditorMode = forceReadOnly
     ? 'display'
     : initialEditorMode || (initialPolicy ? 'edit' : 'create');
-  const [editorMode, setEditorMode] = useState<EditorMode>(
-    resolvedInitialEditorMode
-  );
+  const [editorMode, setEditorMode] = useState<EditorMode>(resolvedInitialEditorMode);
   const effectiveEditorMode: EditorMode = forceReadOnly ? 'display' : editorMode;
   const isReadOnly = effectiveEditorMode === 'display';
   const colorConfig = INGREDIENT_COLORS.policy;

--- a/app/src/pages/reportBuilder/modals/PolicyCreationModal.tsx
+++ b/app/src/pages/reportBuilder/modals/PolicyCreationModal.tsx
@@ -69,6 +69,7 @@ interface PolicyCreationModalProps {
   initialPolicy?: PolicyStateProps;
   initialEditorMode?: EditorMode;
   initialAssociationId?: string;
+  forceReadOnly?: boolean;
 }
 
 export function PolicyCreationModal({
@@ -80,6 +81,7 @@ export function PolicyCreationModal({
   initialPolicy,
   initialEditorMode,
   initialAssociationId,
+  forceReadOnly = false,
 }: PolicyCreationModalProps) {
   const countryId = useCurrentCountry();
 
@@ -127,10 +129,14 @@ export function PolicyCreationModal({
   void simulationIndex;
 
   // Editor mode: create (new policy), display (read-only existing), edit (modifying existing)
+  const resolvedInitialEditorMode: EditorMode = forceReadOnly
+    ? 'display'
+    : initialEditorMode || (initialPolicy ? 'edit' : 'create');
   const [editorMode, setEditorMode] = useState<EditorMode>(
-    initialEditorMode || (initialPolicy ? 'edit' : 'create')
+    resolvedInitialEditorMode
   );
-  const isReadOnly = editorMode === 'display';
+  const effectiveEditorMode: EditorMode = forceReadOnly ? 'display' : editorMode;
+  const isReadOnly = effectiveEditorMode === 'display';
   const colorConfig = INGREDIENT_COLORS.policy;
 
   // Reset state when modal opens; pre-populate from initialPolicy when editing
@@ -138,7 +144,7 @@ export function PolicyCreationModal({
     if (isOpen) {
       setPolicyLabel(initialPolicy?.label || '');
       setPolicyParameters(initialPolicy?.parameters || []);
-      setEditorMode(initialEditorMode || (initialPolicy ? 'edit' : 'create'));
+      setEditorMode(resolvedInitialEditorMode);
       setActiveTab('overview');
       setSelectedParam(null);
       setExpandedMenuItems(new Set());
@@ -147,7 +153,7 @@ export function PolicyCreationModal({
       setEndDate(defaultEndDate);
       setParameterSearch('');
     }
-  }, [isOpen, initialEditorMode, initialPolicy, defaultStartDate, defaultEndDate]);
+  }, [isOpen, initialPolicy, resolvedInitialEditorMode, defaultStartDate, defaultEndDate]);
 
   // Create local policy state object for components
   const localPolicy: PolicyStateProps = useMemo(
@@ -303,12 +309,12 @@ export function PolicyCreationModal({
   const handleSaveAsNewPolicy = useCallback(() => {
     const currentName = (policyLabel || '').trim();
     const originalName = (initialPolicy?.label || '').trim();
-    if (editorMode === 'edit' && currentName && currentName === originalName) {
+    if (effectiveEditorMode === 'edit' && currentName && currentName === originalName) {
       setShowSameNameWarning(true);
     } else {
       handleCreatePolicy();
     }
-  }, [policyLabel, initialPolicy?.label, editorMode, handleCreatePolicy]);
+  }, [policyLabel, initialPolicy?.label, effectiveEditorMode, handleCreatePolicy]);
 
   // Handle updating an existing policy (create new base policy, update association)
   const handleUpdateExistingPolicy = useCallback(async () => {
@@ -472,9 +478,9 @@ export function PolicyCreationModal({
         }}
       >
         <DialogTitle className="tw:sr-only">
-          {editorMode === 'display'
+          {effectiveEditorMode === 'display'
             ? 'Policy details'
-            : editorMode === 'edit'
+            : effectiveEditorMode === 'edit'
               ? 'Edit policy'
               : 'Policy editor'}
         </DialogTitle>
@@ -508,9 +514,9 @@ export function PolicyCreationModal({
                 <IconScale size={18} color={colorConfig.icon} />
               </div>
               <Text fw={600} style={{ fontSize: FONT_SIZES.normal, color: colors.gray[800] }}>
-                {editorMode === 'display'
+                {effectiveEditorMode === 'display'
                   ? 'Policy details'
-                  : editorMode === 'edit'
+                  : effectiveEditorMode === 'edit'
                     ? 'Edit policy'
                     : 'Policy editor'}
               </Text>
@@ -601,7 +607,7 @@ export function PolicyCreationModal({
               )}
             </div>
             <Group gap="sm" justify="end">
-              {editorMode === 'create' && (
+              {!forceReadOnly && effectiveEditorMode === 'create' && (
                 <Button
                   onClick={() => {
                     if (!policyLabel.trim()) {
@@ -616,10 +622,17 @@ export function PolicyCreationModal({
                   Create policy
                 </Button>
               )}
-              {editorMode === 'display' && (
-                <EditDefaultButton label="Edit this policy" onClick={() => setEditorMode('edit')} />
+              {!forceReadOnly && effectiveEditorMode === 'display' && (
+                <EditDefaultButton
+                  label="Edit this policy"
+                  onClick={() => {
+                    if (!forceReadOnly) {
+                      setEditorMode('edit');
+                    }
+                  }}
+                />
               )}
-              {editorMode === 'edit' && (
+              {!forceReadOnly && effectiveEditorMode === 'edit' && (
                 <>
                   <EditAndUpdateButton
                     label="Update existing policy"

--- a/app/src/tests/fixtures/utils/reportRoutingMocks.ts
+++ b/app/src/tests/fixtures/utils/reportRoutingMocks.ts
@@ -16,7 +16,9 @@ export const TEST_REPORT_IDS = {
 
 export const EXPECTED_PATHS = {
   US_NUMERIC: '/us/report-output/12345',
+  US_NUMERIC_CONFIG: '/us/report-output/12345/config',
   UK_STRING: '/uk/report-output/report-abc-123',
+  UK_STRING_CONFIG: '/uk/report-output/report-abc-123/config',
   US_SPECIAL_CHARS: '/us/report-output/report_id-123',
   UK_GENERIC: '/uk/report-output/999',
 } as const;

--- a/app/src/tests/unit/components/report/ReportActionButtons.test.tsx
+++ b/app/src/tests/unit/components/report/ReportActionButtons.test.tsx
@@ -1,16 +1,37 @@
 import { render, screen, userEvent } from '@test-utils';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ReportActionButtons } from '@/components/report/ReportActionButtons';
 
 describe('ReportActionButtons', () => {
-  test('given isSharedView=true then renders save button only', () => {
+  let clipboardWriteText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: clipboardWriteText,
+      },
+      configurable: true,
+    });
+  });
+
+  test('given isSharedView=true then renders save and the standard action buttons', () => {
     // Given
-    render(<ReportActionButtons isSharedView onSave={vi.fn()} />);
+    render(
+      <ReportActionButtons
+        isSharedView
+        shareUrl="https://app.policyengine.org/us/report-output/sur-abc123?share=abc"
+        onSave={vi.fn()}
+        onView={vi.fn()}
+        onReproduce={vi.fn()}
+      />
+    );
 
     // Then
     expect(screen.getByRole('button', { name: /save report to my reports/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /share/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /view/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /share/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /view/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reproduce in python/i })).toBeInTheDocument();
   });
 
   test('given isSharedView=false then renders reproduce, view, and share buttons', () => {
@@ -18,7 +39,7 @@ describe('ReportActionButtons', () => {
     render(
       <ReportActionButtons
         isSharedView={false}
-        onShare={vi.fn()}
+        shareUrl="https://app.policyengine.org/us/report-output/sur-abc123?share=abc"
         onView={vi.fn()}
         onReproduce={vi.fn()}
       />
@@ -44,17 +65,17 @@ describe('ReportActionButtons', () => {
     expect(handleSave).toHaveBeenCalledOnce();
   });
 
-  test('given onShare callback then calls it when share clicked', async () => {
+  test('given share url then copies the link and shows confirmation when share clicked', async () => {
     // Given
     const user = userEvent.setup();
-    const handleShare = vi.fn();
-    render(<ReportActionButtons isSharedView={false} onShare={handleShare} />);
+    const shareUrl = 'https://app.policyengine.org/us/report-output/sur-abc123?share=abc';
+    render(<ReportActionButtons isSharedView={false} shareUrl={shareUrl} />);
 
     // When
     await user.click(screen.getByRole('button', { name: /share/i }));
 
     // Then
-    expect(handleShare).toHaveBeenCalledOnce();
+    expect(screen.getByText(/share link copied/i)).toBeInTheDocument();
   });
 
   test('given onReproduce callback then calls it when reproduce clicked', async () => {

--- a/app/src/tests/unit/pages/ReportOutput.page.test.tsx
+++ b/app/src/tests/unit/pages/ReportOutput.page.test.tsx
@@ -120,6 +120,12 @@ describe('ReportOutputPage', () => {
     expect(screen.getByRole('heading', { name: 'Test Report' })).toBeInTheDocument();
   });
 
+  test('given reproduce subpage then breadcrumb returns to the current report', () => {
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="reproduce" />);
+
+    expect(screen.getByText('Back to Test Report')).toBeInTheDocument();
+  });
+
   test('given society-wide report output versions then version metadata is displayed in the header', () => {
     render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
 

--- a/app/src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx
+++ b/app/src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx
@@ -172,6 +172,22 @@ describe('ReportOutputLayout', () => {
     expect(screen.getByText(testContent)).toBeInTheDocument();
   });
 
+  test('given back label then breadcrumb uses report-specific text', () => {
+    render(
+      <ReportOutputLayout
+        reportId={MOCK_REPORT_ID}
+        reportLabel={MOCK_REPORT_LABEL}
+        timestamp={MOCK_TIMESTAMP}
+        backPath="/us/report-output/sur-123"
+        backLabel="test report"
+      >
+        <div>Test Content</div>
+      </ReportOutputLayout>
+    );
+
+    expect(screen.getByText('Back to test report')).toBeInTheDocument();
+  });
+
   test('given isSharedView=true then shows SharedReportTag and save button', () => {
     // Given
     render(
@@ -181,7 +197,10 @@ describe('ReportOutputLayout', () => {
         reportYear={MOCK_REPORT_YEAR}
         timestamp={MOCK_TIMESTAMP}
         isSharedView
+        shareUrl="https://app.policyengine.org/us/report-output/sur-abc123?share=abc"
         onSave={vi.fn()}
+        onView={vi.fn()}
+        onReproduce={vi.fn()}
       >
         <div>Content</div>
       </ReportOutputLayout>
@@ -190,6 +209,9 @@ describe('ReportOutputLayout', () => {
     // Then
     expect(screen.getByTestId('shared-report-tag')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /save report to my reports/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /view/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reproduce in python/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /share/i })).toBeInTheDocument();
   });
 
   test('given isSharedView=false then shows view, edit, and share buttons', () => {
@@ -201,7 +223,7 @@ describe('ReportOutputLayout', () => {
         reportYear={MOCK_REPORT_YEAR}
         timestamp={MOCK_TIMESTAMP}
         isSharedView={false}
-        onShare={vi.fn()}
+        shareUrl="https://app.policyengine.org/us/report-output/sur-abc123?share=abc"
         onView={vi.fn()}
         onReproduce={vi.fn()}
       >

--- a/app/src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import ModifyReportPage from '@/pages/reportBuilder/ModifyReportPage';
 import type { ReportIngredientsInput } from '@/hooks/utils/useFetchReportIngredients';
+import ModifyReportPage from '@/pages/reportBuilder/ModifyReportPage';
 import type { ReportBuilderState } from '@/pages/reportBuilder/types';
 
 const mockUseAppLocation = vi.fn();
@@ -65,7 +65,10 @@ vi.mock('@/pages/reportBuilder/components', () => ({
 describe('ModifyReportPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseAppLocation.mockReturnValue({ pathname: '/us/report-output/sur-123/config', search: '' });
+    mockUseAppLocation.mockReturnValue({
+      pathname: '/us/report-output/sur-123/config',
+      search: '',
+    });
     mockUseReportBuilderState.mockReturnValue({
       reportState: baseReportState,
       setReportState: vi.fn(),

--- a/app/src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import ModifyReportPage from '@/pages/reportBuilder/ModifyReportPage';
+import type { ReportIngredientsInput } from '@/hooks/utils/useFetchReportIngredients';
+import type { ReportBuilderState } from '@/pages/reportBuilder/types';
+
+const mockUseAppLocation = vi.fn();
+const mockUseReportBuilderState = vi.fn();
+const mockReportBuilderShell = vi.fn();
+
+const baseReportState: ReportBuilderState = {
+  id: 'sur-123',
+  label: 'Test report',
+  year: '2024',
+  simulations: [],
+};
+
+vi.mock('@/hooks/useCurrentCountry', () => ({
+  useCurrentCountry: () => 'us',
+}));
+
+vi.mock('@/contexts/NavigationContext', async () => {
+  const actual = await vi.importActual<typeof import('@/contexts/NavigationContext')>(
+    '@/contexts/NavigationContext'
+  );
+  return {
+    ...actual,
+    useAppNavigate: () => ({
+      push: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/contexts/LocationContext', async () => {
+  const actual = await vi.importActual<typeof import('@/contexts/LocationContext')>(
+    '@/contexts/LocationContext'
+  );
+  return {
+    ...actual,
+    useAppLocation: () => mockUseAppLocation(),
+  };
+});
+
+vi.mock('@/pages/reportBuilder/hooks/useReportBuilderState', () => ({
+  useReportBuilderState: (...args: unknown[]) => mockUseReportBuilderState(...args),
+}));
+
+vi.mock('@/pages/reportBuilder/hooks/useModifyReportSubmission', () => ({
+  useModifyReportSubmission: () => ({
+    handleSaveAsNew: vi.fn(),
+    handleReplace: vi.fn(),
+    isSavingNew: false,
+    isReplacing: false,
+  }),
+}));
+
+vi.mock('@/pages/reportBuilder/components', () => ({
+  ReportBuilderShell: (props: unknown) => {
+    mockReportBuilderShell(props);
+    return <div data-testid="report-builder-shell" />;
+  },
+  SimulationBlockFull: () => <div data-testid="simulation-block-full" />,
+}));
+
+describe('ModifyReportPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAppLocation.mockReturnValue({ pathname: '/us/report-output/sur-123/config', search: '' });
+    mockUseReportBuilderState.mockReturnValue({
+      reportState: baseReportState,
+      setReportState: vi.fn(),
+      originalState: baseReportState,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  test('given owned report then edit action is available', () => {
+    render(<ModifyReportPage userReportId="sur-123" />);
+
+    const shellProps = mockReportBuilderShell.mock.calls[0]?.[0];
+    expect(shellProps.actions).toHaveLength(1);
+    expect(shellProps.actions[0].label).toBe('Edit report');
+    expect(shellProps.isReadOnly).toBe(true);
+    expect(shellProps.backPath).toBe('/us/report-output/sur-123');
+    expect(shellProps.backLabel).toBe('Test report');
+  });
+
+  test('given share query then builder stays read-only and hides edit actions', () => {
+    const shareData: ReportIngredientsInput = {
+      userReport: {
+        id: 'sur-shared-123',
+        reportId: 'rpt-123',
+        countryId: 'us',
+        label: 'Shared report',
+      },
+      userSimulations: [],
+      userPolicies: [],
+      userHouseholds: [],
+      userGeographies: [],
+    };
+    const encodedShare = btoa(JSON.stringify(shareData))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+
+    mockUseAppLocation.mockReturnValue({
+      pathname: '/us/report-output/sur-shared-123/config',
+      search: `?share=${encodedShare}`,
+    });
+
+    render(<ModifyReportPage userReportId="sur-shared-123" />);
+
+    const shellProps = mockReportBuilderShell.mock.calls[0]?.[0];
+    expect(shellProps.title).toBe('View report setup');
+    expect(shellProps.actions).toEqual([]);
+    expect(shellProps.isReadOnly).toBe(true);
+    expect(shellProps.backPath).toBe(`/us/report-output/sur-shared-123?share=${encodedShare}`);
+    expect(shellProps.backLabel).toBe('Test report');
+    expect(mockUseReportBuilderState).toHaveBeenCalledWith('sur-shared-123', shareData);
+    expect(screen.getByTestId('report-builder-shell')).toBeInTheDocument();
+  });
+});

--- a/app/src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx
@@ -120,4 +120,19 @@ describe('ModifyReportPage', () => {
     expect(mockUseReportBuilderState).toHaveBeenCalledWith('sur-shared-123', shareData);
     expect(screen.getByTestId('report-builder-shell')).toBeInTheDocument();
   });
+
+  test('given report with no label then breadcrumb falls back to report id', () => {
+    mockUseReportBuilderState.mockReturnValue({
+      reportState: { ...baseReportState, label: null },
+      setReportState: vi.fn(),
+      originalState: { ...baseReportState, label: null },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModifyReportPage userReportId="sur-123" />);
+
+    const shellProps = mockReportBuilderShell.mock.calls[0]?.[0];
+    expect(shellProps.backLabel).toBe('sur-123');
+  });
 });

--- a/app/src/tests/unit/pages/reportBuilder/modals/PolicyCreationModal.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/modals/PolicyCreationModal.test.tsx
@@ -71,7 +71,9 @@ describe('PolicyCreationModal', () => {
     );
 
     expect(screen.queryByRole('button', { name: /edit this policy/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /update existing policy/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /update existing policy/i })
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /save as new policy/i })).not.toBeInTheDocument();
   });
 

--- a/app/src/tests/unit/pages/reportBuilder/modals/PolicyCreationModal.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/modals/PolicyCreationModal.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { PolicyCreationModal } from '@/pages/reportBuilder/modals/PolicyCreationModal';
+import type { PolicyStateProps } from '@/types/pathwayState';
+
+const mockReduxState = {
+  metadata: {
+    parameterTree: null,
+    parameters: {},
+    loading: false,
+    economyOptions: {
+      time_period: [{ name: '2024', label: '2024' }],
+    },
+  },
+};
+
+vi.mock('react-redux', async () => {
+  const actual = await vi.importActual<typeof import('react-redux')>('react-redux');
+  return {
+    ...actual,
+    useSelector: (selector: (state: typeof mockReduxState) => unknown) => selector(mockReduxState),
+  };
+});
+
+vi.mock('@/hooks/useCurrentCountry', () => ({
+  useCurrentCountry: () => 'us',
+}));
+
+vi.mock('@/hooks/useCreatePolicy', () => ({
+  useCreatePolicy: () => ({
+    createPolicy: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useUserPolicy', () => ({
+  useUpdatePolicyAssociation: () => ({
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+vi.mock('@/pages/reportBuilder/modals/policyCreation', () => ({
+  ChangesCard: () => <div data-testid="changes-card" />,
+  EmptyParameterState: () => <div data-testid="empty-parameter-state" />,
+  HistoricalValuesCard: () => <div data-testid="historical-values-card" />,
+  ParameterHeaderCard: () => <div data-testid="parameter-header-card" />,
+  ParameterSidebar: () => <div data-testid="parameter-sidebar" />,
+  PolicyOverviewContent: () => <div data-testid="policy-overview-content" />,
+  ValueSetterCard: () => <div data-testid="value-setter-card" />,
+}));
+
+const initialPolicy: PolicyStateProps = {
+  id: 'pol-123',
+  label: 'Test policy',
+  parameters: [],
+};
+
+describe('PolicyCreationModal', () => {
+  test('given forceReadOnly then does not render edit transition actions', () => {
+    render(
+      <PolicyCreationModal
+        isOpen
+        onClose={vi.fn()}
+        onPolicyCreated={vi.fn()}
+        reportYear="2024"
+        simulationIndex={0}
+        initialPolicy={initialPolicy}
+        initialEditorMode="display"
+        forceReadOnly
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /edit this policy/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /update existing policy/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /save as new policy/i })).not.toBeInTheDocument();
+  });
+
+  test('given display mode without forceReadOnly then renders edit transition action', () => {
+    render(
+      <PolicyCreationModal
+        isOpen
+        onClose={vi.fn()}
+        onPolicyCreated={vi.fn()}
+        reportYear="2024"
+        simulationIndex={0}
+        initialPolicy={initialPolicy}
+        initialEditorMode="display"
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /edit this policy/i })).toBeInTheDocument();
+  });
+});

--- a/app/src/tests/unit/utils/reportRouting.test.ts
+++ b/app/src/tests/unit/utils/reportRouting.test.ts
@@ -4,7 +4,7 @@ import {
   TEST_COUNTRY,
   TEST_REPORT_IDS,
 } from '@/tests/fixtures/utils/reportRoutingMocks';
-import { getReportOutputPath } from '@/utils/reportRouting';
+import { getReportConfigPath, getReportOutputPath } from '@/utils/reportRouting';
 
 describe('reportRouting', () => {
   describe('getReportOutputPath', () => {
@@ -38,6 +38,20 @@ describe('reportRouting', () => {
 
       // Then
       expect(result.startsWith('/')).toBe(true);
+    });
+  });
+
+  describe('getReportConfigPath', () => {
+    it('given US country and numeric report ID then returns correct config path', () => {
+      const result = getReportConfigPath(TEST_COUNTRY.US, TEST_REPORT_IDS.NUMERIC);
+
+      expect(result).toBe(EXPECTED_PATHS.US_NUMERIC_CONFIG);
+    });
+
+    it('given UK country and string report ID then returns correct config path', () => {
+      const result = getReportConfigPath(TEST_COUNTRY.UK, TEST_REPORT_IDS.STRING);
+
+      expect(result).toBe(EXPECTED_PATHS.UK_STRING_CONFIG);
     });
   });
 });

--- a/app/src/utils/reportRouting.ts
+++ b/app/src/utils/reportRouting.ts
@@ -8,3 +8,14 @@
 export function getReportOutputPath(countryId: string, userReportId: string | number): string {
   return `/${countryId}/report-output/${userReportId}`;
 }
+
+/**
+ * Generates the absolute URL path to a report configuration page.
+ *
+ * @param countryId - The country ID (e.g., 'us', 'uk')
+ * @param userReportId - The user report ID
+ * @returns Absolute path to the report configuration page
+ */
+export function getReportConfigPath(countryId: string, userReportId: string | number): string {
+  return `${getReportOutputPath(countryId, userReportId)}/config`;
+}

--- a/calculator-app/.vercel-deploy-trigger
+++ b/calculator-app/.vercel-deploy-trigger
@@ -1,0 +1,1 @@
+This file exists to force Vercel to treat calculator-app as affected.

--- a/calculator-app/src/app/[countryId]/report-output/[reportId]/config/page.tsx
+++ b/calculator-app/src/app/[countryId]/report-output/[reportId]/config/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { use } from "react";
+import StandardLayout from "@/components/StandardLayout";
+import ModifyReportPage from "@/pages/reportBuilder/ModifyReportPage";
+import { CalculatorProviders } from "../../../providers";
+
+export default function ReportConfigRoute({
+  params,
+}: {
+  params: Promise<{ reportId: string }>;
+}) {
+  const { reportId } = use(params);
+
+  return (
+    <CalculatorProviders>
+      <StandardLayout>
+        <ModifyReportPage userReportId={reportId} />
+      </StandardLayout>
+    </CalculatorProviders>
+  );
+}


### PR DESCRIPTION
Fixes #960

## Summary

This keeps the scope narrow to shared report viewing and config access:
- shows the normal report output actions in shared mode where they are safe
- adds a canonical report config route at `/report-output/:reportId/config`
- keeps shared config strictly read-only, including policy modal flows
- updates the share interaction to copy immediately with app-native styling
- makes report/config/reproduce breadcrumbs consistently point back to the current report

## Testing

- `bun run vitest src/tests/unit/utils/reportRouting.test.ts src/tests/unit/pages/ReportOutput.page.test.tsx src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx src/tests/unit/pages/report-output/ReportOutputLayout.test.tsx`
- `bun run vitest src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx src/tests/unit/pages/reportBuilder/modals/PolicyCreationModal.test.tsx src/tests/unit/pages/ReportOutput.page.test.tsx`
- `bun run typecheck` in `calculator-app`
