### PR TITLE
Proxy /us/python to household-api-docs deployment

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -59,6 +59,9 @@ const nextConfig: NextConfig = {
         // Household API docs (Vercel) — beforeFiles so it intercepts before Next.js trailing slash redirect
         { source: "/us/api", destination: "https://household-api-docs-policy-engine.vercel.app/us/api/" },
         { source: "/us/api/:path*", destination: "https://household-api-docs-policy-engine.vercel.app/us/api/:path*" },
+        // Python client docs — same household-api-docs deployment, served at top-level /us/python
+        { source: "/us/python", destination: "https://household-api-docs-policy-engine.vercel.app/us/python" },
+        { source: "/us/python/:path*", destination: "https://household-api-docs-policy-engine.vercel.app/us/python/:path*" },
         // Zone asset proxy — API docs uses assetPrefix: '/_zones/household-api-docs'
         { source: "/_zones/household-api-docs/:path*", destination: "https://household-api-docs-policy-engine.vercel.app/_zones/household-api-docs/:path*" },
       ],

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -587,6 +587,7 @@ export default function Header() {
     { label: "Research", href: `/${countryId}/research`, hasDropdown: false },
     { label: "Model", href: `/${countryId}/model`, hasDropdown: false, external: true },
     { label: "API", href: `/${countryId}/api`, hasDropdown: false, external: true },
+    { label: "Python", href: `/${countryId}/python`, hasDropdown: false, external: true },
     {
       label: "About",
       hasDropdown: true,


### PR DESCRIPTION
## Summary
- After a recent merge in the `household-api-docs` repo, the Python client docs moved from being nested under `/us/api/...` to living at the top-level path `/us/python` on that deployment.
- The main site only proxies `/us/api` and `/us/api/:path*` to that deployment, so requests to `policyengine.org/us/python` were falling through to the Next.js `[countryId]/[slug]` dynamic route and returning 404.
- Adds two `beforeFiles` rewrites (bare path and `:path*`) pointing `/us/python` at `household-api-docs-policy-engine.vercel.app/us/python`, matching the existing `/us/api` pattern.

Verified upstream is live:
- `household-api-docs-policy-engine.vercel.app/us/python` → 200
- `policyengine.org/us/python` → 404 (pre-fix), matched path `/[countryId]/[slug]`

## Test plan
- [ ] After deploy, `https://www.policyengine.org/us/python` returns 200 and renders the Python docs
- [ ] Deep links under `/us/python/:path*` resolve correctly
- [ ] `/us/api` and `/us/api/:path*` still work (unchanged)
- [ ] Static assets under `/_zones/household-api-docs/...` still load (existing asset proxy covers both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)