### PR TITLE
Fix multizone audit for new rewrites not yet on production

### DIFF
--- a/.github/scripts/audit-multizone-tracking.mjs
+++ b/.github/scripts/audit-multizone-tracking.mjs
@@ -156,11 +156,25 @@ for (const destination of destinations) {
     continue;
   }
   const testUrl = `https://policyengine.org${sourcePath}`;
-  const result = await checkUrl(testUrl);
+  let result = await checkUrl(testUrl);
+  // If policyengine.org returns 404, the rewrite likely hasn't been
+  // deployed yet (e.g. this PR adds it). Fall back to testing the
+  // destination URL directly — what we care about is whether the
+  // destination zone has gtag, not whether the rewrite is live.
+  let testedDestinationDirectly = false;
+  if (!result.ok && result.status === 404) {
+    const stripped = destination.replace(/\/:path\*?$/, "");
+    const fallback = await checkUrl(stripped);
+    if (fallback.ok || fallback.status !== 404) {
+      result = fallback;
+      testedDestinationDirectly = true;
+    }
+  }
   results.push({ destination, testUrl, ...result });
   const mark = result.ok ? "✓" : "✗";
   console.log(`${mark} ${testUrl}`);
   console.log(`    ${result.reason}`);
+  if (testedDestinationDirectly) console.log(`    (tested destination directly — rewrite not yet live on production)`);
   if (destination !== testUrl) console.log(`    (rewrites to ${destination})`);
 }
 


### PR DESCRIPTION
## Summary
- When a PR adds a new multizone rewrite, the audit script tests `https://policyengine.org/<path>` which returns 404 because the rewrite hasn't been deployed yet
- This fix falls back to testing the destination Vercel URL directly when the production URL returns 404
- Unblocks PRs that add new multizone tools (e.g. #1012)

## Test plan
- [x] Ran script locally — all 24/24 destinations pass, Utah entries show fallback working:
  ```
  ✓ https://policyengine.org/us/utah-2026-tax-changes
      gtag present
      (tested destination directly — rewrite not yet live on production)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)