### PR TITLE
Dual-emit tool_name alongside toolSlug

### DIFF
--- a/app/src/utils/analytics.ts
+++ b/app/src/utils/analytics.ts
@@ -28,7 +28,11 @@ export function trackSimulationCompleted(params: {
 
 /** Fires after 15s on an iframe tool page */
 export function trackToolEngaged(params: { toolSlug: string; toolTitle: string }) {
-  trackEvent('tool_engaged', params);
+  trackEvent('tool_engaged', {
+    ...params,
+    tool_name: params.toolSlug,
+    tool_title: params.toolTitle,
+  });
 }
 
 /** Fires when user clicks the email contact link */

--- a/website/src/app/[countryId]/[slug]/AppClient.tsx
+++ b/website/src/app/[countryId]/[slug]/AppClient.tsx
@@ -24,7 +24,11 @@ interface AppClientProps {
 
 function trackToolEngaged(params: { toolSlug: string; toolTitle: string }) {
   if (typeof window !== "undefined" && window.gtag) {
-    window.gtag("event", "tool_engaged", params);
+    window.gtag("event", "tool_engaged", {
+      ...params,
+      tool_name: params.toolSlug,
+      tool_title: params.toolTitle,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- Expands the `tool_engaged` GA4 event to include `tool_name` and `tool_title` parameters alongside the existing `toolSlug` and `toolTitle`.
- Aligns app-v2's analytics with the 28 embedded tools (which already tag all events with `tool_name`), so tool-level signal aggregates cleanly in one GA4 property on one dimension.
- `toolSlug` and `toolTitle` are preserved to avoid breaking any Google Ads conversions or custom dimensions currently wired to those parameter names.

## Why
Each of the 28 embedded tools (SALT cap NY-17, California wealth tax, WPTRA, etc.) now fires GA4 events tagged with `tool_name` = the repo slug. app-v2's parent `tool_engaged` event uses `toolSlug` for the same concept. Registering both as custom dimensions produces two fragmented views of the same data; dual-emitting lets them share one dimension.

## Retirement plan (not in this PR)
Once analytics confirms nothing external still reads `toolSlug` (Google Ads conversions, Looker Studio, partner dashboards), a follow-up PR can drop `toolSlug` and `toolTitle` from the emission.

## Test plan
- [ ] Open any embedded tool page (e.g., /us/california-wealth-tax), wait 15s
- [ ] Confirm \`tool_engaged\` event in GA4 DebugView includes BOTH \`toolSlug\` and \`tool_name\` parameters with the same value

🤖 Generated with [Claude Code](https://claude.com/claude-code)