### PR TITLE
Pass AI inequality country into embedded app

### DIFF
--- a/website/src/app/[countryId]/ai-inequality/income-shift/page.tsx
+++ b/website/src/app/[countryId]/ai-inequality/income-shift/page.tsx
@@ -6,10 +6,20 @@ export const metadata: Metadata = {
     "A PolicyEngine prototype examining distributional effects when positive labor income shifts to positive capital income.",
 };
 
-export default function IncomeShiftPage() {
+type Props = {
+  params: Promise<{ countryId: string }>;
+};
+
+function countryQuery(countryId: string) {
+  return countryId === "us" ? "" : `?country=${encodeURIComponent(countryId)}`;
+}
+
+export default async function IncomeShiftPage({ params }: Props) {
+  const { countryId } = await params;
+
   return (
     <iframe
-      src="https://ai-inequality-theta.vercel.app/income-shift"
+      src={`https://ai-inequality-theta.vercel.app/income-shift${countryQuery(countryId)}`}
       title="Income shift experiment | PolicyEngine"
       style={{
         width: "100%",

--- a/website/src/app/[countryId]/ai-inequality/page.tsx
+++ b/website/src/app/[countryId]/ai-inequality/page.tsx
@@ -6,10 +6,20 @@ export const metadata: Metadata = {
     "Research examining how policy interventions shape distributional outcomes when AI drives economic transformation.",
 };
 
-export default function AIInequalityPage() {
+type Props = {
+  params: Promise<{ countryId: string }>;
+};
+
+function countryQuery(countryId: string) {
+  return countryId === "us" ? "" : `?country=${encodeURIComponent(countryId)}`;
+}
+
+export default async function AIInequalityPage({ params }: Props) {
+  const { countryId } = await params;
+
   return (
     <iframe
-      src="https://ai-inequality-theta.vercel.app"
+      src={`https://ai-inequality-theta.vercel.app${countryQuery(countryId)}`}
       title="AI and inequality | PolicyEngine"
       style={{
         width: "100%",


### PR DESCRIPTION
## Summary
- pass the app-v2 country id into the AI inequality iframe as a query parameter
- make /uk/ai-inequality and /uk/ai-inequality/income-shift open the UK view of the embedded tool while preserving the US default

## Tests
- bun run design-system:build
- bun run --filter=@policyengine/website typecheck
- bun run --filter=@policyengine/website build