### PR TITLE
Temporarily remove energy price shock UK interactive

### DIFF
--- a/app/public/sitemap.xml
+++ b/app/public/sitemap.xml
@@ -1252,12 +1252,6 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://policyengine.org/uk/energy-price-shock</loc>
-    <lastmod>2026-03-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
     <loc>https://policyengine.org/us/keep-your-pay-act</loc>
     <lastmod>2026-03-09</lastmod>
     <changefreq>weekly</changefreq>

--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -73,19 +73,6 @@
   },
   {
     "type": "iframe",
-    "slug": "energy-price-shock",
-    "title": "Energy price shock: distributional impact and policy options",
-    "description": "Estimate the distributional impact of energy price shock scenarios on UK households, with electricity and gas breakdowns, and model five policy responses",
-    "source": "https://energy-price-shock.vercel.app/",
-    "tags": ["uk", "featured", "policy", "interactives"],
-    "countryId": "uk",
-    "displayWithResearch": true,
-    "image": "energy-price-shock-calculator.png",
-    "date": "2026-03-12 12:00:00",
-    "authors": ["vahid-ahmadi"]
-  },
-  {
-    "type": "iframe",
     "slug": "keep-your-pay-act",
     "title": "Keep Your Pay Act calculator",
     "description": "Estimate the household and national impact of Senator Booker's Keep Your Pay Act, which raises the standard deduction, expands the Child Tax Credit, and triples the childless EITC",

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
-    added:
-      - Add Working Parents Tax Relief Act calculator at /us/working-parents-tax-relief-act
+    removed:
+      - Temporarily remove energy price shock UK interactive from apps listing and sitemap


### PR DESCRIPTION
## Summary
- Remove the energy-price-shock app entry from `apps.json` and `sitemap.xml` temporarily
- Update changelog entry

## Test plan
- [ ] Verify `/uk/research` page loads without the energy price shock tile
- [ ] Verify no broken links referencing the removed app

🤖 Generated with [Claude Code](https://claude.com/claude-code)