### PR TITLE
Post energy price shock UK interactive

### DIFF
--- a/app/public/sitemap.xml
+++ b/app/public/sitemap.xml
@@ -1252,6 +1252,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://policyengine.org/uk/energy-price-shock</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://policyengine.org/us/keep-your-pay-act</loc>
     <lastmod>2026-03-09</lastmod>
     <changefreq>weekly</changefreq>

--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -73,6 +73,19 @@
   },
   {
     "type": "iframe",
+    "slug": "energy-price-shock",
+    "title": "Energy price shock: distributional impact and policy options",
+    "description": "Estimate the distributional impact of energy price shock scenarios on UK households, with electricity and gas breakdowns, and model five policy responses",
+    "source": "https://energy-price-shock.vercel.app/",
+    "tags": ["uk", "featured", "policy", "interactives"],
+    "countryId": "uk",
+    "displayWithResearch": true,
+    "image": "energy-price-shock-calculator.png",
+    "date": "2026-04-22 12:00:00",
+    "authors": ["vahid-ahmadi"]
+  },
+  {
+    "type": "iframe",
     "slug": "keep-your-pay-act",
     "title": "Keep Your Pay Act calculator",
     "description": "Estimate the household and national impact of Senator Booker's Keep Your Pay Act, which raises the standard deduction, expands the Child Tax Credit, and triples the childless EITC",

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
-    fixed:
-      - Proxy /ingest to PostHog so analytics from the state legislative tracker are captured on policyengine.org
+    added:
+      - Restore energy price shock UK interactive with updated data


### PR DESCRIPTION
Re-add the energy-price-shock entry to apps.json and sitemap.xml with updated data (2026-04-22), reversing the temporary removal in #974.