### PR TITLE
Add UK chat route

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -115,6 +115,14 @@
       "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/:path*"
     },
     {
+      "source": "/uk/chat",
+      "destination": "https://policyengine-uk-chat.vercel.app"
+    },
+    {
+      "source": "/uk/chat/:path*",
+      "destination": "https://policyengine-uk-chat.vercel.app/:path*"
+    },
+    {
       "source": "/:countryId/model",
       "destination": "https://policyengine-model-phi.vercel.app/?country=:countryId"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -115,14 +115,6 @@
       "destination": "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim/:path*"
     },
     {
-      "source": "/uk/chat",
-      "destination": "https://policyengine-uk-chat.vercel.app"
-    },
-    {
-      "source": "/uk/chat/:path*",
-      "destination": "https://policyengine-uk-chat.vercel.app/:path*"
-    },
-    {
       "source": "/:countryId/model",
       "destination": "https://policyengine-model-phi.vercel.app/?country=:countryId"
     },

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -53,6 +53,9 @@ const nextConfig: NextConfig = {
         { source: "/us/marriage/:path*", destination: "https://marriage-zeta-beryl.vercel.app/us/marriage/:path*" },
         { source: "/uk/marriage", destination: "https://marriage-zeta-beryl.vercel.app/us/marriage?country=uk" },
         { source: "/uk/marriage/:path*", destination: "https://marriage-zeta-beryl.vercel.app/us/marriage/:path*?country=uk" },
+        // UK chat assistant (Vercel)
+        { source: "/uk/chat", destination: "https://policyengine-uk-chat.vercel.app" },
+        { source: "/uk/chat/:path*", destination: "https://policyengine-uk-chat.vercel.app/:path*" },
         // Working Parents Tax Relief Act calculator (Vercel)
         { source: "/us/working-parents-tax-relief-act", destination: "https://wptra.vercel.app/us/working-parents-tax-relief-act" },
         { source: "/us/working-parents-tax-relief-act/:path*", destination: "https://wptra.vercel.app/us/working-parents-tax-relief-act/:path*" },

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -1,5 +1,9 @@
 import type { NextConfig } from "next";
 
+const ukChatOrigin = (
+  process.env.UK_CHAT_ORIGIN ?? "https://policyengine-uk-chat.vercel.app"
+).replace(/\/$/, "");
+
 const nextConfig: NextConfig = {
   async redirects() {
     return [
@@ -54,8 +58,8 @@ const nextConfig: NextConfig = {
         { source: "/uk/marriage", destination: "https://marriage-zeta-beryl.vercel.app/us/marriage?country=uk" },
         { source: "/uk/marriage/:path*", destination: "https://marriage-zeta-beryl.vercel.app/us/marriage/:path*?country=uk" },
         // UK chat assistant (Vercel)
-        { source: "/uk/chat", destination: "https://policyengine-uk-chat.vercel.app" },
-        { source: "/uk/chat/:path*", destination: "https://policyengine-uk-chat.vercel.app/:path*" },
+        { source: "/uk/chat", destination: ukChatOrigin },
+        { source: "/uk/chat/:path*", destination: ukChatOrigin + "/:path*" },
         // Working Parents Tax Relief Act calculator (Vercel)
         { source: "/us/working-parents-tax-relief-act", destination: "https://wptra.vercel.app/us/working-parents-tax-relief-act" },
         { source: "/us/working-parents-tax-relief-act/:path*", destination: "https://wptra.vercel.app/us/working-parents-tax-relief-act/:path*" },


### PR DESCRIPTION
## Summary
- Add Vercel rewrites for /uk/chat and /uk/chat/:path* to mount the policyengine-uk-chat app as a full-page multizone route
- Keep the integration minimal so local demos can use the uk-chat app now, then production can use the merged uk-chat deployment later

## Verification
- node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8')); console.log('vercel.json ok')"
- cd app && bun run vitest src/tests/unit/config/vercel.test.ts

## Notes
- This route depends on PolicyEngine/policyengine-uk-chat#41 for the model backend selector and Python backend support.
- Until that PR is merged/deployed, demos should use a fully local uk-chat setup or a manually configured branch backend.