### PR TITLE
Fix household chart focus person and marker placement

### DIFF
--- a/app/src/hooks/useHouseholdVariation.ts
+++ b/app/src/hooks/useHouseholdVariation.ts
@@ -12,6 +12,7 @@ interface UseHouseholdVariationParams {
   policyData: any;
   year: string;
   countryId: string;
+  personName?: string | null;
   enabled?: boolean;
 }
 
@@ -39,17 +40,29 @@ export function useHouseholdVariation({
   policyData,
   year,
   countryId,
+  personName,
   enabled = true,
 }: UseHouseholdVariationParams) {
   return useQuery({
-    queryKey: householdVariationKeys.byParams(householdId, policyId, year, countryId),
+    queryKey: householdVariationKeys.byParams(
+      householdId,
+      policyId,
+      year,
+      countryId,
+      personName ?? ''
+    ),
     queryFn: async () => {
       // Step 1: Fetch household input structure from API
       const householdMetadata = await fetchHouseholdById(countryId, householdId);
       const householdInput = householdMetadata.household_json;
 
       // Step 2: Build axes configuration
-      const householdWithAxes = buildHouseholdVariationAxes(householdInput, year, countryId);
+      const householdWithAxes = buildHouseholdVariationAxes(
+        householdInput,
+        year,
+        countryId,
+        personName
+      );
 
       // Step 3: Call calculate-full API
       const resultData = await fetchHouseholdVariation(countryId, householdWithAxes, policyData);

--- a/app/src/libs/queryKeys.ts
+++ b/app/src/libs/queryKeys.ts
@@ -91,7 +91,13 @@ export const calculationKeys = {
 
 export const householdVariationKeys = {
   all: ['household-variations'] as const,
-  byParams: (householdId: string, policyId: string, year: string, countryId: string) =>
+  byParams: (
+    householdId: string,
+    policyId: string,
+    year: string,
+    countryId: string,
+    personName = ''
+  ) =>
     [
       ...householdVariationKeys.all,
       'household',
@@ -102,5 +108,7 @@ export const householdVariationKeys = {
       year,
       'country',
       countryId,
+      'person',
+      personName,
     ] as const,
 };

--- a/app/src/pages/report-output/earnings-variation/BaselineAndReformChart.tsx
+++ b/app/src/pages/report-output/earnings-variation/BaselineAndReformChart.tsx
@@ -8,6 +8,7 @@ import {
   Legend,
   Line,
   LineChart,
+  ReferenceDot,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -22,13 +23,28 @@ import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useViewportSize } from '@/hooks/useViewportSize';
 import type { RootState } from '@/store';
 import type { Household } from '@/types/ingredients/Household';
-import { getClampedChartHeight, getNiceTicks, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  getClampedChartHeight,
+  getNiceTicks,
+  getYAxisLayout,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { currencySymbol } from '@/utils/formatters';
+import { getHeadOfHouseholdPersonName } from '@/utils/householdHead';
+import {
+  buildHouseholdVariationEarningsAxis,
+  getHouseholdVariationIndexForEarnings,
+  getHouseholdVariationMaxEarnings,
+} from '@/utils/householdVariationAxes';
+import {
+  formatChartValueForVariable,
+} from '@/utils/chartValueFormatting';
 import { getValueFromHousehold } from '@/utils/householdValues';
 
 interface Props {
   baseline: Household;
   baselineVariation: Household;
+  focusPersonName?: string | null;
   reform: Household;
   reformVariation: Household;
   variableName: string;
@@ -36,8 +52,8 @@ interface Props {
 }
 
 type ViewMode = 'both' | 'absolute' | 'relative';
+function EarningsTooltip({ active, payload, label, formatValue, symbol }: any) {
 
-function EarningsTooltip({ active, payload, label, symbol }: any) {
   if (!active || !payload?.length) {
     return null;
   }
@@ -52,7 +68,7 @@ function EarningsTooltip({ active, payload, label, symbol }: any) {
           key={p.name}
           style={{ margin: '2px 0', fontSize: typography.fontSize.sm, color: p.stroke }}
         >
-          {p.name}: {p.value}
+          {p.name}: {formatValue(Number(p.value))}
         </p>
       ))}
     </div>
@@ -90,7 +106,8 @@ function PercentTooltip({ active, payload, label, symbol }: any) {
 export default function BaselineAndReformChart({
   baseline,
   baselineVariation,
-  reform: _reform,
+  focusPersonName,
+  reform,
   reformVariation,
   variableName,
   year,
@@ -123,17 +140,19 @@ export default function BaselineAndReformChart({
       return null;
     }
 
-    const firstPersonName = Object.keys(baseline.householdData?.people || {})[0];
+    const resolvedFocusPersonName =
+      focusPersonName ?? getHeadOfHouseholdPersonName(baseline, year);
     const currentEarnings = getValueFromHousehold(
       'employment_income',
       year,
-      firstPersonName,
+      resolvedFocusPersonName,
       baseline,
       metadata
     ) as number;
 
-    const maxEarnings = Math.max(countryId === 'ng' ? 1_200_000 : 200_000, 2 * currentEarnings);
-    const xValues = Array.from({ length: 401 }, (_, i) => (i * maxEarnings) / 400);
+    const maxEarnings = getHouseholdVariationMaxEarnings(currentEarnings, countryId);
+    const xValues = buildHouseholdVariationEarningsAxis(maxEarnings);
+    const currentIndex = getHouseholdVariationIndexForEarnings(currentEarnings, maxEarnings);
     const absoluteDiff = baselineYValues.map(
       (baseValue, index) => reformYValues[index] - baseValue
     );
@@ -148,6 +167,20 @@ export default function BaselineAndReformChart({
       relativeDiff: relativeDiff[index],
     }));
     const allBothValues = [...baselineYValues, ...reformYValues];
+    const exactCurrentBaselineValue = getValueFromHousehold(
+      variableName,
+      year,
+      null,
+      baseline,
+      metadata
+    );
+    const exactCurrentReformValue = getValueFromHousehold(
+      variableName,
+      year,
+      null,
+      reform,
+      metadata
+    );
 
     return {
       absoluteDiff,
@@ -155,6 +188,15 @@ export default function BaselineAndReformChart({
       baselineYValues,
       bothYTicks: getNiceTicks([Math.min(...allBothValues), Math.max(...allBothValues)]),
       chartData,
+      currentBaselineValue:
+        typeof exactCurrentBaselineValue === 'number'
+          ? exactCurrentBaselineValue
+          : (baselineYValues[currentIndex] ?? null),
+      currentEarnings,
+      currentReformValue:
+        typeof exactCurrentReformValue === 'number'
+          ? exactCurrentReformValue
+          : (reformYValues[currentIndex] ?? null),
       maxEarnings,
       relDiffTicks: getNiceTicks([Math.min(...relativeDiff), Math.max(...relativeDiff)]),
       reformYValues,
@@ -172,18 +214,39 @@ export default function BaselineAndReformChart({
   }
 
   const symbol = currencySymbol(countryId);
+  const formatValue = (value: number) =>
+    formatChartValueForVariable(value, variable, countryId);
+  const bothYAxis = getYAxisLayout(chartSeries.bothYTicks, true, formatValue);
+  const absoluteYAxis = getYAxisLayout(chartSeries.absDiffTicks, true, formatValue);
+  const relativeYAxis = getYAxisLayout(
+    chartSeries.relDiffTicks,
+    true,
+    (value: number) => `${(value * 100).toFixed(1)}%`
+  );
+  const bothChartMargin = { top: 20, right: 20, bottom: 80, left: bothYAxis.marginLeft };
+  const absoluteChartMargin = {
+    top: 20,
+    right: 20,
+    bottom: 80,
+    left: absoluteYAxis.marginLeft,
+  };
+  const relativeChartMargin = {
+    top: 20,
+    right: 20,
+    bottom: 80,
+    left: relativeYAxis.marginLeft,
+  };
 
   const renderChart = () => {
     if (viewMode === 'both') {
       return (
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <LineChart
-            data={chartSeries.chartData}
-            margin={{ top: 20, right: 20, bottom: 80, left: 80 }}
-          >
+          <LineChart data={chartSeries.chartData} margin={bothChartMargin}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
               dataKey="earnings"
+              type="number"
+              domain={[0, chartSeries.maxEarnings]}
               ticks={chartSeries.xTicks}
               tick={RECHARTS_FONT_STYLE}
               tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
@@ -202,15 +265,18 @@ export default function BaselineAndReformChart({
                 chartSeries.bothYTicks[chartSeries.bothYTicks.length - 1],
               ]}
               tick={RECHARTS_FONT_STYLE}
+              tickFormatter={(value: number) => formatValue(value)}
+              width={bothYAxis.yAxisWidth}
             >
               <Label
                 value={variable.label}
                 angle={-90}
-                position="insideLeft"
+                position="center"
+                dx={bothYAxis.labelDx}
                 style={{ textAnchor: 'middle', ...RECHARTS_FONT_STYLE }}
               />
             </YAxis>
-            <Tooltip content={<EarningsTooltip symbol={symbol} />} />
+            <Tooltip content={<EarningsTooltip symbol={symbol} formatValue={formatValue} />} />
             <Legend verticalAlign="top" align="left" />
             <Line
               type="monotone"
@@ -228,6 +294,24 @@ export default function BaselineAndReformChart({
               strokeWidth={2}
               dot={false}
             />
+            <ReferenceDot
+              x={chartSeries.currentEarnings}
+              y={chartSeries.currentBaselineValue}
+              r={5}
+              fill={colors.gray[600]}
+              stroke={colors.background.primary}
+              strokeWidth={2}
+              ifOverflow="visible"
+            />
+            <ReferenceDot
+              x={chartSeries.currentEarnings}
+              y={chartSeries.currentReformValue}
+              r={5}
+              fill={colors.primary[500]}
+              stroke={colors.background.primary}
+              strokeWidth={2}
+              ifOverflow="visible"
+            />
           </LineChart>
         </ResponsiveContainer>
       );
@@ -236,13 +320,12 @@ export default function BaselineAndReformChart({
     if (viewMode === 'absolute') {
       return (
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <AreaChart
-            data={chartSeries.chartData}
-            margin={{ top: 20, right: 20, bottom: 80, left: 80 }}
-          >
+          <AreaChart data={chartSeries.chartData} margin={absoluteChartMargin}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
               dataKey="earnings"
+              type="number"
+              domain={[0, chartSeries.maxEarnings]}
               ticks={chartSeries.xTicks}
               tick={RECHARTS_FONT_STYLE}
               tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
@@ -261,15 +344,18 @@ export default function BaselineAndReformChart({
                 chartSeries.absDiffTicks[chartSeries.absDiffTicks.length - 1],
               ]}
               tick={RECHARTS_FONT_STYLE}
+              tickFormatter={(value: number) => formatValue(value)}
+              width={absoluteYAxis.yAxisWidth}
             >
               <Label
                 value={`Change in ${variable.label}`}
                 angle={-90}
-                position="insideLeft"
+                position="center"
+                dx={absoluteYAxis.labelDx}
                 style={{ textAnchor: 'middle', ...RECHARTS_FONT_STYLE }}
               />
             </YAxis>
-            <Tooltip content={<EarningsTooltip symbol={symbol} />} />
+            <Tooltip content={<EarningsTooltip symbol={symbol} formatValue={formatValue} />} />
             <Area
               type="monotone"
               dataKey="absoluteDiff"
@@ -286,13 +372,12 @@ export default function BaselineAndReformChart({
 
     return (
       <ResponsiveContainer width="100%" height={chartHeight}>
-        <AreaChart
-          data={chartSeries.chartData}
-          margin={{ top: 20, right: 20, bottom: 80, left: 80 }}
-        >
+        <AreaChart data={chartSeries.chartData} margin={relativeChartMargin}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
             dataKey="earnings"
+            type="number"
+            domain={[0, chartSeries.maxEarnings]}
             ticks={chartSeries.xTicks}
             tick={RECHARTS_FONT_STYLE}
             tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
@@ -312,11 +397,13 @@ export default function BaselineAndReformChart({
             ]}
             tick={RECHARTS_FONT_STYLE}
             tickFormatter={(v: number) => `${(v * 100).toFixed(1)}%`}
+            width={relativeYAxis.yAxisWidth}
           >
             <Label
               value={`% change in ${variable.label}`}
               angle={-90}
-              position="insideLeft"
+              position="center"
+              dx={relativeYAxis.labelDx}
               style={{ textAnchor: 'middle', ...RECHARTS_FONT_STYLE }}
             />
           </YAxis>

--- a/app/src/pages/report-output/earnings-variation/BaselineAndReformChart.tsx
+++ b/app/src/pages/report-output/earnings-variation/BaselineAndReformChart.tsx
@@ -29,17 +29,15 @@ import {
   getYAxisLayout,
   RECHARTS_FONT_STYLE,
 } from '@/utils/chartUtils';
+import { formatChartValueForVariable } from '@/utils/chartValueFormatting';
 import { currencySymbol } from '@/utils/formatters';
 import { getHeadOfHouseholdPersonName } from '@/utils/householdHead';
+import { getValueFromHousehold } from '@/utils/householdValues';
 import {
   buildHouseholdVariationEarningsAxis,
   getHouseholdVariationIndexForEarnings,
   getHouseholdVariationMaxEarnings,
 } from '@/utils/householdVariationAxes';
-import {
-  formatChartValueForVariable,
-} from '@/utils/chartValueFormatting';
-import { getValueFromHousehold } from '@/utils/householdValues';
 
 interface Props {
   baseline: Household;
@@ -53,7 +51,6 @@ interface Props {
 
 type ViewMode = 'both' | 'absolute' | 'relative';
 function EarningsTooltip({ active, payload, label, formatValue, symbol }: any) {
-
   if (!active || !payload?.length) {
     return null;
   }
@@ -140,8 +137,7 @@ export default function BaselineAndReformChart({
       return null;
     }
 
-    const resolvedFocusPersonName =
-      focusPersonName ?? getHeadOfHouseholdPersonName(baseline, year);
+    const resolvedFocusPersonName = focusPersonName ?? getHeadOfHouseholdPersonName(baseline, year);
     const currentEarnings = getValueFromHousehold(
       'employment_income',
       year,
@@ -214,8 +210,7 @@ export default function BaselineAndReformChart({
   }
 
   const symbol = currencySymbol(countryId);
-  const formatValue = (value: number) =>
-    formatChartValueForVariable(value, variable, countryId);
+  const formatValue = (value: number) => formatChartValueForVariable(value, variable, countryId);
   const bothYAxis = getYAxisLayout(chartSeries.bothYTicks, true, formatValue);
   const absoluteYAxis = getYAxisLayout(chartSeries.absDiffTicks, true, formatValue);
   const relativeYAxis = getYAxisLayout(

--- a/app/src/pages/report-output/earnings-variation/BaselineOnlyChart.tsx
+++ b/app/src/pages/report-output/earnings-variation/BaselineOnlyChart.tsx
@@ -20,18 +20,31 @@ import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useViewportSize } from '@/hooks/useViewportSize';
 import type { RootState } from '@/store';
 import type { Household } from '@/types/ingredients/Household';
-import { getClampedChartHeight, getNiceTicks, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  getClampedChartHeight,
+  getNiceTicks,
+  getYAxisLayout,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { currencySymbol } from '@/utils/formatters';
+import { getHeadOfHouseholdPersonName } from '@/utils/householdHead';
+import {
+  buildHouseholdVariationEarningsAxis,
+  getHouseholdVariationIndexForEarnings,
+  getHouseholdVariationMaxEarnings,
+} from '@/utils/householdVariationAxes';
+import { formatChartValueForVariable } from '@/utils/chartValueFormatting';
 import { getValueFromHousehold } from '@/utils/householdValues';
 
 interface Props {
   baseline: Household;
   baselineVariation: Household;
+  focusPersonName?: string | null;
   variableName: string;
   year: string;
 }
 
-function EarningsTooltip({ active, payload, label, symbol }: any) {
+function EarningsTooltip({ active, payload, label, formatValue, symbol }: any) {
   if (!active || !payload?.length) {
     return null;
   }
@@ -46,7 +59,7 @@ function EarningsTooltip({ active, payload, label, symbol }: any) {
           key={p.name}
           style={{ margin: '2px 0', fontSize: typography.fontSize.sm, color: p.stroke }}
         >
-          {p.name}: {p.value}
+          {p.name}: {formatValue(Number(p.value))}
         </p>
       ))}
     </div>
@@ -60,6 +73,7 @@ function EarningsTooltip({ active, payload, label, symbol }: any) {
 export default function BaselineOnlyChart({
   baseline,
   baselineVariation,
+  focusPersonName,
   variableName,
   year,
 }: Props) {
@@ -77,27 +91,28 @@ export default function BaselineOnlyChart({
       return null;
     }
 
-    const currentValue = getValueFromHousehold(
-      variableName,
-      year,
-      null,
-      baseline,
-      metadata
-    ) as number;
-    const firstPersonName = Object.keys(baseline.householdData?.people || {})[0];
+    const resolvedFocusPersonName =
+      focusPersonName ?? getHeadOfHouseholdPersonName(baseline, year);
     const currentEarnings = getValueFromHousehold(
       'employment_income',
       year,
-      firstPersonName,
+      resolvedFocusPersonName,
       baseline,
       metadata
     ) as number;
-    const maxEarnings = Math.max(countryId === 'ng' ? 1_200_000 : 200_000, 2 * currentEarnings);
-    const xValues = Array.from({ length: 401 }, (_, i) => (i * maxEarnings) / 400);
+    const maxEarnings = getHouseholdVariationMaxEarnings(currentEarnings, countryId);
+    const xValues = buildHouseholdVariationEarningsAxis(maxEarnings);
+    const currentIndex = getHouseholdVariationIndexForEarnings(currentEarnings, maxEarnings);
     const chartData = xValues.map((earnings, index) => ({
       earnings,
       value: yValues[index],
     }));
+    const exactCurrentValue = getValueFromHousehold(variableName, year, null, baseline, metadata);
+    const currentValue =
+      typeof exactCurrentValue === 'number'
+        ? exactCurrentValue
+        : ((chartData[currentIndex]?.value ??
+            getValueFromHousehold(variableName, year, null, baseline, metadata)) as number);
     const yNumValues = chartData.map((datum) => datum.value);
 
     return {
@@ -119,17 +134,20 @@ export default function BaselineOnlyChart({
   }
 
   const symbol = currencySymbol(countryId);
+  const formatValue = (value: number) =>
+    formatChartValueForVariable(value, variable, countryId);
+  const yAxis = getYAxisLayout(chartSeries.yTicks, true, formatValue);
+  const chartMargin = { top: 20, right: 20, bottom: 80, left: yAxis.marginLeft };
 
   return (
     <div style={{ width: '100%', position: 'relative' }}>
       <ResponsiveContainer width="100%" height={chartHeight}>
-        <LineChart
-          data={chartSeries.chartData}
-          margin={{ top: 20, right: 20, bottom: 80, left: 80 }}
-        >
+        <LineChart data={chartSeries.chartData} margin={chartMargin}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
             dataKey="earnings"
+            type="number"
+            domain={[0, chartSeries.maxEarnings]}
             ticks={chartSeries.xTicks}
             tick={RECHARTS_FONT_STYLE}
             tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
@@ -145,15 +163,18 @@ export default function BaselineOnlyChart({
             ticks={chartSeries.yTicks}
             domain={[chartSeries.yTicks[0], chartSeries.yTicks[chartSeries.yTicks.length - 1]]}
             tick={RECHARTS_FONT_STYLE}
+            tickFormatter={(value: number) => formatValue(value)}
+            width={yAxis.yAxisWidth}
           >
             <Label
               value={variable.label}
               angle={-90}
-              position="insideLeft"
+              position="center"
+              dx={yAxis.labelDx}
               style={{ textAnchor: 'middle', ...RECHARTS_FONT_STYLE }}
             />
           </YAxis>
-          <Tooltip content={<EarningsTooltip symbol={symbol} />} />
+          <Tooltip content={<EarningsTooltip symbol={symbol} formatValue={formatValue} />} />
           <Legend verticalAlign="top" align="left" />
           <Line
             type="monotone"
@@ -168,7 +189,9 @@ export default function BaselineOnlyChart({
             y={chartSeries.currentValue}
             r={5}
             fill={colors.primary[500]}
-            stroke={colors.primary[500]}
+            stroke={colors.background.primary}
+            strokeWidth={2}
+            ifOverflow="visible"
           />
         </LineChart>
       </ResponsiveContainer>

--- a/app/src/pages/report-output/earnings-variation/BaselineOnlyChart.tsx
+++ b/app/src/pages/report-output/earnings-variation/BaselineOnlyChart.tsx
@@ -26,15 +26,15 @@ import {
   getYAxisLayout,
   RECHARTS_FONT_STYLE,
 } from '@/utils/chartUtils';
+import { formatChartValueForVariable } from '@/utils/chartValueFormatting';
 import { currencySymbol } from '@/utils/formatters';
 import { getHeadOfHouseholdPersonName } from '@/utils/householdHead';
+import { getValueFromHousehold } from '@/utils/householdValues';
 import {
   buildHouseholdVariationEarningsAxis,
   getHouseholdVariationIndexForEarnings,
   getHouseholdVariationMaxEarnings,
 } from '@/utils/householdVariationAxes';
-import { formatChartValueForVariable } from '@/utils/chartValueFormatting';
-import { getValueFromHousehold } from '@/utils/householdValues';
 
 interface Props {
   baseline: Household;
@@ -91,8 +91,7 @@ export default function BaselineOnlyChart({
       return null;
     }
 
-    const resolvedFocusPersonName =
-      focusPersonName ?? getHeadOfHouseholdPersonName(baseline, year);
+    const resolvedFocusPersonName = focusPersonName ?? getHeadOfHouseholdPersonName(baseline, year);
     const currentEarnings = getValueFromHousehold(
       'employment_income',
       year,
@@ -134,8 +133,7 @@ export default function BaselineOnlyChart({
   }
 
   const symbol = currencySymbol(countryId);
-  const formatValue = (value: number) =>
-    formatChartValueForVariable(value, variable, countryId);
+  const formatValue = (value: number) => formatChartValueForVariable(value, variable, countryId);
   const yAxis = getYAxisLayout(chartSeries.yTicks, true, formatValue);
   const chartMargin = { top: 20, right: 20, bottom: 80, left: yAxis.marginLeft };
 

--- a/app/src/pages/report-output/earnings-variation/EarningsVariationSubPage.tsx
+++ b/app/src/pages/report-output/earnings-variation/EarningsVariationSubPage.tsx
@@ -22,6 +22,7 @@ import type { Household } from '@/types/ingredients/Household';
 import type { Policy } from '@/types/ingredients/Policy';
 import type { Simulation } from '@/types/ingredients/Simulation';
 import type { UserPolicy } from '@/types/ingredients/UserPolicy';
+import { getHeadOfHouseholdPersonName } from '@/utils/householdHead';
 import { getValueFromHousehold } from '@/utils/householdValues';
 import BaselineAndReformChart from './BaselineAndReformChart';
 import BaselineOnlyChart from './BaselineOnlyChart';
@@ -60,6 +61,14 @@ export default function EarningsVariationSubPage({
   const normalizedReportYear = reportYear ?? '';
   const deferredSearchQuery = useDeferredValue(searchQuery.trim().toLowerCase());
   const metadata = useSelector((state: RootState) => state.metadata);
+  const baselineFocusPersonName = useMemo(
+    () => getHeadOfHouseholdPersonName(baseline, normalizedReportYear),
+    [baseline, normalizedReportYear]
+  );
+  const reformFocusPersonName = useMemo(
+    () => (reform ? getHeadOfHouseholdPersonName(reform, normalizedReportYear) : null),
+    [normalizedReportYear, reform]
+  );
 
   // Get policy data for variations
   const baselinePolicy = policies?.find((p) => p.id === simulations[0]?.policyId);
@@ -87,6 +96,7 @@ export default function EarningsVariationSubPage({
     policyData: baselinePolicyData,
     year: normalizedReportYear,
     countryId,
+    personName: baselineFocusPersonName,
     enabled:
       shouldFetchInternally && !!reportYear && !!simulations[0]?.populationId && !!baselinePolicy,
   });
@@ -102,6 +112,7 @@ export default function EarningsVariationSubPage({
     policyData: reformPolicyData,
     year: normalizedReportYear,
     countryId,
+    personName: reformFocusPersonName ?? baselineFocusPersonName,
     enabled:
       shouldFetchInternally &&
       !!reportYear &&
@@ -354,6 +365,7 @@ export default function EarningsVariationSubPage({
         <BaselineAndReformChart
           baseline={baseline}
           baselineVariation={resolvedBaselineVariation}
+          focusPersonName={baselineFocusPersonName}
           reform={reform}
           reformVariation={resolvedReformVariation!}
           variableName={selectedVariable}
@@ -363,6 +375,7 @@ export default function EarningsVariationSubPage({
         <BaselineOnlyChart
           baseline={baseline}
           baselineVariation={resolvedBaselineVariation}
+          focusPersonName={baselineFocusPersonName}
           variableName={selectedVariable}
           year={normalizedReportYear}
         />

--- a/app/src/pages/report-output/marginal-tax-rates/MarginalTaxRatesSubPage.tsx
+++ b/app/src/pages/report-output/marginal-tax-rates/MarginalTaxRatesSubPage.tsx
@@ -29,8 +29,19 @@ import type { Household } from '@/types/ingredients/Household';
 import type { Policy } from '@/types/ingredients/Policy';
 import type { Simulation } from '@/types/ingredients/Simulation';
 import type { UserPolicy } from '@/types/ingredients/UserPolicy';
-import { getClampedChartHeight, getNiceTicks, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
+import {
+  getClampedChartHeight,
+  getNiceTicks,
+  getYAxisLayout,
+  RECHARTS_FONT_STYLE,
+} from '@/utils/chartUtils';
 import { currencySymbol } from '@/utils/formatters';
+import { getHeadOfHouseholdPersonName } from '@/utils/householdHead';
+import {
+  buildHouseholdVariationEarningsAxis,
+  getHouseholdVariationIndexForEarnings,
+  getHouseholdVariationMaxEarnings,
+} from '@/utils/householdVariationAxes';
 import { getValueFromHousehold } from '@/utils/householdValues';
 
 interface Props {
@@ -45,8 +56,8 @@ interface Props {
 }
 
 type ViewMode = 'both' | 'difference';
-
 function MTRTooltip({ active, payload, label, symbol }: any) {
+
   if (!active || !payload?.length) {
     return null;
   }
@@ -91,6 +102,14 @@ export default function MarginalTaxRatesSubPage({
   const normalizedReportYear = reportYear ?? '';
   const metadata = useSelector((state: RootState) => state.metadata);
   const chartHeight = getClampedChartHeight(viewportHeight, mobile);
+  const baselineFocusPersonName = useMemo(
+    () => getHeadOfHouseholdPersonName(baseline, normalizedReportYear),
+    [baseline, normalizedReportYear]
+  );
+  const reformFocusPersonName = useMemo(
+    () => (reform ? getHeadOfHouseholdPersonName(reform, normalizedReportYear) : null),
+    [normalizedReportYear, reform]
+  );
 
   const baselinePolicy = policies?.find((p) => p.id === simulations[0]?.policyId);
   const reformPolicy = simulations[1] && policies?.find((p) => p.id === simulations[1].policyId);
@@ -114,6 +133,7 @@ export default function MarginalTaxRatesSubPage({
     policyData: baselinePolicyData,
     year: normalizedReportYear,
     countryId,
+    personName: baselineFocusPersonName,
     enabled:
       shouldFetchInternally && !!reportYear && !!simulations[0]?.populationId && !!baselinePolicy,
   });
@@ -128,6 +148,7 @@ export default function MarginalTaxRatesSubPage({
     policyData: reformPolicyData,
     year: normalizedReportYear,
     countryId,
+    personName: reformFocusPersonName ?? baselineFocusPersonName,
     enabled:
       shouldFetchInternally &&
       !!reportYear &&
@@ -148,11 +169,13 @@ export default function MarginalTaxRatesSubPage({
     }
 
     const clipMTR = (values: number[]) => values.map((value) => Math.max(-2, Math.min(2, value)));
-    const firstPersonName = Object.keys(resolvedBaselineVariation.householdData?.people || {})[0];
+    const resolvedFocusPersonName =
+      baselineFocusPersonName ??
+      getHeadOfHouseholdPersonName(resolvedBaselineVariation, normalizedReportYear);
     const baselineMTR = getValueFromHousehold(
       'marginal_tax_rate',
       normalizedReportYear,
-      firstPersonName,
+      resolvedFocusPersonName,
       resolvedBaselineVariation,
       metadata
     );
@@ -161,7 +184,7 @@ export default function MarginalTaxRatesSubPage({
         ? getValueFromHousehold(
             'marginal_tax_rate',
             normalizedReportYear,
-            firstPersonName,
+            resolvedFocusPersonName,
             resolvedReformVariation,
             metadata
           )
@@ -173,23 +196,33 @@ export default function MarginalTaxRatesSubPage({
 
     const baselineMTRClipped = clipMTR(baselineMTR);
     const reformMTRClipped = Array.isArray(reformMTR) ? clipMTR(reformMTR) : null;
-    const firstPersonNameBaseline = Object.keys(baseline.householdData?.people || {})[0];
     const currentEarnings = getValueFromHousehold(
       'employment_income',
       normalizedReportYear,
-      firstPersonNameBaseline,
+      resolvedFocusPersonName,
       baseline,
       metadata
     ) as number;
-    const currentMTR = getValueFromHousehold(
+    const exactCurrentBaselineMTR = getValueFromHousehold(
       'marginal_tax_rate',
       normalizedReportYear,
-      firstPersonNameBaseline,
+      resolvedFocusPersonName,
       baseline,
       metadata
-    ) as number;
-    const maxEarnings = Math.max(countryId === 'ng' ? 1_200_000 : 200_000, 2 * currentEarnings);
-    const xValues = Array.from({ length: 401 }, (_, i) => (i * maxEarnings) / 400);
+    );
+    const exactCurrentReformMTR =
+      reform && resolvedReformVariation
+        ? getValueFromHousehold(
+            'marginal_tax_rate',
+            normalizedReportYear,
+            resolvedFocusPersonName,
+            reform,
+            metadata
+          )
+        : null;
+    const maxEarnings = getHouseholdVariationMaxEarnings(currentEarnings, countryId);
+    const xValues = buildHouseholdVariationEarningsAxis(maxEarnings);
+    const currentIndex = getHouseholdVariationIndexForEarnings(currentEarnings, maxEarnings);
     const mtrDifference = reformMTRClipped
       ? baselineMTRClipped.map((baseValue, index) => reformMTRClipped[index] - baseValue)
       : null;
@@ -204,7 +237,16 @@ export default function MarginalTaxRatesSubPage({
     return {
       chartData,
       currentEarnings,
-      currentMTR,
+      currentBaselineMTR:
+        typeof exactCurrentBaselineMTR === 'number'
+          ? Math.max(-2, Math.min(2, exactCurrentBaselineMTR))
+          : (baselineMTRClipped[currentIndex] ?? 0),
+      currentReformMTR:
+        typeof exactCurrentReformMTR === 'number'
+          ? Math.max(-2, Math.min(2, exactCurrentReformMTR))
+          : reformMTRClipped && reformMTRClipped[currentIndex] !== undefined
+            ? reformMTRClipped[currentIndex]
+            : null,
       diffTicks: getNiceTicks([Math.min(0, ...diffValues), Math.max(0, ...diffValues)]),
       maxEarnings,
       mtrDifference,
@@ -283,6 +325,12 @@ export default function MarginalTaxRatesSubPage({
   }
 
   const symbol = currencySymbol(countryId);
+  const formatMTR = (value: number) => `${(value * 100).toFixed(1)}%`;
+  const formatMTRTick = (value: number) => `${(value * 100).toFixed(0)}%`;
+  const mtrYAxis = getYAxisLayout(chartSeries.mtrTicks, true, formatMTRTick);
+  const diffYAxis = getYAxisLayout(chartSeries.diffTicks, true, formatMTR);
+  const bothChartMargin = { top: 20, right: 20, bottom: 80, left: mtrYAxis.marginLeft };
+  const diffChartMargin = { top: 20, right: 20, bottom: 80, left: diffYAxis.marginLeft };
 
   const renderChart = () => {
     if (!reform || !chartSeries.reformMTRClipped || viewMode === 'both') {
@@ -290,13 +338,12 @@ export default function MarginalTaxRatesSubPage({
         reform && chartSeries.reformMTRClipped ? colors.gray[600] : colors.primary[500];
       return (
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <LineChart
-            data={chartSeries.chartData}
-            margin={{ top: 20, right: 20, bottom: 80, left: 80 }}
-          >
+          <LineChart data={chartSeries.chartData} margin={bothChartMargin}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
               dataKey="earnings"
+              type="number"
+              domain={[0, chartSeries.maxEarnings]}
               ticks={chartSeries.xTicks}
               tick={RECHARTS_FONT_STYLE}
               tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
@@ -312,12 +359,14 @@ export default function MarginalTaxRatesSubPage({
               domain={[-2, 2]}
               ticks={chartSeries.mtrTicks}
               tick={RECHARTS_FONT_STYLE}
-              tickFormatter={(v: number) => `${(v * 100).toFixed(0)}%`}
+              tickFormatter={formatMTRTick}
+              width={mtrYAxis.yAxisWidth}
             >
               <Label
                 value="Marginal tax rate"
                 angle={-90}
-                position="insideLeft"
+                position="center"
+                dx={mtrYAxis.labelDx}
                 style={{ textAnchor: 'middle', ...RECHARTS_FONT_STYLE }}
               />
             </YAxis>
@@ -341,13 +390,24 @@ export default function MarginalTaxRatesSubPage({
                 dot={false}
               />
             )}
-            {!reform && (
+            <ReferenceDot
+              x={chartSeries.currentEarnings}
+              y={chartSeries.currentBaselineMTR}
+              r={5}
+              fill={baselineStroke}
+              stroke={colors.background.primary}
+              strokeWidth={2}
+              ifOverflow="visible"
+            />
+            {reform && chartSeries.currentReformMTR !== null && (
               <ReferenceDot
                 x={chartSeries.currentEarnings}
-                y={Math.max(-2, Math.min(2, chartSeries.currentMTR))}
+                y={chartSeries.currentReformMTR}
                 r={5}
                 fill={colors.primary[500]}
-                stroke={colors.primary[500]}
+                stroke={colors.background.primary}
+                strokeWidth={2}
+                ifOverflow="visible"
               />
             )}
           </LineChart>
@@ -361,13 +421,12 @@ export default function MarginalTaxRatesSubPage({
 
     return (
       <ResponsiveContainer width="100%" height={chartHeight}>
-        <AreaChart
-          data={chartSeries.chartData}
-          margin={{ top: 20, right: 20, bottom: 80, left: 80 }}
-        >
+        <AreaChart data={chartSeries.chartData} margin={diffChartMargin}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
             dataKey="earnings"
+            type="number"
+            domain={[0, chartSeries.maxEarnings]}
             ticks={chartSeries.xTicks}
             tick={RECHARTS_FONT_STYLE}
             tickFormatter={(v: number) => `${symbol}${v.toLocaleString()}`}
@@ -386,12 +445,14 @@ export default function MarginalTaxRatesSubPage({
               chartSeries.diffTicks[chartSeries.diffTicks.length - 1],
             ]}
             tick={RECHARTS_FONT_STYLE}
-            tickFormatter={(v: number) => `${(v * 100).toFixed(1)}%`}
+            tickFormatter={formatMTR}
+            width={diffYAxis.yAxisWidth}
           >
             <Label
               value="Change in marginal tax rate"
               angle={-90}
-              position="insideLeft"
+              position="center"
+              dx={diffYAxis.labelDx}
               style={{ textAnchor: 'middle', ...RECHARTS_FONT_STYLE }}
             />
           </YAxis>

--- a/app/src/pages/report-output/marginal-tax-rates/MarginalTaxRatesSubPage.tsx
+++ b/app/src/pages/report-output/marginal-tax-rates/MarginalTaxRatesSubPage.tsx
@@ -37,12 +37,12 @@ import {
 } from '@/utils/chartUtils';
 import { currencySymbol } from '@/utils/formatters';
 import { getHeadOfHouseholdPersonName } from '@/utils/householdHead';
+import { getValueFromHousehold } from '@/utils/householdValues';
 import {
   buildHouseholdVariationEarningsAxis,
   getHouseholdVariationIndexForEarnings,
   getHouseholdVariationMaxEarnings,
 } from '@/utils/householdVariationAxes';
-import { getValueFromHousehold } from '@/utils/householdValues';
 
 interface Props {
   baseline: Household;
@@ -57,7 +57,6 @@ interface Props {
 
 type ViewMode = 'both' | 'difference';
 function MTRTooltip({ active, payload, label, symbol }: any) {
-
   if (!active || !payload?.length) {
     return null;
   }

--- a/app/src/tests/unit/utils/householdHead.test.ts
+++ b/app/src/tests/unit/utils/householdHead.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'vitest';
+import type { Household } from '@/types/ingredients/Household';
+import { getHeadOfHouseholdPersonName } from '@/utils/householdHead';
+
+const YEAR = '2026';
+
+describe('getHeadOfHouseholdPersonName', () => {
+  test('prefers the canonical "you" person when present', () => {
+    const household: Household = {
+      countryId: 'us',
+      householdData: {
+        people: {
+          spouse: {
+            age: { [YEAR]: 35 },
+          },
+          you: {
+            age: { [YEAR]: 36 },
+          },
+        },
+        tax_units: {
+          'your tax unit': {
+            members: ['spouse', 'you'],
+          },
+        },
+      },
+    };
+
+    expect(getHeadOfHouseholdPersonName(household, YEAR)).toBe('you');
+  });
+
+  test('falls back to the first adult member of the first tax unit when flags are absent', () => {
+    const household: Household = {
+      countryId: 'us',
+      householdData: {
+        people: {
+          child: {
+            age: { [YEAR]: 10 },
+          },
+          adult: {
+            age: { [YEAR]: 40 },
+          },
+        },
+        tax_units: {
+          'your tax unit': {
+            members: ['child', 'adult'],
+          },
+        },
+      },
+    };
+
+    expect(getHeadOfHouseholdPersonName(household, YEAR)).toBe('adult');
+  });
+
+  test('falls back to you when no explicit group structure exists', () => {
+    const household: Household = {
+      countryId: 'us',
+      householdData: {
+        people: {
+          'your partner': {
+            age: { [YEAR]: 31 },
+          },
+          you: {
+            age: { [YEAR]: 30 },
+          },
+        },
+      },
+    };
+
+    expect(getHeadOfHouseholdPersonName(household, YEAR)).toBe('you');
+  });
+
+  test('uses stable sorted fallback when no other signal exists', () => {
+    const household: Household = {
+      countryId: 'uk',
+      householdData: {
+        people: {
+          zed: {
+            age: { [YEAR]: 17 },
+          },
+          alex: {
+            age: { [YEAR]: 16 },
+          },
+        },
+      },
+    };
+
+    expect(getHeadOfHouseholdPersonName(household, YEAR)).toBe('alex');
+  });
+});

--- a/app/src/tests/unit/utils/householdVariationAxes.test.ts
+++ b/app/src/tests/unit/utils/householdVariationAxes.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest';
 import {
-  HOUSEHOLD_VARIATION_POINT_COUNT,
   buildHouseholdVariationAxes,
   getHouseholdVariationIndexForEarnings,
+  HOUSEHOLD_VARIATION_POINT_COUNT,
 } from '@/utils/householdVariationAxes';
 
 const YEAR = '2026';

--- a/app/src/tests/unit/utils/householdVariationAxes.test.ts
+++ b/app/src/tests/unit/utils/householdVariationAxes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import {
+  HOUSEHOLD_VARIATION_POINT_COUNT,
+  buildHouseholdVariationAxes,
+  getHouseholdVariationIndexForEarnings,
+} from '@/utils/householdVariationAxes';
+
+const YEAR = '2026';
+
+describe('buildHouseholdVariationAxes', () => {
+  test('varies the requested person instead of defaulting to object order', () => {
+    const householdInput = {
+      people: {
+        spouse: {
+          employment_income: { [YEAR]: 60000 },
+        },
+        filer: {
+          employment_income: { [YEAR]: 45000 },
+        },
+      },
+    };
+
+    const result = buildHouseholdVariationAxes(householdInput, YEAR, 'us', 'filer');
+
+    expect(result.people.filer.employment_income[YEAR]).toBeNull();
+    expect(result.people.spouse.employment_income[YEAR]).toBe(60000);
+    expect(result.axes[0][0].count).toBe(HOUSEHOLD_VARIATION_POINT_COUNT);
+  });
+});
+
+describe('getHouseholdVariationIndexForEarnings', () => {
+  test('maps earnings back to the nearest variation index', () => {
+    expect(getHouseholdVariationIndexForEarnings(0, 200000)).toBe(0);
+    expect(getHouseholdVariationIndexForEarnings(200000, 200000)).toBe(
+      HOUSEHOLD_VARIATION_POINT_COUNT - 1
+    );
+    expect(getHouseholdVariationIndexForEarnings(100000, 200000)).toBe(200);
+  });
+});

--- a/app/src/utils/chartValueFormatting.ts
+++ b/app/src/utils/chartValueFormatting.ts
@@ -1,0 +1,49 @@
+import { countryIds } from '@/libs/countries';
+import { formatCurrency, formatNumber, formatPercent } from './formatters';
+
+type CountryId = (typeof countryIds)[number];
+
+export function getVariableChartPrecision(variable: any): number {
+  if (variable?.unit === '/1') {
+    return 1;
+  }
+
+  if (variable?.valueType === 'float' && !String(variable?.unit ?? '').startsWith('currency-')) {
+    return 1;
+  }
+
+  return 0;
+}
+
+export function formatChartValueForVariable(
+  value: number,
+  variable: any,
+  countryId: CountryId,
+  precision = getVariableChartPrecision(variable)
+): string {
+  if (variable?.unit === '/1') {
+    return formatPercent(value, countryId, {
+      minimumFractionDigits: precision,
+      maximumFractionDigits: precision,
+    });
+  }
+
+  if (String(variable?.unit ?? '').startsWith('currency-')) {
+    return formatCurrency(value, countryId, {
+      minimumFractionDigits: precision,
+      maximumFractionDigits: precision,
+    });
+  }
+
+  return formatNumber(value, countryId, {
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+  });
+}
+
+export function formatEmploymentIncomeValue(value: number, countryId: CountryId): string {
+  return formatCurrency(value, countryId, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+}

--- a/app/src/utils/householdHead.ts
+++ b/app/src/utils/householdHead.ts
@@ -1,0 +1,80 @@
+import type { Household, HouseholdGroupEntity, HouseholdPerson } from '@/types/ingredients/Household';
+import { sortPeopleKeys } from './householdIndividuals';
+
+const GROUP_CANDIDATES = ['tax_units', 'taxUnits', 'households', 'families', 'benunits'] as const;
+
+function isAdult(person: HouseholdPerson | undefined, year: string | null | undefined): boolean {
+  if (!person || !year) {
+    return false;
+  }
+
+  const age = person.age?.[year];
+  return typeof age === 'number' && age >= 18;
+}
+
+function getFirstAdultOrMember(
+  members: string[] | undefined,
+  people: Record<string, HouseholdPerson>,
+  year: string | null | undefined
+): string | null {
+  if (!Array.isArray(members) || members.length === 0) {
+    return null;
+  }
+
+  const existingMembers = members.filter((member) => member in people);
+  if (existingMembers.length === 0) {
+    return null;
+  }
+
+  const firstAdult = existingMembers.find((member) => isAdult(people[member], year));
+  return firstAdult ?? existingMembers[0];
+}
+
+function getPersonFromGroups(
+  household: Household,
+  year: string | null | undefined
+): string | null {
+  const householdData = household.householdData ?? {};
+  const people = householdData.people ?? {};
+
+  for (const groupName of GROUP_CANDIDATES) {
+    const groups = householdData[groupName] as Record<string, HouseholdGroupEntity> | undefined;
+    if (!groups) {
+      continue;
+    }
+
+    const orderedGroupKeys = Object.keys(groups).sort((left, right) => left.localeCompare(right));
+    for (const groupKey of orderedGroupKeys) {
+      const match = getFirstAdultOrMember(groups[groupKey]?.members, people, year);
+      if (match) {
+        return match;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function getHeadOfHouseholdPersonName(
+  household: Household,
+  year: string | null | undefined
+): string | null {
+  const people = household.householdData?.people ?? {};
+  const orderedPeople = sortPeopleKeys(Object.keys(people));
+
+  if (orderedPeople.length === 0) {
+    return null;
+  }
+
+  if ('you' in people) {
+    return 'you';
+  }
+
+  const groupedPerson = getPersonFromGroups(household, year);
+  if (groupedPerson) {
+    return groupedPerson;
+  }
+
+  const firstAdult = orderedPeople.find((personName) => isAdult(people[personName], year));
+  return firstAdult ?? orderedPeople[0];
+}

--- a/app/src/utils/householdHead.ts
+++ b/app/src/utils/householdHead.ts
@@ -1,4 +1,8 @@
-import type { Household, HouseholdGroupEntity, HouseholdPerson } from '@/types/ingredients/Household';
+import type {
+  Household,
+  HouseholdGroupEntity,
+  HouseholdPerson,
+} from '@/types/ingredients/Household';
 import { sortPeopleKeys } from './householdIndividuals';
 
 const GROUP_CANDIDATES = ['tax_units', 'taxUnits', 'households', 'families', 'benunits'] as const;
@@ -30,10 +34,7 @@ function getFirstAdultOrMember(
   return firstAdult ?? existingMembers[0];
 }
 
-function getPersonFromGroups(
-  household: Household,
-  year: string | null | undefined
-): string | null {
+function getPersonFromGroups(household: Household, year: string | null | undefined): string | null {
   const householdData = household.householdData ?? {};
   const people = householdData.people ?? {};
 

--- a/app/src/utils/householdVariationAxes.ts
+++ b/app/src/utils/householdVariationAxes.ts
@@ -1,6 +1,9 @@
 export const HOUSEHOLD_VARIATION_POINT_COUNT = 401;
 
-export function getHouseholdVariationMaxEarnings(currentEarnings: number, countryId: string): number {
+export function getHouseholdVariationMaxEarnings(
+  currentEarnings: number,
+  countryId: string
+): number {
   return Math.max(countryId === 'ng' ? 1_200_000 : 200_000, 2 * currentEarnings);
 }
 

--- a/app/src/utils/householdVariationAxes.ts
+++ b/app/src/utils/householdVariationAxes.ts
@@ -1,42 +1,70 @@
+export const HOUSEHOLD_VARIATION_POINT_COUNT = 401;
+
+export function getHouseholdVariationMaxEarnings(currentEarnings: number, countryId: string): number {
+  return Math.max(countryId === 'ng' ? 1_200_000 : 200_000, 2 * currentEarnings);
+}
+
+export function buildHouseholdVariationEarningsAxis(maxEarnings: number): number[] {
+  return Array.from(
+    { length: HOUSEHOLD_VARIATION_POINT_COUNT },
+    (_, index) => (index * maxEarnings) / (HOUSEHOLD_VARIATION_POINT_COUNT - 1)
+  );
+}
+
+export function getHouseholdVariationIndexForEarnings(
+  currentEarnings: number,
+  maxEarnings: number
+): number {
+  if (maxEarnings <= 0) {
+    return 0;
+  }
+
+  const clampedEarnings = Math.max(0, Math.min(currentEarnings, maxEarnings));
+  return Math.round((clampedEarnings / maxEarnings) * (HOUSEHOLD_VARIATION_POINT_COUNT - 1));
+}
+
 /**
  * Builds axes configuration for household variation calculations
- * Sets employment_income to null for the first person and adds axes array
+ * Sets employment_income to null for the selected person and adds axes array
  *
  * @param householdInput - Raw household data structure (from API)
  * @param year - The year to vary employment income for
  * @param countryId - Country code (affects max earnings calculation)
+ * @param personName - Person whose earnings should vary
  * @returns Household data with axes configuration for calculate-full endpoint
  */
 export function buildHouseholdVariationAxes(
   householdInput: any,
   year: string,
-  countryId: string
+  countryId: string,
+  personName?: string | null
 ): any {
   // Validate household has people
   if (!householdInput?.people || Object.keys(householdInput.people).length === 0) {
     throw new Error('Household has no people defined');
   }
 
-  // Get first person (assumes first person is "you" - adjust if household structure differs)
-  const firstPersonKey = Object.keys(householdInput.people)[0];
-  const firstPerson: any = Object.values(householdInput.people)[0];
+  const fallbackPersonKey = Object.keys(householdInput.people)[0];
+  const targetPersonKey =
+    personName && householdInput.people[personName] ? personName : fallbackPersonKey;
+  const targetPerson = householdInput.people[targetPersonKey];
 
   // Get current earnings for max calculation
-  const currentEarnings = (firstPerson?.employment_income?.[year] as number) || 0;
+  const currentEarnings = (targetPerson?.employment_income?.[year] as number) || 0;
 
   // Calculate max earnings based on country
-  const maxEarnings = Math.max(countryId === 'ng' ? 1_200_000 : 200_000, 2 * currentEarnings);
+  const maxEarnings = getHouseholdVariationMaxEarnings(currentEarnings, countryId);
 
   // Preserve existing employment_income values for other years
-  const existingEmploymentIncome = householdInput.people[firstPersonKey].employment_income || {};
+  const existingEmploymentIncome = householdInput.people[targetPersonKey].employment_income || {};
 
   // Build household data with variation
   const householdDataWithVariation = {
     ...householdInput,
     people: {
       ...householdInput.people,
-      [firstPersonKey]: {
-        ...householdInput.people[firstPersonKey],
+      [targetPersonKey]: {
+        ...householdInput.people[targetPersonKey],
         employment_income: {
           ...existingEmploymentIncome,
           [year]: null, // Null = vary this for the specific year only
@@ -55,7 +83,7 @@ export function buildHouseholdVariationAxes(
           period: year,
           min: 0,
           max: maxEarnings,
-          count: 401,
+          count: HOUSEHOLD_VARIATION_POINT_COUNT,
         },
       ],
     ],

--- a/calculator-app/src/app/[countryId]/layout.tsx
+++ b/calculator-app/src/app/[countryId]/layout.tsx
@@ -12,6 +12,7 @@ import { countryIds, type CountryId } from "@/libs/countries";
  * Provides CountryContext, NavigationContext, and LocationContext
  * so shared components work identically in both router contexts.
  * This comment exists to force calculator-next redeploys when needed.
+ * This line is a no-op touch for the calculator-app Vercel project.
  */
 export default function CountryLayout({
   children,


### PR DESCRIPTION
## Summary
- use a stable household focus person for variation charts, preferring `you` when present
- place household earnings and MTR markers at the raw current earnings value on a numeric axis
- prefer exact scalar current values for the marker when available, while keeping the plotted line bucketed
- apply the dynamic left-axis layout treatment to the MTR chart as well

## Testing
- bun run typecheck
- bun run vitest run src/tests/unit/utils/householdHead.test.ts src/tests/unit/utils/householdVariationAxes.test.ts