### PR TITLE
Add multizone tracking audit CI check

### DIFF
--- a/.github/scripts/audit-multizone-tracking.mjs
+++ b/.github/scripts/audit-multizone-tracking.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Pre-merge guard against the multizone-tracking regression we hit in
+ * April 2026: when /us/marriage was rewired from the main app to a
+ * separate Vercel zone (PolicyEngine/marriage), that zone had no GA4
+ * bootstrap — so every click silently lost both page_view and the
+ * tool_engaged conversion event.
+ *
+ * This script parses website/next.config.ts, extracts every multizone
+ * rewrite destination, fetches each one with a cache-busting query
+ * string, and verifies the GA4 measurement ID appears in the served
+ * HTML. If any destination is missing tracking, the script exits
+ * non-zero and the PR check fails.
+ *
+ * Only checks user-facing destinations (HTML pages). Skips asset-proxy
+ * rewrites (e.g. /_zones/...), API endpoints, and internal services
+ * where tracking wouldn't apply.
+ */
+import { readFileSync } from "node:fs";
+
+const GA_MEASUREMENT_ID = "G-2YHG89FY0N";
+const NEXT_CONFIG = "website/next.config.ts";
+
+// Destinations that are intentionally not user-facing pages — API
+// endpoints, analytics proxies, static asset proxies. Matched as
+// substrings against the destination URL. We still want to catch the
+// interesting case (a new multizone frontend added without GA), not
+// trip over every backend proxy.
+const SKIP_IF_CONTAINS = [
+  "/_zones/",            // Next.js zone asset proxy
+  "/_tracker/",          // PostHog analytics proxy
+  "/ingest",             // PostHog ingestion proxy
+  "/api/",               // Backend API proxy
+  "/robots.txt",
+  "/sitemap.xml",
+  ".modal.run",          // Modal-hosted backend services (not frontends)
+  "posthog.com",         // PostHog itself
+  "policyengine.github.io/plugin-blog",  // Legacy blog, not in ads
+  "policyengine-slides.vercel.app",      // Internal slides, not in ads
+];
+
+// File extensions that indicate a static-asset proxy rather than a
+// page. Static SVGs / images / fonts don't have a root layout to
+// install gtag into.
+const STATIC_ASSET_EXTS = [".svg", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".woff", ".woff2", ".ttf", ".css", ".js"];
+
+// Pages that serve reference / documentation content where firing
+// tool_engaged would inflate conversion counts. Allowed to have gtag
+// but the test doesn't require tool_engaged there. Kept here for
+// reference — the current check only verifies gtag presence, not
+// whether tool_engaged fires (that's harder to test statically).
+// const REFERENCE_CONTENT = ["policyengine-model", "household-api-docs"];
+
+function extractRewriteDestinations(source) {
+  // Matches: destination: "https://..." allowing single or double quotes.
+  // Keeps destinations that look like full URLs to external hosts.
+  const urlRegex = /destination:\s*["'`](https?:\/\/[^"'`]+)["'`]/g;
+  const urls = new Set();
+  let match;
+  while ((match = urlRegex.exec(source)) !== null) {
+    const url = match[1];
+    if (SKIP_IF_CONTAINS.some((s) => url.includes(s))) continue;
+    // Skip static-asset destinations — no layout, no gtag to install.
+    const pathPart = url.split("?")[0];
+    if (STATIC_ASSET_EXTS.some((ext) => pathPart.endsWith(ext))) continue;
+    urls.add(url);
+  }
+  return Array.from(urls);
+}
+
+/**
+ * Resolve the rewrite destination to the user-facing policyengine.org
+ * URL it will serve, by finding the matching source in next.config.ts.
+ * That's what users actually hit — we want to verify THAT URL renders
+ * a page with tracking, not the underlying Vercel project URL (which
+ * may respond differently outside the rewrite context).
+ *
+ * Returns null if the source path contains a parameter we can't
+ * confidently concretize (e.g. dynamic multi-country routes where
+ * the audit shouldn't guess a value). Callers skip those — one
+ * representative concrete path per family is enough to catch the
+ * failure mode.
+ */
+function resolveSourcePathForDestination(source, destinationUrl) {
+  const pattern = new RegExp(
+    `source:\\s*["'\`](/[^"'\`]+)["'\`]\\s*,\\s*destination:\\s*["'\`]${destinationUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["'\`]`,
+    "g",
+  );
+  const match = pattern.exec(source);
+  if (!match) return null;
+  const rawPath = match[1];
+
+  // Strip catch-all suffix. Keep all-path variants out since they'd
+  // usually map to arbitrary deep paths we can't test meaningfully.
+  let resolved = rawPath.replace(/\/:path\*?$/, "");
+
+  // Substitute known parameter placeholders with concrete values so
+  // the URL is actually testable. :countryId is the only dynamic
+  // param currently used for multizone sources; default to "us" which
+  // every zone is expected to support.
+  resolved = resolved.replace(/\/:countryId\b/, "/us");
+
+  // Any remaining :param tokens mean this rewrite takes a value we
+  // can't guess — skip rather than fabricate a path that 404s.
+  if (/\/:[a-zA-Z]/.test(resolved)) return null;
+
+  return resolved;
+}
+
+async function checkUrl(url) {
+  const busted = `${url}${url.includes("?") ? "&" : "?"}_cb=${Date.now()}`;
+  try {
+    const res = await fetch(busted, {
+      redirect: "follow",
+      headers: { "Cache-Control": "no-cache", "User-Agent": "multizone-tracking-audit/1.0" },
+    });
+    if (!res.ok) {
+      return { ok: false, reason: `HTTP ${res.status}`, status: res.status };
+    }
+    const html = await res.text();
+    const hasGtagId = html.includes(GA_MEASUREMENT_ID);
+    const hasGtagLoader = html.includes("googletagmanager.com/gtag/js");
+    return {
+      ok: hasGtagId && hasGtagLoader,
+      reason: hasGtagId && hasGtagLoader
+        ? "gtag present"
+        : !hasGtagLoader
+          ? "gtag loader missing"
+          : "GA4 measurement ID missing",
+      status: res.status,
+    };
+  } catch (e) {
+    return { ok: false, reason: `fetch failed: ${e.message}` };
+  }
+}
+
+const configText = readFileSync(NEXT_CONFIG, "utf8");
+const destinations = extractRewriteDestinations(configText);
+
+if (destinations.length === 0) {
+  console.log("No multizone rewrites found in", NEXT_CONFIG);
+  process.exit(0);
+}
+
+console.log(`Found ${destinations.length} multizone destination(s) to audit.\n`);
+
+const results = [];
+const skipped = [];
+for (const destination of destinations) {
+  const sourcePath = resolveSourcePathForDestination(configText, destination);
+  if (!sourcePath) {
+    // Rewrite has a parameter we can't safely concretize; skip rather
+    // than test a fabricated URL. The :countryId version (resolved to
+    // /us/...) usually covers the same destination zone.
+    skipped.push(destination);
+    continue;
+  }
+  const testUrl = `https://policyengine.org${sourcePath}`;
+  const result = await checkUrl(testUrl);
+  results.push({ destination, testUrl, ...result });
+  const mark = result.ok ? "✓" : "✗";
+  console.log(`${mark} ${testUrl}`);
+  console.log(`    ${result.reason}`);
+  if (destination !== testUrl) console.log(`    (rewrites to ${destination})`);
+}
+
+if (skipped.length > 0) {
+  console.log(`\n${skipped.length} destination(s) skipped (dynamic source, tested via concretized sibling):`);
+  skipped.forEach((s) => console.log(`  - ${s}`));
+}
+
+const failures = results.filter((r) => !r.ok);
+console.log(`\n${results.length - failures.length}/${results.length} destinations have tracking.`);
+
+if (failures.length > 0) {
+  console.error(`\n❌ ${failures.length} destination(s) missing Google Analytics bootstrap:\n`);
+  failures.forEach((f) => {
+    console.error(`  - ${f.testUrl} (${f.reason})`);
+    console.error(`    → destination: ${f.destination}`);
+  });
+  console.error("\nEvery multizone page served from policyengine.org must have the GA4");
+  console.error("bootstrap (gtag.js + config('G-2YHG89FY0N')) in its root layout.");
+  console.error("Without it, page_view and tool_engaged events silently drop, and");
+  console.error("Google Ads stops reporting conversions for any keyword landing there.");
+  console.error("");
+  console.error("Fix: in the destination repo, add the same gtag setup that");
+  console.error("website/src/app/layout.tsx uses. See PolicyEngine/marriage#114 or");
+  console.error("PolicyEngine/policyengine-model#21 for example PRs.");
+  process.exit(1);
+}
+
+console.log("\n✅ All multizone destinations have tracking.");

--- a/.github/workflows/multizone-tracking-audit.yml
+++ b/.github/workflows/multizone-tracking-audit.yml
@@ -1,0 +1,30 @@
+name: Multizone tracking audit
+
+# Guards against the class of bug where a multizone rewrite is added
+# (or its destination is edited) but the target zone lacks the GA4
+# bootstrap — silently dropping page_view and tool_engaged events for
+# every click that lands on that zone.
+#
+# See PolicyEngine/marriage#114 and PolicyEngine/policyengine-model#21
+# for the incident this check was built in response to.
+
+on:
+  pull_request:
+    paths:
+      - "website/next.config.ts"
+      - ".github/scripts/audit-multizone-tracking.mjs"
+      - ".github/workflows/multizone-tracking-audit.yml"
+
+jobs:
+  audit:
+    name: Audit GA4 tracking on multizone destinations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run multizone tracking audit
+        run: node .github/scripts/audit-multizone-tracking.mjs


### PR DESCRIPTION
## What this adds

A GitHub Actions check that runs whenever `website/next.config.ts` changes. It parses every multizone rewrite destination, fetches the corresponding user-facing `policyengine.org` URL, and fails the PR if the destination is missing the GA4 bootstrap.

## Why

We hit this exact class of bug in April 2026: #978 moved `/us/marriage` into the `PolicyEngine/marriage` multizone, but that zone didn't have the GA4 setup in its layout. Every click to the marriage calculator silently dropped both `page_view` and `tool_engaged` — Google Ads reported zero conversions on the top-converting keywords for roughly 5 days before anyone caught it.

Neither repo's existing CI could catch this:
- `policyengine-app-v2` touched routing. Its tests pass because the routing change is correct in isolation.
- `PolicyEngine/marriage` wasn't touched by the PR. Its CI had nothing to react to.

The bug only exists in the composed system. This check tests the composed system.

## How it works

`node .github/scripts/audit-multizone-tracking.mjs`:

1. Read `website/next.config.ts`
2. Extract every `destination: "https://..."` in the rewrites
3. Filter out things that legitimately shouldn't have GA — API proxies (Modal, PostHog), static assets, intentional-untracked zones
4. For each remaining destination, determine the user-facing `policyengine.org` URL that reaches it (substituting `:countryId` → `us`)
5. Fetch with a cache-busting query string, grep for `G-2YHG89FY0N` and `googletagmanager.com/gtag/js` in the HTML
6. Exit non-zero if any are missing

## Current state

Dry-run against main passes:
\`\`\`
22/22 destinations have tracking.
✅ All multizone destinations have tracking.
\`\`\`

## Test plan

- [ ] This PR itself runs the check — should pass since no rewrites change.
- [ ] Sanity check: confirm the check actually catches the failure mode. If you temporarily revert [PolicyEngine/marriage#114](https://github.com/PolicyEngine/marriage/pull/114) (or point `/us/marriage` at an untracked zone), this check should fail the PR.

## Fails look like

\`\`\`
✗ https://policyengine.org/us/marriage
    GA4 measurement ID missing
    (rewrites to https://marriage-zeta-beryl.vercel.app/us/marriage)

❌ 1 destination(s) missing Google Analytics bootstrap:
  - https://policyengine.org/us/marriage (GA4 measurement ID missing)
    → destination: https://marriage-zeta-beryl.vercel.app/us/marriage

Every multizone page served from policyengine.org must have the GA4
bootstrap (gtag.js + config('G-2YHG89FY0N')) in its root layout.
\`\`\`

The error message points at PolicyEngine/marriage#114 and PolicyEngine/policyengine-model#21 as example fix PRs so future incidents resolve fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)