### PR TITLE
Fix raw HTML rendering in blog markdown so iframes render

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -60,6 +60,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "recharts": "^3.7.0",
     "rehype-katex": "^7.0.0",
+    "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",
     "tailwind-merge": "^3.5.0",

--- a/app/src/components/blog/MarkdownFormatter.tsx
+++ b/app/src/components/blog/MarkdownFormatter.tsx
@@ -985,11 +985,7 @@ export function MarkdownFormatter({
   };
 
   return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeRaw]}
-      components={components}
-    >
+    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]} components={components}>
       {markdown}
     </ReactMarkdown>
   );

--- a/app/src/components/blog/MarkdownFormatter.tsx
+++ b/app/src/components/blog/MarkdownFormatter.tsx
@@ -18,6 +18,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
 import OptimisedImage from '@/components/ui/OptimisedImage';
 import type { MarkdownFormatterProps } from '@/types/blog';
@@ -984,7 +985,11 @@ export function MarkdownFormatter({
   };
 
   return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeRaw]}
+      components={components}
+    >
       {markdown}
     </ReactMarkdown>
   );

--- a/app/src/tests/unit/components/blog/MarkdownFormatter.test.tsx
+++ b/app/src/tests/unit/components/blog/MarkdownFormatter.test.tsx
@@ -66,8 +66,25 @@ describe('MarkdownFormatter', () => {
       expect(screen.getByRole('list')).toBeInTheDocument();
     });
 
-    test('given raw HTML markdown then does not render raw elements', () => {
+    test('given markdown with iframe then renders embedded iframe', () => {
       // Given
+      const markdown =
+        'Embed below.\n\n<iframe src="https://example.com/embed.html" width="100%" height="400" frameborder="0"></iframe>';
+
+      // When
+      const { container } = render(<MarkdownFormatter markdown={markdown} />);
+
+      // Then
+      expect(screen.getByText('Embed below.')).toBeInTheDocument();
+      const iframe = container.querySelector('iframe');
+      expect(iframe).not.toBeNull();
+      expect(iframe).toHaveAttribute('src', 'https://example.com/embed.html');
+    });
+
+    test('given raw HTML with dangerous attributes then strips event handlers', () => {
+      // Given – raw HTML is rendered (so iframes work) but the custom component
+      // overrides only forward a safe subset of attributes, dropping inline
+      // event handlers such as onerror.
       const markdown =
         'Paragraph before HTML.\n\n<img src="x" alt="malicious" onerror="alert(1)" />';
 
@@ -76,7 +93,8 @@ describe('MarkdownFormatter', () => {
 
       // Then
       expect(screen.getByText('Paragraph before HTML.')).toBeInTheDocument();
-      expect(screen.queryByRole('img', { name: 'malicious' })).toBeNull();
+      const img = screen.getByRole('img', { name: 'malicious' });
+      expect(img).not.toHaveAttribute('onerror');
     });
   });
 

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
         "react-syntax-highlighter": "^15.5.0",
         "recharts": "^3.7.0",
         "rehype-katex": "^7.0.0",
+        "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
         "tailwind-merge": "^3.5.0",
@@ -180,6 +181,7 @@
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
         "react-plotly.js": "^2.6.0",
+        "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
       },
@@ -1665,7 +1667,11 @@
 
     "hast-util-parse-selector": ["hast-util-parse-selector@2.2.5", "", {}, "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="],
 
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
 
     "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
 
@@ -1686,6 +1692,8 @@
     "html-to-image": ["html-to-image@1.11.13", "", {}, "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -2298,6 +2306,8 @@
     "regl-splom": ["regl-splom@1.0.14", "", { "dependencies": { "array-bounds": "^1.0.1", "array-range": "^1.0.1", "color-alpha": "^1.0.4", "flatten-vertex-data": "^1.0.2", "parse-rect": "^1.2.0", "pick-by-alias": "^1.2.0", "raf": "^3.4.1", "regl-scatter2d": "^3.2.3" } }, "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw=="],
 
     "rehype-katex": ["rehype-katex@7.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/katex": "^0.16.0", "hast-util-from-html-isomorphic": "^2.0.0", "hast-util-to-text": "^4.0.0", "katex": "^0.16.0", "unist-util-visit-parents": "^6.0.0", "vfile": "^6.0.0" } }, "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA=="],
+
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 

--- a/website/package.json
+++ b/website/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "react-plotly.js": "^2.6.0",
+    "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"
   },

--- a/website/src/components/blog/MarkdownFormatter.tsx
+++ b/website/src/components/blog/MarkdownFormatter.tsx
@@ -10,6 +10,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
+import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import {
   blogColors,
@@ -865,7 +866,11 @@ export function MarkdownFormatter({
   };
 
   return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeRaw]}
+      components={components}
+    >
       {markdown}
     </ReactMarkdown>
   );


### PR DESCRIPTION
react-markdown v10 ignores raw HTML by default, so <iframe> tags in research posts were rendered as literal text. Added rehype-raw to both the website/ and app/ MarkdownFormatter copies so HTML is parsed and the existing iframe component override (which already centers and mobile-sizes the embed) takes effect.

Affects all recent posts that embed dashboards via iframe (e.g. uk-two-child-limit-reintroduction, uk-combined-reforms-autumn-budget-2025, charitable-contributions). Post content is repo-controlled, so rehype-raw is safe without an additional sanitizer.