### PR TITLE
Restore analytics bootstrapping in Next apps

### DIFF
--- a/calculator-app/src/app/layout.tsx
+++ b/calculator-app/src/app/layout.tsx
@@ -1,5 +1,10 @@
 import type { Metadata } from "next";
+import Script from "next/script";
+import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
+
+const GA_MEASUREMENT_ID = "G-2YHG89FY0N";
 
 export const metadata: Metadata = {
   title: "PolicyEngine Calculator",
@@ -14,8 +19,25 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            window.gtag = gtag;
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}');
+          `}
+        </Script>
+      </head>
       <body>
         <div id="root">{children}</div>
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -1,5 +1,10 @@
 import type { Metadata } from "next";
+import Script from "next/script";
+import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
+
+const GA_MEASUREMENT_ID = "G-2YHG89FY0N";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.policyengine.org"),
@@ -19,6 +24,19 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            window.gtag = gtag;
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}');
+          `}
+        </Script>
         <link
           href="https://fonts.googleapis.com/css2?family=Inter:wght@100;300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
           rel="stylesheet"
@@ -32,6 +50,8 @@ export default function RootLayout({
         }}
       >
         {children}
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
Restore GA4 and Vercel analytics bootstrapping in the Next.js website and calculator app layouts.

## Root cause
The legacy Vite apps loaded GA and mounted Vercel Analytics, but the migrated Next app layouts did not. That left `window.gtag` undefined on migrated routes and caused analytics to drop sharply once traffic shifted to those apps.

## Changes
- load `gtag.js` in `website/src/app/layout.tsx`
- initialize `window.dataLayer` and `window.gtag` in `website/src/app/layout.tsx`
- mount `@vercel/analytics` and `@vercel/speed-insights` in `website/src/app/layout.tsx`
- load `gtag.js` in `calculator-app/src/app/layout.tsx`
- initialize `window.dataLayer` and `window.gtag` in `calculator-app/src/app/layout.tsx`
- mount `@vercel/analytics` and `@vercel/speed-insights` in `calculator-app/src/app/layout.tsx`

## Verification
- ran local Next dev servers via `bun run dev`
- verified served HTML for `http://localhost:3002/us` includes GA4 bootstrap and Vercel analytics clients
- verified served HTML for `http://localhost:3002/us/pe84` includes GA4 bootstrap and the migrated `AppClient` route bundle used for `tool_engaged`
- verified served HTML for `http://localhost:3003/us/simulations` includes GA4 bootstrap and Vercel analytics clients

## Notes
- local calculator routes still surface an unrelated existing SSR issue: `No QueryClient set, use QueryClientProvider to set one`
- that issue is separate from this analytics fix and does not change the restored analytics bootstrapping
