### PR TITLE
Fix calculator mobile header overflow

### DIFF
--- a/app/src/components/homeHeader/MobileMenu.tsx
+++ b/app/src/components/homeHeader/MobileMenu.tsx
@@ -1,5 +1,5 @@
 import { IconMenu2 } from '@tabler/icons-react';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui';
 import { colors, spacing, typography } from '@/designTokens';
 import CountrySelector from './CountrySelector';
 import { NavItemSetup } from './NavItem';
@@ -32,10 +32,18 @@ export default function MobileMenu({ opened, onOpen, onClose, navItems }: Mobile
         <SheetContent
           side="right"
           className="tw:w-[300px]"
-          style={{ backgroundColor: colors.primary[600] }}
+          style={{
+            backgroundColor: colors.primary[600],
+            width: 'min(300px, calc(100vw - 24px))',
+            maxWidth: '100vw',
+            boxSizing: 'border-box',
+          }}
         >
           <SheetHeader>
             <SheetTitle className="tw:text-white">Menu</SheetTitle>
+            <SheetDescription className="tw:sr-only">
+              Mobile site navigation and country selector links.
+            </SheetDescription>
           </SheetHeader>
           <div className="tw:flex tw:flex-col" style={{ gap: spacing.lg, padding: spacing.lg }}>
             {navItems.map((item) =>

--- a/app/src/components/shared/HomeHeader.tsx
+++ b/app/src/components/shared/HomeHeader.tsx
@@ -55,7 +55,8 @@ export default function HeaderNavigation({ navbarOpened, onToggleNavbar }: Heade
       style={{
         position: 'sticky',
         top: 0,
-        padding: `${spacing.sm} ${spacing['2xl']}`,
+        paddingBlock: spacing.sm,
+        paddingInline: 'clamp(16px, 4vw, 32px)',
         height: spacing.layout.header,
         background: `linear-gradient(to right, ${colors.primary[800]}, ${colors.primary[600]})`,
         borderBottom: `0.5px solid ${colors.primary[700]}`,
@@ -65,6 +66,7 @@ export default function HeaderNavigation({ navbarOpened, onToggleNavbar }: Heade
         opacity: opened ? 0 : 1,
         transition: 'opacity 0.1s ease',
         width: '100%',
+        boxSizing: 'border-box',
       }}
     >
       <HeaderContent

--- a/app/src/tests/unit/components/homeHeader/MobileMenu.test.tsx
+++ b/app/src/tests/unit/components/homeHeader/MobileMenu.test.tsx
@@ -63,6 +63,27 @@ describe('MobileMenu', () => {
     expect(screen.getByText('Donate')).toBeInTheDocument();
   });
 
+  test('given menu is opened then drawer width stays within the viewport', () => {
+    // Given
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+
+    // When
+    renderWithCountry(
+      <MobileMenu opened onOpen={onOpen} onClose={onClose} navItems={MOCK_NAV_ITEMS} />,
+      'us'
+    );
+
+    // Then
+    const drawerTitle = screen.getByText('Menu');
+    const drawer = drawerTitle.closest('[data-slot="sheet-content"]');
+    expect(drawer).toHaveStyle({
+      width: 'min(300px, calc(100vw - 24px))',
+      maxWidth: '100vw',
+      boxSizing: 'border-box',
+    });
+  });
+
   test('given menu is opened then displays dropdown section with items', () => {
     // Given
     const onOpen = vi.fn();

--- a/app/src/tests/unit/components/shared/HomeHeader.test.tsx
+++ b/app/src/tests/unit/components/shared/HomeHeader.test.tsx
@@ -41,6 +41,18 @@ describe('HeaderNavigation', () => {
       // Then
       expect(container.firstChild).toBeInTheDocument();
     });
+
+    test('given component renders then header uses border-box sizing to avoid mobile overflow', () => {
+      // When
+      const { container } = renderWithCountry(<HeaderNavigation />, TEST_COUNTRIES.US);
+
+      // Then
+      expect(container.firstChild).toHaveStyle({
+        width: '100%',
+        boxSizing: 'border-box',
+        paddingInline: 'clamp(16px, 4vw, 32px)',
+      });
+    });
   });
 
   describe('website app mode (same-app navigation)', () => {

--- a/calculator-app/src/vite-env-shim.d.ts
+++ b/calculator-app/src/vite-env-shim.d.ts
@@ -1,6 +1,7 @@
 /**
  * Type declarations for import.meta.env used in shared code from app/src/.
  * Values are polyfilled at build time via DefinePlugin in next.config.ts.
+ * Keep this file touched when a calculator-only deploy trigger is needed.
  */
 interface ImportMetaEnv {
   readonly DEV: boolean;


### PR DESCRIPTION
## Summary
Fixes the mobile header overflow issue in the calculator Next.js app by updating the shared app header path that calculator-app imports.

- make the shared app header use border-box sizing with responsive horizontal padding
- clamp the shared mobile menu drawer width to the viewport
- add the missing sheet description for the shared mobile menu
- add focused tests for the shared app header and mobile menu

## Testing
- bun run vitest src/tests/unit/components/shared/HomeHeader.test.tsx src/tests/unit/components/homeHeader/MobileMenu.test.tsx src/tests/unit/components/StandardLayout.test.tsx

## Note
This targets the calculator app path, which resolves shared UI from app/src rather than website/src.