### PR TITLE
Add AI inequality income-shift route

### DIFF
--- a/website/src/app/[countryId]/ai-inequality/income-shift/page.tsx
+++ b/website/src/app/[countryId]/ai-inequality/income-shift/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Income shift experiment",
+  description:
+    "A PolicyEngine prototype examining distributional effects when positive labor income shifts to positive capital income.",
+};
+
+export default function IncomeShiftPage() {
+  return (
+    <iframe
+      src="https://ai-inequality-theta.vercel.app/income-shift"
+      title="Income shift experiment | PolicyEngine"
+      style={{
+        width: "100%",
+        height: "calc(100vh - 120px)",
+        border: "none",
+      }}
+    />
+  );
+}

--- a/website/src/app/[countryId]/ai-inequality/page.tsx
+++ b/website/src/app/[countryId]/ai-inequality/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 export default function AIInequalityPage() {
   return (
     <iframe
-      src="https://policyengine.github.io/ai-inequality"
+      src="https://ai-inequality-theta.vercel.app"
       title="AI and inequality | PolicyEngine"
       style={{
         width: "100%",


### PR DESCRIPTION
## Summary\n- point the AI inequality wrapper at the current Vercel-hosted app\n- add a nested /ai-inequality/income-shift route for the standalone income-shift experiment\n\n## Tests\n- bun run design-system:build\n- bun run --filter=@policyengine/website typecheck\n- bun run --filter=@policyengine/website build