### PR TITLE
Fix report output timestamps and chart downloads

### DIFF
--- a/app/src/adapters/ReportAdapter.ts
+++ b/app/src/adapters/ReportAdapter.ts
@@ -44,6 +44,9 @@ export class ReportAdapter {
       simulationIds,
       status: this.mapApiStatusToReportStatus(metadata.status),
       output: convertJsonToReportOutput(metadata.output) as any, // Can be economy or household output
+      ...(metadata.requested_at ? { requestedAt: metadata.requested_at } : {}),
+      ...(metadata.started_at ? { startedAt: metadata.started_at } : {}),
+      ...(metadata.finished_at ? { finishedAt: metadata.finished_at } : {}),
     };
   }
 

--- a/app/src/adapters/ReportAdapter.ts
+++ b/app/src/adapters/ReportAdapter.ts
@@ -44,9 +44,6 @@ export class ReportAdapter {
       simulationIds,
       status: this.mapApiStatusToReportStatus(metadata.status),
       output: convertJsonToReportOutput(metadata.output) as any, // Can be economy or household output
-      ...(metadata.requested_at ? { requestedAt: metadata.requested_at } : {}),
-      ...(metadata.started_at ? { startedAt: metadata.started_at } : {}),
-      ...(metadata.finished_at ? { finishedAt: metadata.finished_at } : {}),
     };
   }
 

--- a/app/src/adapters/ReportAdapter.ts
+++ b/app/src/adapters/ReportAdapter.ts
@@ -20,6 +20,7 @@ export class ReportAdapter {
       error: 'error',
       // As well as current API report statuses
       pending: 'pending',
+      running: 'pending',
       complete: 'complete',
     };
     return statusMap[apiStatus] || 'pending';
@@ -43,6 +44,9 @@ export class ReportAdapter {
       apiVersion: metadata.api_version,
       simulationIds,
       status: this.mapApiStatusToReportStatus(metadata.status),
+      ...(metadata.requested_at ? { requestedAt: metadata.requested_at } : {}),
+      ...(metadata.started_at ? { startedAt: metadata.started_at } : {}),
+      ...(metadata.finished_at ? { finishedAt: metadata.finished_at } : {}),
       output: convertJsonToReportOutput(metadata.output) as any, // Can be economy or household output
     };
   }

--- a/app/src/components/ChartContainer.tsx
+++ b/app/src/components/ChartContainer.tsx
@@ -11,13 +11,17 @@ import {
 } from '@/components/ui';
 import { typography } from '@/designTokens';
 import { trackChartCsvDownloaded } from '@/utils/analytics';
-import { downloadChartAsSvg } from '@/utils/chartUtils';
+import { downloadChartAsSvg, downloadCsv } from '@/utils/chartUtils';
 
 interface ChartContainerProps {
   children: ReactNode;
   title: string;
   /** When set, renders a download button that exports the chart as SVG */
   downloadFilename?: string;
+  /** CSV rows to export when the CSV download button is used */
+  csvData?: string[][];
+  /** When set with csvData, renders a download button that exports chart data as CSV */
+  csvFilename?: string;
 }
 
 /**
@@ -28,8 +32,15 @@ interface ChartContainerProps {
  * @param downloadFilename - SVG filename (enables download button when set)
  * @param children - Main content (description and chart) displayed inside the white card
  */
-export function ChartContainer({ children, title, downloadFilename }: ChartContainerProps) {
+export function ChartContainer({
+  children,
+  title,
+  downloadFilename,
+  csvData,
+  csvFilename,
+}: ChartContainerProps) {
   const contentRef = useRef<HTMLDivElement>(null);
+  const hasCsvDownload = !!csvFilename && !!csvData;
 
   return (
     <Stack gap="sm">
@@ -37,29 +48,51 @@ export function ChartContainer({ children, title, downloadFilename }: ChartConta
         <Text size="lg" fw={typography.fontWeight.medium} className="tw:flex-1 tw:break-words">
           {title}
         </Text>
-        {downloadFilename && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="tw:shrink-0"
-                onClick={() => {
-                  trackChartCsvDownloaded();
-                  if (contentRef.current) {
-                    downloadChartAsSvg(contentRef.current, {
-                      title,
-                      filename: downloadFilename,
-                    });
-                  }
-                }}
-                aria-label="Download as SVG"
-              >
-                <IconDownload size={18} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="left">Download as SVG</TooltipContent>
-          </Tooltip>
+        {(downloadFilename || hasCsvDownload) && (
+          <Group gap="xs" wrap="nowrap" className="tw:shrink-0">
+            {hasCsvDownload && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="tw:shrink-0"
+                    onClick={() => {
+                      trackChartCsvDownloaded();
+                      downloadCsv(csvData!, csvFilename!);
+                    }}
+                    aria-label="Download CSV"
+                  >
+                    <IconDownload size={18} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="left">Download CSV</TooltipContent>
+              </Tooltip>
+            )}
+            {downloadFilename && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="tw:shrink-0"
+                    onClick={() => {
+                      if (contentRef.current) {
+                        downloadChartAsSvg(contentRef.current, {
+                          title,
+                          filename: downloadFilename,
+                        });
+                      }
+                    }}
+                    aria-label="Download as SVG"
+                  >
+                    <IconDownload size={18} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="left">Download as SVG</TooltipContent>
+              </Tooltip>
+            )}
+          </Group>
         )}
       </Group>
 

--- a/app/src/components/ChartContainer.tsx
+++ b/app/src/components/ChartContainer.tsx
@@ -10,7 +10,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui';
 import { typography } from '@/designTokens';
-import { trackChartCsvDownloaded } from '@/utils/analytics';
+import { trackChartCsvDownloaded, trackChartSvgDownload } from '@/utils/analytics';
 import { downloadChartAsSvg, downloadCsv } from '@/utils/chartUtils';
 
 interface ChartContainerProps {
@@ -78,6 +78,7 @@ export function ChartContainer({
                     className="tw:shrink-0"
                     onClick={() => {
                       if (contentRef.current) {
+                        trackChartSvgDownload();
                         downloadChartAsSvg(contentRef.current, {
                           title,
                           filename: downloadFilename,

--- a/app/src/components/ChartContainer.tsx
+++ b/app/src/components/ChartContainer.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui';
 import { typography } from '@/designTokens';
 import { trackChartCsvDownloaded, trackChartSvgDownload } from '@/utils/analytics';
-import { downloadChartAsSvg, downloadCsv } from '@/utils/chartUtils';
+import { downloadChartAsSvg, downloadCsv, type CsvData } from '@/utils/chartUtils';
 
 interface ChartContainerProps {
   children: ReactNode;
@@ -19,7 +19,7 @@ interface ChartContainerProps {
   /** When set, renders a download button that exports the chart as SVG */
   downloadFilename?: string;
   /** CSV rows to export when the CSV download button is used */
-  csvData?: string[][];
+  csvData?: CsvData;
   /** When set with csvData, renders a download button that exports chart data as CSV */
   csvFilename?: string;
 }

--- a/app/src/components/report/DashboardCard.tsx
+++ b/app/src/components/report/DashboardCard.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { colors, spacing } from '@/designTokens';
 import { typography } from '@/designTokens/typography';
 import { trackChartCsvDownloaded, trackChartSvgDownload } from '@/utils/analytics';
-import { downloadChartAsSvg, downloadCsv } from '@/utils/chartUtils';
+import { downloadChartAsSvg, downloadCsv, type CsvData } from '@/utils/chartUtils';
 
 const FADE_MS = 150;
 const RESIZE_S = 0.35;
@@ -43,7 +43,7 @@ interface DashboardCardProps {
   /** SVG download filename — renders a download button in the expanded toolbar */
   downloadFilename?: string;
   /** CSV rows to export from the expanded toolbar */
-  csvData?: string[][];
+  csvData?: CsvData;
   /** CSV download filename — renders a CSV download button when csvData is provided */
   csvFilename?: string;
 

--- a/app/src/components/report/DashboardCard.tsx
+++ b/app/src/components/report/DashboardCard.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { colors, spacing } from '@/designTokens';
 import { typography } from '@/designTokens/typography';
 import { trackChartCsvDownloaded } from '@/utils/analytics';
-import { downloadChartAsSvg } from '@/utils/chartUtils';
+import { downloadChartAsSvg, downloadCsv } from '@/utils/chartUtils';
 
 const FADE_MS = 150;
 const RESIZE_S = 0.35;
@@ -42,6 +42,10 @@ interface DashboardCardProps {
   expandedTitle?: string;
   /** SVG download filename — renders a download button in the expanded toolbar */
   downloadFilename?: string;
+  /** CSV rows to export from the expanded toolbar */
+  csvData?: string[][];
+  /** CSV download filename — renders a CSV download button when csvData is provided */
+  csvFilename?: string;
 
   // Style overrides (apply only when shrunken/idle)
   shrunkenBackground?: string;
@@ -84,6 +88,8 @@ export default function DashboardCard({
   expandedControls,
   expandedTitle,
   downloadFilename,
+  csvData,
+  csvFilename,
   shrunkenBackground,
   shrunkenBorderColor,
   padding: paddingProp,
@@ -192,6 +198,7 @@ export default function DashboardCard({
   const shrunkenContentOpacity = phase === 'idle' ? 1 : 0;
   const mountExpanded = phase === 'expanded' || phase === 'pre-collapse';
   const expandedContentOpacity = phase === 'expanded' && expandedVisible ? 1 : 0;
+  const hasCsvDownload = !!csvFilename && !!csvData;
 
   // Animate target: cell size when shrinking, expanded size when growing
   const getAnimateTarget = (): { width: number; height: number } | undefined => {
@@ -377,7 +384,7 @@ export default function DashboardCard({
                     flexShrink: 0,
                   }}
                 >
-                  {downloadFilename && (
+                  {hasCsvDownload && (
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Button
@@ -386,6 +393,24 @@ export default function DashboardCard({
                           onClick={(e) => {
                             e.stopPropagation();
                             trackChartCsvDownloaded();
+                            downloadCsv(csvData!, csvFilename!);
+                          }}
+                          aria-label="Download CSV"
+                        >
+                          <IconDownload size={16} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="left">Download CSV</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {downloadFilename && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={(e) => {
+                            e.stopPropagation();
                             if (expandedContentRef.current) {
                               downloadChartAsSvg(expandedContentRef.current, {
                                 title: expandedTitle,

--- a/app/src/components/report/DashboardCard.tsx
+++ b/app/src/components/report/DashboardCard.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { colors, spacing } from '@/designTokens';
 import { typography } from '@/designTokens/typography';
-import { trackChartCsvDownloaded } from '@/utils/analytics';
+import { trackChartCsvDownloaded, trackChartSvgDownload } from '@/utils/analytics';
 import { downloadChartAsSvg, downloadCsv } from '@/utils/chartUtils';
 
 const FADE_MS = 150;
@@ -412,6 +412,7 @@ export default function DashboardCard({
                           onClick={(e) => {
                             e.stopPropagation();
                             if (expandedContentRef.current) {
+                              trackChartSvgDownload();
                               downloadChartAsSvg(expandedContentRef.current, {
                                 title: expandedTitle,
                                 filename: downloadFilename,

--- a/app/src/hooks/useHydrateCalculationCache.ts
+++ b/app/src/hooks/useHydrateCalculationCache.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { calculationKeys, simulationKeys } from '@/libs/queryKeys';
 import type { CalcStatus } from '@/types/calculation';
@@ -46,7 +46,7 @@ export function useHydrateCalculationCache({
   const queryClient = useQueryClient();
   const hydratedRef = useRef<string>(''); // Track which report we've hydrated
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const currentReportId = report?.id || '';
 
     // Only hydrate once per report ID

--- a/app/src/hooks/useHydrateCalculationCache.ts
+++ b/app/src/hooks/useHydrateCalculationCache.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { calculationKeys, simulationKeys } from '@/libs/queryKeys';
 import type { CalcStatus } from '@/types/calculation';
@@ -46,7 +46,7 @@ export function useHydrateCalculationCache({
   const queryClient = useQueryClient();
   const hydratedRef = useRef<string>(''); // Track which report we've hydrated
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const currentReportId = report?.id || '';
 
     // Only hydrate once per report ID

--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -9,6 +9,7 @@ import { useAppNavigate } from '@/contexts/NavigationContext';
 import { ReportYearProvider } from '@/contexts/ReportYearContext';
 import { colors, spacing } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import { useHydrateCalculationCache } from '@/hooks/useHydrateCalculationCache';
 import { useSaveSharedReport } from '@/hooks/useSaveSharedReport';
 import { useSharedReportData } from '@/hooks/useSharedReportData';
 import { useUserReportById } from '@/hooks/useUserReports';
@@ -140,9 +141,10 @@ export default function ReportOutputPage({
   const activeTab = resolveDefaultReportOutputSubpage(outputType, subpage);
   const activeView = view || '';
   const versionMetadata = extractReportVersionMetadata(report?.output);
+  useHydrateCalculationCache({ report, outputType });
 
-  // Format the report creation timestamp using the current country's locale
-  const timestamp = formatReportTimestamp(userReport?.createdAt, countryId);
+  const reportRunTimestamp = report?.finishedAt ?? userReport?.updatedAt ?? userReport?.createdAt;
+  const timestamp = formatReportTimestamp(reportRunTimestamp, countryId);
 
   // Hook for saving shared reports with all ingredients
   const { saveSharedReport, saveResult, setSaveResult } = useSaveSharedReport();

--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -143,7 +143,7 @@ export default function ReportOutputPage({
   const versionMetadata = extractReportVersionMetadata(report?.output);
   useHydrateCalculationCache({ report, outputType });
 
-  const reportRunTimestamp = report?.finishedAt ?? userReport?.updatedAt ?? userReport?.createdAt;
+  const reportRunTimestamp = report?.finishedAt ?? report?.requestedAt ?? userReport?.createdAt;
   const timestamp = formatReportTimestamp(reportRunTimestamp, countryId);
 
   // Hook for saving shared reports with all ingredients

--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -141,8 +141,13 @@ export default function ReportOutputPage({
   const activeView = view || '';
   const versionMetadata = extractReportVersionMetadata(report?.output);
 
-  // Format the report creation timestamp using the current country's locale
-  const timestamp = formatReportTimestamp(userReport?.createdAt, countryId);
+  // Prefer API v1 base report execution metadata when present. This is not a
+  // user-specific last-run value; UserReport should own that once available.
+  const reportExecutionTimestamp = report?.finishedAt ?? report?.startedAt ?? report?.requestedAt;
+  const timestamp = formatReportTimestamp(
+    reportExecutionTimestamp ?? userReport?.createdAt,
+    countryId
+  );
 
   // Hook for saving shared reports with all ingredients
   const { saveSharedReport, saveResult, setSaveResult } = useSaveSharedReport();

--- a/app/src/pages/ReportOutput.page.tsx
+++ b/app/src/pages/ReportOutput.page.tsx
@@ -9,7 +9,6 @@ import { useAppNavigate } from '@/contexts/NavigationContext';
 import { ReportYearProvider } from '@/contexts/ReportYearContext';
 import { colors, spacing } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
-import { useHydrateCalculationCache } from '@/hooks/useHydrateCalculationCache';
 import { useSaveSharedReport } from '@/hooks/useSaveSharedReport';
 import { useSharedReportData } from '@/hooks/useSharedReportData';
 import { useUserReportById } from '@/hooks/useUserReports';
@@ -141,10 +140,9 @@ export default function ReportOutputPage({
   const activeTab = resolveDefaultReportOutputSubpage(outputType, subpage);
   const activeView = view || '';
   const versionMetadata = extractReportVersionMetadata(report?.output);
-  useHydrateCalculationCache({ report, outputType });
 
-  const reportRunTimestamp = report?.finishedAt ?? report?.requestedAt ?? userReport?.createdAt;
-  const timestamp = formatReportTimestamp(reportRunTimestamp, countryId);
+  // Format the report creation timestamp using the current country's locale
+  const timestamp = formatReportTimestamp(userReport?.createdAt, countryId);
 
   // Hook for saving shared reports with all ingredients
   const { saveSharedReport, saveResult, setSaveResult } = useSaveSharedReport();

--- a/app/src/pages/report-output/SocietyWideOverview.tsx
+++ b/app/src/pages/report-output/SocietyWideOverview.tsx
@@ -35,7 +35,9 @@ import {
 } from './distributional-impact/distributionalChartUtils';
 import DistributionalImpactIncomeAverageSubPage from './distributional-impact/DistributionalImpactIncomeAverageSubPage';
 import DistributionalImpactIncomeRelativeSubPage from './distributional-impact/DistributionalImpactIncomeRelativeSubPage';
-import WinnersLosersIncomeDecileSubPage from './distributional-impact/WinnersLosersIncomeDecileSubPage';
+import WinnersLosersIncomeDecileSubPage, {
+  getWinnersLosersCsvRows,
+} from './distributional-impact/WinnersLosersIncomeDecileSubPage';
 import { getInequalityTitle } from './inequality-impact/inequalityChartUtils';
 import InequalityImpactSubPage from './inequality-impact/InequalityImpactSubPage';
 import DeepPovertyImpactByAgeSubPage from './poverty-impact/DeepPovertyImpactByAgeSubPage';
@@ -1417,6 +1419,8 @@ export default function SocietyWideOverview({
         }
         expandedTitle={getWinnersLosersTitle(output, countryId, metadata)}
         downloadFilename="winners-losers-income-decile.svg"
+        csvFilename="winners-losers-income-decile.csv"
+        csvData={getWinnersLosersCsvRows(output)}
         expandedContent={<WinnersLosersIncomeDecileSubPage output={output} fillHeight />}
         onToggleMode={() => toggle('winners')}
       />

--- a/app/src/pages/report-output/SocietyWideOverview.tsx
+++ b/app/src/pages/report-output/SocietyWideOverview.tsx
@@ -27,22 +27,29 @@ import { formatBudgetaryImpact } from '@/utils/formatPowers';
 import { currencySymbol, formatCurrencyAbbr } from '@/utils/formatters';
 import { DIVERGING_GRAY_TEAL } from '@/utils/visualization/colorScales';
 import BudgetaryImpactSubPage from './budgetary-impact/BudgetaryImpactSubPage';
-import { getBudgetChartTitle } from './budgetary-impact/budgetChartUtils';
+import { getBudgetChartTitle, getBudgetCsvRows } from './budgetary-impact/budgetChartUtils';
 import {
+  getDecileAverageCsvRows,
+  getDecileRelativeCsvRows,
   getDistributionalAverageTitle,
   getDistributionalRelativeTitle,
+  getWinnersLosersCsvRows,
   getWinnersLosersTitle,
 } from './distributional-impact/distributionalChartUtils';
 import DistributionalImpactIncomeAverageSubPage from './distributional-impact/DistributionalImpactIncomeAverageSubPage';
 import DistributionalImpactIncomeRelativeSubPage from './distributional-impact/DistributionalImpactIncomeRelativeSubPage';
-import WinnersLosersIncomeDecileSubPage, {
-  getWinnersLosersCsvRows,
-} from './distributional-impact/WinnersLosersIncomeDecileSubPage';
-import { getInequalityTitle } from './inequality-impact/inequalityChartUtils';
+import WinnersLosersIncomeDecileSubPage from './distributional-impact/WinnersLosersIncomeDecileSubPage';
+import { getInequalityCsvRows, getInequalityTitle } from './inequality-impact/inequalityChartUtils';
 import InequalityImpactSubPage from './inequality-impact/InequalityImpactSubPage';
 import DeepPovertyImpactByAgeSubPage from './poverty-impact/DeepPovertyImpactByAgeSubPage';
 import DeepPovertyImpactByGenderSubPage from './poverty-impact/DeepPovertyImpactByGenderSubPage';
-import { getDeepPovertyTitle, getPovertyTitle } from './poverty-impact/povertyChartUtils';
+import {
+  getDeepPovertyTitle,
+  getPovertyByAgeCsvRows,
+  getPovertyByGenderCsvRows,
+  getPovertyByRaceCsvRows,
+  getPovertyTitle,
+} from './poverty-impact/povertyChartUtils';
 import PovertyImpactByAgeSubPage from './poverty-impact/PovertyImpactByAgeSubPage';
 import PovertyImpactByGenderSubPage from './poverty-impact/PovertyImpactByGenderSubPage';
 import PovertyImpactByRaceSubPage from './poverty-impact/PovertyImpactByRaceSubPage';
@@ -1100,6 +1107,33 @@ export default function SocietyWideOverview({
           : 'by-race';
     return `${depthPrefix}poverty-impact-${breakdownSuffix}.svg`;
   })();
+  const povertyCsvFilename = povertyDownloadFilename.replace(/\.svg$/, '.csv');
+  const povertyCsvData = (() => {
+    if (povertyDepth === 'regular') {
+      if (povertyBreakdown === 'by-age') {
+        return getPovertyByAgeCsvRows(output);
+      }
+      if (povertyBreakdown === 'by-gender') {
+        return getPovertyByGenderCsvRows(output);
+      }
+      if (povertyBreakdown === 'by-race') {
+        return getPovertyByRaceCsvRows(output);
+      }
+    }
+    if (povertyBreakdown === 'by-age') {
+      return getPovertyByAgeCsvRows(output, 'deep_poverty');
+    }
+    if (povertyBreakdown === 'by-gender') {
+      return getPovertyByGenderCsvRows(output, 'deep_poverty');
+    }
+    return undefined;
+  })();
+  const decileCsvFilename =
+    decileMode === 'absolute'
+      ? 'distributional-impact-income-average.csv'
+      : 'distributional-impact-income-relative.csv';
+  const decileCsvData =
+    decileMode === 'absolute' ? getDecileAverageCsvRows(output) : getDecileRelativeCsvRows(output);
 
   // Decile impact mini chart data (absolute)
   const decileKeys = Object.keys(output.decile.average).sort((a, b) => Number(a) - Number(b));
@@ -1248,6 +1282,8 @@ export default function SocietyWideOverview({
         }
         expandedTitle={getBudgetChartTitle(output.budget.budgetary_impact, countryId, metadata)}
         downloadFilename="budgetary-impact.svg"
+        csvFilename="budgetary-impact.csv"
+        csvData={getBudgetCsvRows(output, countryId)}
         expandedContent={<BudgetaryImpactSubPage output={output} fillHeight />}
         onToggleMode={() => toggle('budget')}
       />
@@ -1315,6 +1351,8 @@ export default function SocietyWideOverview({
             ? 'distributional-impact-income-average.svg'
             : 'distributional-impact-income-relative.svg'
         }
+        csvFilename={decileCsvFilename}
+        csvData={decileCsvData}
         expandedContent={
           decileMode === 'absolute' ? (
             <DistributionalImpactIncomeAverageSubPage output={output} fillHeight />
@@ -1474,6 +1512,8 @@ export default function SocietyWideOverview({
             : getDeepPovertyTitle(output, countryId, metadata)
         }
         downloadFilename={povertyDownloadFilename}
+        csvFilename={povertyCsvFilename}
+        csvData={povertyCsvData}
         expandedContent={povertyChart}
         onToggleMode={() => toggle('poverty')}
       />
@@ -1507,6 +1547,8 @@ export default function SocietyWideOverview({
         }
         expandedTitle={getInequalityTitle(output, metadata)}
         downloadFilename="inequality-impact.svg"
+        csvFilename="inequality-impact.csv"
+        csvData={getInequalityCsvRows(output)}
         expandedContent={<InequalityImpactSubPage output={output} fillHeight />}
         onToggleMode={() => toggle('inequality')}
       />

--- a/app/src/pages/report-output/budgetary-impact/BudgetaryImpactByProgramSubPage.tsx
+++ b/app/src/pages/report-output/budgetary-impact/BudgetaryImpactByProgramSubPage.tsx
@@ -21,6 +21,7 @@ import {
   formatBillions,
   getBudgetChartTitle,
   getBudgetFillColor,
+  getDetailedBudgetCsvRows,
   makeBudgetTickFormatter,
 } from './budgetChartUtils';
 
@@ -111,6 +112,8 @@ export default function BudgetaryImpactByProgramSubPage({ output }: Props) {
     <ChartContainer
       title={getBudgetChartTitle(budgetaryImpact, countryId, metadata)}
       downloadFilename="budgetary-impact-by-program.svg"
+      csvFilename="budgetary-impact-by-program.csv"
+      csvData={getDetailedBudgetCsvRows(output, metadata)}
     >
       <WaterfallChart
         data={dataWithHover}

--- a/app/src/pages/report-output/budgetary-impact/BudgetaryImpactSubPage.tsx
+++ b/app/src/pages/report-output/budgetary-impact/BudgetaryImpactSubPage.tsx
@@ -20,6 +20,7 @@ import {
   BudgetWaterfallTooltip,
   formatBillions,
   getBudgetChartTitle,
+  getBudgetCsvRows,
   getBudgetFillColor,
   makeBudgetTickFormatter,
 } from './budgetChartUtils';
@@ -134,6 +135,8 @@ export default function BudgetaryImpactSubPage({
     <ChartContainer
       title={getBudgetChartTitle(budgetaryImpact, countryId, metadata)}
       downloadFilename="budgetary-impact.svg"
+      csvFilename="budgetary-impact.csv"
+      csvData={getBudgetCsvRows(output, countryId)}
     >
       <WaterfallChart {...waterfallProps} height={chartHeight} />
     </ChartContainer>

--- a/app/src/pages/report-output/budgetary-impact/budgetChartUtils.tsx
+++ b/app/src/pages/report-output/budgetary-impact/budgetChartUtils.tsx
@@ -2,13 +2,21 @@
  * Shared utilities for the budgetary impact waterfall charts.
  */
 
+import type { SocietyWideReportOutput } from '@/api/societyWideCalculation';
 import { TOOLTIP_STYLE, type WaterfallDatum } from '@/components/charts';
 import { colors } from '@/designTokens/colors';
 import { typography } from '@/designTokens/typography';
 import type { CountryId } from '@/libs/countries';
 import type { MetadataState } from '@/types/metadata';
+import type { CsvData } from '@/utils/chartUtils';
 import { formatCurrencyAbbr } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+
+interface ProgramBudgetItem {
+  baseline: number;
+  difference: number;
+  reform: number;
+}
 
 /** Tooltip for budget waterfall charts - shows name and hover text */
 export function BudgetWaterfallTooltip({ active, payload }: any) {
@@ -57,6 +65,64 @@ export function getBudgetChartTitle(
 /** Formats a value in billions using the country's currency abbreviation. */
 export function formatBillions(value: number, countryId: CountryId): string {
   return formatCurrencyAbbr(value, countryId, { maximumFractionDigits: 1 });
+}
+
+export function getBudgetCsvRows(output: SocietyWideReportOutput, countryId: CountryId): CsvData {
+  const budgetaryImpact = output.budget.budgetary_impact;
+  const spendingImpact = output.budget.benefit_spending_impact;
+  const stateTaxImpact = output.budget.state_tax_revenue_impact;
+  const taxImpact = output.budget.tax_revenue_impact - stateTaxImpact;
+  const labelsBeforeFilter =
+    countryId === 'us'
+      ? [
+          'Federal tax revenues',
+          'State and local income tax revenues',
+          'Benefit spending',
+          'Net impact',
+        ]
+      : ['Tax revenues', 'State and local income tax revenues', 'Benefit spending', 'Net impact'];
+  const valuesBeforeFilter = [
+    taxImpact / 1e9,
+    stateTaxImpact / 1e9,
+    -spendingImpact / 1e9,
+    budgetaryImpact / 1e9,
+  ];
+  const rows = labelsBeforeFilter
+    .map((label, index) => [label, valuesBeforeFilter[index]])
+    .filter(([, value]) => value !== 0);
+
+  return [['Category', 'Budgetary impact (billions)'], ...rows];
+}
+
+function isProgramBudgetItem(value: unknown): value is ProgramBudgetItem {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const item = value as Partial<ProgramBudgetItem>;
+  return (
+    typeof item.baseline === 'number' &&
+    typeof item.reform === 'number' &&
+    typeof item.difference === 'number'
+  );
+}
+
+export function getDetailedBudgetCsvRows(
+  output: SocietyWideReportOutput,
+  metadata: MetadataState
+): CsvData {
+  const rows = Object.entries(output.detailed_budget ?? {})
+    .filter(([, values]) => isProgramBudgetItem(values))
+    .map(([program, values]) => {
+      const programValues = values as ProgramBudgetItem;
+      return [
+        metadata.variables[program]?.label ?? program,
+        programValues.baseline,
+        programValues.reform,
+        programValues.difference,
+      ];
+    });
+
+  return [['Program', 'Baseline', 'Reform', 'Difference'], ...rows];
 }
 
 /**

--- a/app/src/pages/report-output/distributional-impact/DistributionalImpactIncomeAverageSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/DistributionalImpactIncomeAverageSubPage.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/utils/chartUtils';
 import { currencySymbol, formatCurrency, ordinal, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import { getDecileAverageCsvRows } from './distributionalChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
@@ -173,6 +174,8 @@ export default function DistributionalImpactIncomeAverageSubPage({
     <ChartContainer
       title={getChartTitle()}
       downloadFilename="distributional-impact-income-average.svg"
+      csvFilename="distributional-impact-income-average.csv"
+      csvData={getDecileAverageCsvRows(output)}
     >
       <Stack gap="sm">
         <ResponsiveContainer width="100%" height={chartHeight}>

--- a/app/src/pages/report-output/distributional-impact/DistributionalImpactIncomeRelativeSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/DistributionalImpactIncomeRelativeSubPage.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/utils/chartUtils';
 import { formatPercent, ordinal, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import { getDecileRelativeCsvRows } from './distributionalChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
@@ -163,6 +164,8 @@ export default function DistributionalImpactIncomeRelativeSubPage({
     <ChartContainer
       title={getChartTitle()}
       downloadFilename="distributional-impact-income-relative.svg"
+      csvFilename="distributional-impact-income-relative.csv"
+      csvData={getDecileRelativeCsvRows(output)}
     >
       <Stack gap="sm">
         <ResponsiveContainer width="100%" height={chartHeight}>

--- a/app/src/pages/report-output/distributional-impact/DistributionalImpactWealthAverageSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/DistributionalImpactWealthAverageSubPage.tsx
@@ -24,6 +24,7 @@ import { absoluteChangeMessage } from '@/utils/chartMessages';
 import { getClampedChartHeight, getNiceTicks, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
 import { currencySymbol, formatCurrency, ordinal, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import { getDecileAverageCsvRows } from './distributionalChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
@@ -102,6 +103,8 @@ export default function DistributionalImpactWealthAverageSubPage({ output }: Pro
     <ChartContainer
       title={getChartTitle()}
       downloadFilename="distributional-impact-wealth-average.svg"
+      csvFilename="distributional-impact-wealth-average.csv"
+      csvData={getDecileAverageCsvRows(output, 'wealth')}
     >
       <Stack gap="sm">
         <ResponsiveContainer width="100%" height={chartHeight}>

--- a/app/src/pages/report-output/distributional-impact/DistributionalImpactWealthRelativeSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/DistributionalImpactWealthRelativeSubPage.tsx
@@ -24,6 +24,7 @@ import { relativeChangeMessage } from '@/utils/chartMessages';
 import { getClampedChartHeight, getNiceTicks, RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
 import { formatPercent, ordinal, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import { getDecileRelativeCsvRows } from './distributionalChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
@@ -92,6 +93,8 @@ export default function DistributionalImpactWealthRelativeSubPage({ output }: Pr
     <ChartContainer
       title={getChartTitle()}
       downloadFilename="distributional-impact-wealth-relative.svg"
+      csvFilename="distributional-impact-wealth-relative.csv"
+      csvData={getDecileRelativeCsvRows(output, 'wealth')}
     >
       <Stack gap="sm">
         <ResponsiveContainer width="100%" height={chartHeight}>

--- a/app/src/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.tsx
@@ -45,6 +45,29 @@ const LEGEND_TEXT_MAP: Record<string, string> = {
 };
 
 const BAR_SIZE = 18;
+const TOOLTIP_POSITION = { x: 72, y: 0 };
+const TOOLTIP_WRAPPER_STYLE = {
+  zIndex: 1000,
+  pointerEvents: 'none' as const,
+  maxWidth: 'min(280px, calc(100vw - 32px))',
+};
+
+function formatCsvValue(value: number | null | undefined): string {
+  return value === null || value === undefined ? '' : String(value);
+}
+
+export function getWinnersLosersCsvRows(output: SocietyWideReportOutput): string[][] {
+  const deciles = output.intra_decile.deciles;
+  const all = output.intra_decile.all;
+  const header = ['Income decile', ...CATEGORIES];
+  const allRow = ['All', ...CATEGORIES.map((cat) => formatCsvValue(all[cat]))];
+  const decileRows = Array.from({ length: 10 }, (_, index) => [
+    String(index + 1),
+    ...CATEGORIES.map((cat) => formatCsvValue(deciles[cat]?.[index])),
+  ]);
+
+  return [header, allRow, ...decileRows];
+}
 
 function WinnersLosersTooltip({ active, payload, label }: any) {
   if (!active || !payload?.length) {
@@ -158,7 +181,8 @@ export default function WinnersLosersIncomeDecileSubPage({
           content={<WinnersLosersTooltip />}
           allowEscapeViewBox={{ x: true, y: true }}
           offset={20}
-          wrapperStyle={{ zIndex: 1000 }}
+          position={TOOLTIP_POSITION}
+          wrapperStyle={TOOLTIP_WRAPPER_STYLE}
         />
         {CATEGORIES.map((cat) => (
           <Bar
@@ -215,7 +239,8 @@ export default function WinnersLosersIncomeDecileSubPage({
           content={<WinnersLosersTooltip />}
           allowEscapeViewBox={{ x: true, y: true }}
           offset={20}
-          wrapperStyle={{ zIndex: 1000 }}
+          position={TOOLTIP_POSITION}
+          wrapperStyle={TOOLTIP_WRAPPER_STYLE}
         />
         {CATEGORIES.map((cat) => (
           <Bar
@@ -285,7 +310,12 @@ export default function WinnersLosersIncomeDecileSubPage({
   }
 
   return (
-    <ChartContainer title={getChartTitle()} downloadFilename="winners-losers-income-decile.svg">
+    <ChartContainer
+      title={getChartTitle()}
+      downloadFilename="winners-losers-income-decile.svg"
+      csvFilename="winners-losers-income-decile.csv"
+      csvData={getWinnersLosersCsvRows(output)}
+    >
       <Stack gap="sm">
         <div style={{ display: 'flex' }}>
           <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>

--- a/app/src/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.tsx
@@ -57,8 +57,8 @@ function formatCsvValue(value: number | null | undefined): string {
 }
 
 export function getWinnersLosersCsvRows(output: SocietyWideReportOutput): string[][] {
-  const deciles = output.intra_decile.deciles;
-  const all = output.intra_decile.all;
+  const deciles = output.intra_decile.deciles ?? {};
+  const all = output.intra_decile.all ?? {};
   const header = ['Income decile', ...CATEGORIES];
   const allRow = ['All', ...CATEGORIES.map((cat) => formatCsvValue(all[cat]))];
   const decileRows = Array.from({ length: 10 }, (_, index) => [

--- a/app/src/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.tsx
@@ -12,21 +12,18 @@ import type { RootState } from '@/store';
 import { RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
 import { formatPercent } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import {
+  WINNERS_LOSERS_CATEGORIES as CATEGORIES,
+  getWinnersLosersCsvRows,
+} from './distributionalChartUtils';
+
+export { getWinnersLosersCsvRows } from './distributionalChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
   chartHeight?: number;
   fillHeight?: boolean;
 }
-
-// Category definitions and styling
-const CATEGORIES = [
-  'Gain more than 5%',
-  'Gain less than 5%',
-  'No change',
-  'Lose less than 5%',
-  'Lose more than 5%',
-] as const;
 
 const COLOR_MAP: Record<string, string> = {
   'Gain more than 5%': colors.primary[700],
@@ -51,23 +48,6 @@ const TOOLTIP_WRAPPER_STYLE = {
   pointerEvents: 'none' as const,
   maxWidth: 'min(280px, calc(100vw - 32px))',
 };
-
-function formatCsvValue(value: number | null | undefined): string {
-  return value === null || value === undefined ? '' : String(value);
-}
-
-export function getWinnersLosersCsvRows(output: SocietyWideReportOutput): string[][] {
-  const deciles = output.intra_decile.deciles ?? {};
-  const all = output.intra_decile.all ?? {};
-  const header = ['Income decile', ...CATEGORIES];
-  const allRow = ['All', ...CATEGORIES.map((cat) => formatCsvValue(all[cat]))];
-  const decileRows = Array.from({ length: 10 }, (_, index) => [
-    String(index + 1),
-    ...CATEGORIES.map((cat) => formatCsvValue(deciles[cat]?.[index])),
-  ]);
-
-  return [header, allRow, ...decileRows];
-}
 
 function WinnersLosersTooltip({ active, payload, label }: any) {
   if (!active || !payload?.length) {

--- a/app/src/pages/report-output/distributional-impact/WinnersLosersWealthDecileSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/WinnersLosersWealthDecileSubPage.tsx
@@ -43,6 +43,12 @@ const LEGEND_TEXT_MAP: Record<string, string> = {
 };
 
 const BAR_SIZE = 18;
+const TOOLTIP_POSITION = { x: 72, y: 0 };
+const TOOLTIP_WRAPPER_STYLE = {
+  zIndex: 1000,
+  pointerEvents: 'none' as const,
+  maxWidth: 'min(280px, calc(100vw - 32px))',
+};
 
 function WinnersLosersTooltip({ active, payload, label }: any) {
   if (!active || !payload?.length) {
@@ -157,7 +163,8 @@ export default function WinnersLosersWealthDecileSubPage({ output }: Props) {
                     content={<WinnersLosersTooltip />}
                     allowEscapeViewBox={{ x: true, y: true }}
                     offset={20}
-                    wrapperStyle={{ zIndex: 1000 }}
+                    position={TOOLTIP_POSITION}
+                    wrapperStyle={TOOLTIP_WRAPPER_STYLE}
                   />
                   {CATEGORIES.map((cat) => (
                     <Bar
@@ -216,7 +223,8 @@ export default function WinnersLosersWealthDecileSubPage({ output }: Props) {
                     content={<WinnersLosersTooltip />}
                     allowEscapeViewBox={{ x: true, y: true }}
                     offset={20}
-                    wrapperStyle={{ zIndex: 1000 }}
+                    position={TOOLTIP_POSITION}
+                    wrapperStyle={TOOLTIP_WRAPPER_STYLE}
                   />
                   {CATEGORIES.map((cat) => (
                     <Bar

--- a/app/src/pages/report-output/distributional-impact/WinnersLosersWealthDecileSubPage.tsx
+++ b/app/src/pages/report-output/distributional-impact/WinnersLosersWealthDecileSubPage.tsx
@@ -12,19 +12,14 @@ import type { RootState } from '@/store';
 import { RECHARTS_FONT_STYLE } from '@/utils/chartUtils';
 import { formatPercent } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import {
+  WINNERS_LOSERS_CATEGORIES as CATEGORIES,
+  getWinnersLosersCsvRows,
+} from './distributionalChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
 }
-
-// Category definitions and styling
-const CATEGORIES = [
-  'Gain more than 5%',
-  'Gain less than 5%',
-  'No change',
-  'Lose less than 5%',
-  'Lose more than 5%',
-] as const;
 
 const COLOR_MAP: Record<string, string> = {
   'Gain more than 5%': colors.primary[700],
@@ -135,7 +130,12 @@ export default function WinnersLosersWealthDecileSubPage({ output }: Props) {
   };
 
   return (
-    <ChartContainer title={getChartTitle()} downloadFilename="winners-losers-wealth-decile.svg">
+    <ChartContainer
+      title={getChartTitle()}
+      downloadFilename="winners-losers-wealth-decile.svg"
+      csvFilename="winners-losers-wealth-decile.csv"
+      csvData={getWinnersLosersCsvRows(output, 'wealth')}
+    >
       <Stack gap="sm">
         <div style={{ display: 'flex' }}>
           {/* Chart area */}

--- a/app/src/pages/report-output/distributional-impact/distributionalChartUtils.ts
+++ b/app/src/pages/report-output/distributional-impact/distributionalChartUtils.ts
@@ -5,8 +5,24 @@
 import type { SocietyWideReportOutput } from '@/api/societyWideCalculation';
 import type { CountryId } from '@/libs/countries';
 import type { MetadataState } from '@/types/metadata';
+import type { CsvData } from '@/utils/chartUtils';
 import { formatCurrency, formatPercent } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+
+export const WINNERS_LOSERS_CATEGORIES = [
+  'Gain more than 5%',
+  'Gain less than 5%',
+  'No change',
+  'Lose less than 5%',
+  'Lose more than 5%',
+] as const;
+
+type DecileBreakdown = 'income' | 'wealth';
+type WinnersLosersCategory = (typeof WINNERS_LOSERS_CATEGORIES)[number];
+
+function sortedDecileEntries(values: Record<string, number> | null | undefined) {
+  return Object.entries(values ?? {}).sort(([left], [right]) => Number(left) - Number(right));
+}
 
 export function getDistributionalAverageTitle(
   output: SocietyWideReportOutput,
@@ -75,4 +91,48 @@ export function getWinnersLosersTitle(
     return `This reform would decrease ${objectTerm} for ${totalBehindTerm} of the population${regionPhrase}`;
   }
   return `This reform would have no effect on ${objectTerm} for the population${regionPhrase}`;
+}
+
+export function getDecileAverageCsvRows(
+  output: SocietyWideReportOutput,
+  breakdown: DecileBreakdown = 'income'
+): CsvData {
+  const deciles = breakdown === 'income' ? output.decile.average : output.wealth_decile?.average;
+  const label = breakdown === 'income' ? 'Income decile' : 'Wealth decile';
+
+  return [
+    [label, 'Average change'],
+    ...sortedDecileEntries(deciles).map(([key, value]) => [key, value]),
+  ];
+}
+
+export function getDecileRelativeCsvRows(
+  output: SocietyWideReportOutput,
+  breakdown: DecileBreakdown = 'income'
+): CsvData {
+  const deciles = breakdown === 'income' ? output.decile.relative : output.wealth_decile?.relative;
+  const label = breakdown === 'income' ? 'Income decile' : 'Wealth decile';
+
+  return [
+    [label, 'Relative change'],
+    ...sortedDecileEntries(deciles).map(([key, value]) => [key, value]),
+  ];
+}
+
+export function getWinnersLosersCsvRows(
+  output: SocietyWideReportOutput,
+  breakdown: DecileBreakdown = 'income'
+): CsvData {
+  const intraDecile =
+    breakdown === 'income' ? output.intra_decile : (output.intra_wealth_decile ?? null);
+  const deciles = (intraDecile?.deciles ?? {}) as Partial<Record<WinnersLosersCategory, number[]>>;
+  const all = (intraDecile?.all ?? {}) as Partial<Record<WinnersLosersCategory, number>>;
+  const label = breakdown === 'income' ? 'Income decile' : 'Wealth decile';
+  const decileRows = Array.from({ length: 10 }, (_, index) => [
+    String(index + 1),
+    ...WINNERS_LOSERS_CATEGORIES.map((category) => deciles[category]?.[index]),
+  ]);
+  const allRow = ['All', ...WINNERS_LOSERS_CATEGORIES.map((category) => all[category])];
+
+  return [[label, ...WINNERS_LOSERS_CATEGORIES], ...decileRows, allRow];
 }

--- a/app/src/pages/report-output/inequality-impact/InequalityImpactSubPage.tsx
+++ b/app/src/pages/report-output/inequality-impact/InequalityImpactSubPage.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/utils/chartUtils';
 import { formatPercent, precision } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import { getInequalityCsvRows } from './inequalityChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
@@ -181,7 +182,12 @@ export default function InequalityImpactSubPage({
   }
 
   return (
-    <ChartContainer title={getChartTitle()} downloadFilename="inequality-impact.svg">
+    <ChartContainer
+      title={getChartTitle()}
+      downloadFilename="inequality-impact.svg"
+      csvFilename="inequality-impact.csv"
+      csvData={getInequalityCsvRows(output)}
+    >
       <Stack gap="sm">
         <ResponsiveContainer width="100%" height={chartHeight}>
           {barChart}

--- a/app/src/pages/report-output/inequality-impact/inequalityChartUtils.ts
+++ b/app/src/pages/report-output/inequality-impact/inequalityChartUtils.ts
@@ -4,6 +4,7 @@
 
 import type { SocietyWideReportOutput } from '@/api/societyWideCalculation';
 import type { MetadataState } from '@/types/metadata';
+import type { CsvData } from '@/utils/chartUtils';
 import { regionName } from '@/utils/impactChartUtils';
 
 export function getInequalityTitle(
@@ -29,4 +30,22 @@ export function getInequalityTitle(
   const region = regionName(metadata);
   const regionPhrase = region ? ` in ${region}` : '';
   return `This reform would ${signTerm} income inequality${regionPhrase}`;
+}
+
+export function getInequalityCsvRows(output: SocietyWideReportOutput): CsvData {
+  const metrics = [
+    ['Gini index', output.inequality.gini],
+    ['Top 10% share', output.inequality.top_10_pct_share],
+    ['Top 1% share', output.inequality.top_1_pct_share],
+  ] as const;
+
+  return [
+    ['Metric', 'Baseline', 'Reform', 'Change'],
+    ...metrics.map(([label, impact]) => [
+      label,
+      impact.baseline,
+      impact.reform,
+      impact.baseline === 0 ? null : impact.reform / impact.baseline - 1,
+    ]),
+  ];
 }

--- a/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByAgeSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByAgeSubPage.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/utils/chartUtils';
 import { formatNumber, formatPercent } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import { getPovertyByAgeCsvRows } from './povertyChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
@@ -191,7 +192,12 @@ export default function DeepPovertyImpactByAgeSubPage({
   }
 
   return (
-    <ChartContainer title={getChartTitle()} downloadFilename="deep-poverty-impact-by-age.svg">
+    <ChartContainer
+      title={getChartTitle()}
+      downloadFilename="deep-poverty-impact-by-age.svg"
+      csvFilename="deep-poverty-impact-by-age.csv"
+      csvData={getPovertyByAgeCsvRows(output, 'deep_poverty')}
+    >
       <Stack gap="sm">
         <ResponsiveContainer width="100%" height={chartHeight}>
           {barChart}

--- a/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByGenderSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/DeepPovertyImpactByGenderSubPage.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/utils/chartUtils';
 import { formatNumber, formatPercent } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import { getPovertyByGenderCsvRows } from './povertyChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
@@ -193,7 +194,12 @@ export default function DeepPovertyImpactByGenderSubPage({
   }
 
   return (
-    <ChartContainer title={getChartTitle()} downloadFilename="deep-poverty-impact-by-gender.svg">
+    <ChartContainer
+      title={getChartTitle()}
+      downloadFilename="deep-poverty-impact-by-gender.svg"
+      csvFilename="deep-poverty-impact-by-gender.csv"
+      csvData={getPovertyByGenderCsvRows(output, 'deep_poverty')}
+    >
       <Stack gap="sm">
         <ResponsiveContainer width="100%" height={chartHeight}>
           {barChart}

--- a/app/src/pages/report-output/poverty-impact/PovertyImpactByAgeSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/PovertyImpactByAgeSubPage.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/utils/chartUtils';
 import { formatNumber, formatPercent } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import { getPovertyByAgeCsvRows } from './povertyChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
@@ -190,7 +191,12 @@ export default function PovertyImpactByAgeSubPage({
   }
 
   return (
-    <ChartContainer title={getChartTitle()} downloadFilename="poverty-impact-by-age.svg">
+    <ChartContainer
+      title={getChartTitle()}
+      downloadFilename="poverty-impact-by-age.svg"
+      csvFilename="poverty-impact-by-age.csv"
+      csvData={getPovertyByAgeCsvRows(output)}
+    >
       <Stack gap="sm">
         <ResponsiveContainer width="100%" height={chartHeight}>
           {barChart}

--- a/app/src/pages/report-output/poverty-impact/PovertyImpactByGenderSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/PovertyImpactByGenderSubPage.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/utils/chartUtils';
 import { formatNumber, formatPercent } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import { getPovertyByGenderCsvRows } from './povertyChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
@@ -193,7 +194,12 @@ export default function PovertyImpactByGenderSubPage({
   }
 
   return (
-    <ChartContainer title={getChartTitle()} downloadFilename="poverty-impact-by-gender.svg">
+    <ChartContainer
+      title={getChartTitle()}
+      downloadFilename="poverty-impact-by-gender.svg"
+      csvFilename="poverty-impact-by-gender.csv"
+      csvData={getPovertyByGenderCsvRows(output)}
+    >
       <Stack gap="sm">
         <ResponsiveContainer width="100%" height={chartHeight}>
           {barChart}

--- a/app/src/pages/report-output/poverty-impact/PovertyImpactByRaceSubPage.tsx
+++ b/app/src/pages/report-output/poverty-impact/PovertyImpactByRaceSubPage.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/utils/chartUtils';
 import { formatNumber, formatPercent } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+import { getPovertyByRaceCsvRows } from './povertyChartUtils';
 
 interface Props {
   output: SocietyWideReportOutput;
@@ -189,7 +190,12 @@ export default function PovertyImpactByRaceSubPage({
   }
 
   return (
-    <ChartContainer title={getChartTitle()} downloadFilename="poverty-impact-by-race.svg">
+    <ChartContainer
+      title={getChartTitle()}
+      downloadFilename="poverty-impact-by-race.svg"
+      csvFilename="poverty-impact-by-race.csv"
+      csvData={getPovertyByRaceCsvRows(output)}
+    >
       <Stack gap="sm">
         <ResponsiveContainer width="100%" height={chartHeight}>
           {barChart}

--- a/app/src/pages/report-output/poverty-impact/povertyChartUtils.ts
+++ b/app/src/pages/report-output/poverty-impact/povertyChartUtils.ts
@@ -5,8 +5,12 @@
 import type { SocietyWideReportOutput } from '@/api/societyWideCalculation';
 import type { CountryId } from '@/libs/countries';
 import type { MetadataState } from '@/types/metadata';
+import type { CsvCell, CsvData } from '@/utils/chartUtils';
 import { formatNumber, formatPercent } from '@/utils/formatters';
 import { regionName } from '@/utils/impactChartUtils';
+
+type PovertyDepth = 'poverty' | 'deep_poverty';
+type PovertyRate = { baseline: number; reform: number };
 
 function povertyTitleFromData(
   baseline: number,
@@ -50,4 +54,56 @@ export function getDeepPovertyTitle(
 ): string {
   const { baseline, reform } = output.poverty.deep_poverty.all;
   return povertyTitleFromData(baseline, reform, 'the deep poverty rate', countryId, metadata);
+}
+
+function relativeChange(rate?: PovertyRate): CsvCell {
+  if (!rate || rate.baseline === 0) {
+    return null;
+  }
+  return rate.reform / rate.baseline - 1;
+}
+
+function povertyRow(label: string, rate?: PovertyRate): CsvCell[] {
+  return [label, rate?.baseline, rate?.reform, relativeChange(rate)];
+}
+
+export function getPovertyByAgeCsvRows(
+  output: SocietyWideReportOutput,
+  depth: PovertyDepth = 'poverty'
+): CsvData {
+  const impact = output.poverty[depth];
+  return [
+    ['Age group', 'Baseline', 'Reform', 'Change'],
+    povertyRow('Children', impact.child),
+    povertyRow('Working-age adults', impact.adult),
+    povertyRow('Seniors', impact.senior),
+    povertyRow('All', impact.all),
+  ];
+}
+
+export function getPovertyByGenderCsvRows(
+  output: SocietyWideReportOutput,
+  depth: PovertyDepth = 'poverty'
+): CsvData {
+  const genderImpact = output.poverty_by_gender?.[depth];
+  const allImpact = output.poverty[depth];
+  return [
+    ['Sex', 'Baseline', 'Reform', 'Change'],
+    povertyRow('Male', genderImpact?.male),
+    povertyRow('Female', genderImpact?.female),
+    povertyRow('All', allImpact.all),
+  ];
+}
+
+export function getPovertyByRaceCsvRows(output: SocietyWideReportOutput): CsvData {
+  const raceImpact = output.poverty_by_race?.poverty;
+  const allImpact = output.poverty.poverty;
+  return [
+    ['Race', 'Baseline', 'Reform', 'Change'],
+    povertyRow('White (non-Hispanic)', raceImpact?.white),
+    povertyRow('Black (non-Hispanic)', raceImpact?.black),
+    povertyRow('Hispanic', raceImpact?.hispanic),
+    povertyRow('Other', raceImpact?.other),
+    povertyRow('All', allImpact.all),
+  ];
 }

--- a/app/src/tests/unit/adapters/ReportAdapter.test.ts
+++ b/app/src/tests/unit/adapters/ReportAdapter.test.ts
@@ -88,6 +88,28 @@ describe('ReportAdapter', () => {
       expect(result.status).toBe(errorStatus);
       expect(result.output).toBe(nullOutput);
     });
+
+    it('given API run timestamps then maps them onto the report domain model', () => {
+      const metadata = {
+        id: 123,
+        country_id: 'us',
+        simulation_1_id: '456',
+        simulation_2_id: null,
+        year: '2026',
+        api_version: 'v1',
+        status: 'complete',
+        output: null,
+        requested_at: '2026-05-04T12:00:00Z',
+        started_at: '2026-05-04T12:01:00Z',
+        finished_at: '2026-05-04T12:02:00Z',
+      } as const;
+
+      const result = ReportAdapter.fromMetadata(metadata);
+
+      expect(result.requestedAt).toBe('2026-05-04T12:00:00Z');
+      expect(result.startedAt).toBe('2026-05-04T12:01:00Z');
+      expect(result.finishedAt).toBe('2026-05-04T12:02:00Z');
+    });
   });
 
   describe('toCreationPayload', () => {

--- a/app/src/tests/unit/adapters/ReportAdapter.test.ts
+++ b/app/src/tests/unit/adapters/ReportAdapter.test.ts
@@ -88,6 +88,32 @@ describe('ReportAdapter', () => {
       expect(result.status).toBe(errorStatus);
       expect(result.output).toBe(nullOutput);
     });
+
+    test('given metadata with running status then maps to pending report status', () => {
+      const metadata = {
+        ...mockReportMetadata,
+        status: 'running' as const,
+      };
+
+      const result = ReportAdapter.fromMetadata(metadata);
+
+      expect(result.status).toBe('pending');
+    });
+
+    test('given metadata with run timestamps then maps them as base report execution metadata', () => {
+      const metadata = {
+        ...mockReportMetadata,
+        requested_at: '2026-02-03T15:00:00Z',
+        started_at: '2026-02-03T15:01:00Z',
+        finished_at: '2026-02-03T15:02:00Z',
+      };
+
+      const result = ReportAdapter.fromMetadata(metadata);
+
+      expect(result.requestedAt).toBe(metadata.requested_at);
+      expect(result.startedAt).toBe(metadata.started_at);
+      expect(result.finishedAt).toBe(metadata.finished_at);
+    });
   });
 
   describe('toCreationPayload', () => {

--- a/app/src/tests/unit/adapters/ReportAdapter.test.ts
+++ b/app/src/tests/unit/adapters/ReportAdapter.test.ts
@@ -88,28 +88,6 @@ describe('ReportAdapter', () => {
       expect(result.status).toBe(errorStatus);
       expect(result.output).toBe(nullOutput);
     });
-
-    it('given API run timestamps then maps them onto the report domain model', () => {
-      const metadata = {
-        id: 123,
-        country_id: 'us',
-        simulation_1_id: '456',
-        simulation_2_id: null,
-        year: '2026',
-        api_version: 'v1',
-        status: 'complete',
-        output: null,
-        requested_at: '2026-05-04T12:00:00Z',
-        started_at: '2026-05-04T12:01:00Z',
-        finished_at: '2026-05-04T12:02:00Z',
-      } as const;
-
-      const result = ReportAdapter.fromMetadata(metadata);
-
-      expect(result.requestedAt).toBe('2026-05-04T12:00:00Z');
-      expect(result.startedAt).toBe('2026-05-04T12:01:00Z');
-      expect(result.finishedAt).toBe('2026-05-04T12:02:00Z');
-    });
   });
 
   describe('toCreationPayload', () => {

--- a/app/src/tests/unit/api/report.test.ts
+++ b/app/src/tests/unit/api/report.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ReportAdapter } from '@/adapters/ReportAdapter';
 import {
   createReport,
   createReportAndAssociateWithUser,
@@ -79,6 +80,31 @@ describe('report API', () => {
         requested_at: metadataWithRunTimestamps.requested_at,
         started_at: metadataWithRunTimestamps.started_at,
         finished_at: metadataWithRunTimestamps.finished_at,
+      });
+    });
+
+    test('given API response includes snake_case run timestamps then adapter exposes report timestamps', async () => {
+      const countryId = 'us';
+      const reportId = 'report-123';
+      const metadataWithRunTimestamps = {
+        ...mockReportMetadata,
+        requested_at: '2026-02-03T15:00:00Z',
+        started_at: '2026-02-03T15:01:00Z',
+        finished_at: '2026-02-03T15:02:00Z',
+      };
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({ status: 'ok', result: metadataWithRunTimestamps }),
+      };
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      const metadata = await fetchReportById(countryId, reportId);
+      const report = ReportAdapter.fromMetadata(metadata);
+
+      expect(report).toMatchObject({
+        requestedAt: metadataWithRunTimestamps.requested_at,
+        startedAt: metadataWithRunTimestamps.started_at,
+        finishedAt: metadataWithRunTimestamps.finished_at,
       });
     });
 

--- a/app/src/tests/unit/api/report.test.ts
+++ b/app/src/tests/unit/api/report.test.ts
@@ -55,6 +55,33 @@ describe('report API', () => {
       expect(result).toEqual(mockReportMetadata);
     });
 
+    test('given API response includes run timestamps then preserves them on metadata', async () => {
+      // Given
+      const countryId = 'us';
+      const reportId = 'report-123';
+      const metadataWithRunTimestamps = {
+        ...mockReportMetadata,
+        requested_at: '2026-02-03T15:00:00Z',
+        started_at: '2026-02-03T15:01:00Z',
+        finished_at: '2026-02-03T15:02:00Z',
+      };
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({ status: 'ok', result: metadataWithRunTimestamps }),
+      };
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      // When
+      const result = await fetchReportById(countryId, reportId);
+
+      // Then
+      expect(result).toMatchObject({
+        requested_at: metadataWithRunTimestamps.requested_at,
+        started_at: metadataWithRunTimestamps.started_at,
+        finished_at: metadataWithRunTimestamps.finished_at,
+      });
+    });
+
     test('given API error then throws error', async () => {
       // Given
       const countryId = 'us';

--- a/app/src/tests/unit/components/ChartContainer.test.tsx
+++ b/app/src/tests/unit/components/ChartContainer.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { ChartContainer } from '@/components/ChartContainer';
+import { downloadChartAsSvg, downloadCsv } from '@/utils/chartUtils';
+
+vi.mock('@/utils/chartUtils', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/chartUtils')>('@/utils/chartUtils');
+  return {
+    ...actual,
+    downloadChartAsSvg: vi.fn(),
+    downloadCsv: vi.fn(),
+  };
+});
+
+vi.mock('@/utils/analytics', () => ({
+  trackChartCsvDownloaded: vi.fn(),
+}));
+
+describe('ChartContainer', () => {
+  test('given csv data then CSV download button downloads the provided rows', () => {
+    const csvRows = [
+      ['Income decile', 'Gain more than 5%'],
+      ['All', '0.25'],
+    ];
+
+    render(
+      <ChartContainer title="Winners and losers" csvFilename="winners-losers.csv" csvData={csvRows}>
+        <div>Chart body</div>
+      </ChartContainer>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /download csv/i }));
+
+    expect(downloadCsv).toHaveBeenCalledWith(csvRows, 'winners-losers.csv');
+  });
+
+  test('given svg and csv downloads then both export actions are available', () => {
+    render(
+      <ChartContainer
+        title="Winners and losers"
+        downloadFilename="winners-losers.svg"
+        csvFilename="winners-losers.csv"
+        csvData={[['Header'], ['Value']]}
+      >
+        <svg width="100" height="100" />
+      </ChartContainer>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /download as svg/i }));
+    fireEvent.click(screen.getByRole('button', { name: /download csv/i }));
+
+    expect(downloadChartAsSvg).toHaveBeenCalled();
+    expect(downloadCsv).toHaveBeenCalledWith([['Header'], ['Value']], 'winners-losers.csv');
+  });
+});

--- a/app/src/tests/unit/components/ChartContainer.test.tsx
+++ b/app/src/tests/unit/components/ChartContainer.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@test-utils';
 import { describe, expect, test, vi } from 'vitest';
 import { ChartContainer } from '@/components/ChartContainer';
+import { trackChartCsvDownloaded, trackChartSvgDownload } from '@/utils/analytics';
 import { downloadChartAsSvg, downloadCsv } from '@/utils/chartUtils';
 
 vi.mock('@/utils/chartUtils', async () => {
@@ -14,6 +15,7 @@ vi.mock('@/utils/chartUtils', async () => {
 
 vi.mock('@/utils/analytics', () => ({
   trackChartCsvDownloaded: vi.fn(),
+  trackChartSvgDownload: vi.fn(),
 }));
 
 describe('ChartContainer', () => {
@@ -50,6 +52,8 @@ describe('ChartContainer', () => {
     fireEvent.click(screen.getByRole('button', { name: /download csv/i }));
 
     expect(downloadChartAsSvg).toHaveBeenCalled();
+    expect(trackChartSvgDownload).toHaveBeenCalled();
     expect(downloadCsv).toHaveBeenCalledWith([['Header'], ['Value']], 'winners-losers.csv');
+    expect(trackChartCsvDownloaded).toHaveBeenCalled();
   });
 });

--- a/app/src/tests/unit/components/report/DashboardCard.test.tsx
+++ b/app/src/tests/unit/components/report/DashboardCard.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import DashboardCard from '@/components/report/DashboardCard';
+import { trackChartCsvDownloaded, trackChartSvgDownload } from '@/utils/analytics';
+import { downloadChartAsSvg, downloadCsv } from '@/utils/chartUtils';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({
+      children,
+      onAnimationComplete,
+      initial,
+      animate,
+      transition,
+      ...props
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      onAnimationComplete?: () => void;
+      initial?: unknown;
+      animate?: unknown;
+      transition?: unknown;
+    }) => {
+      React.useEffect(() => {
+        onAnimationComplete?.();
+      });
+
+      return <div {...props}>{children}</div>;
+    },
+  },
+}));
+
+vi.mock('@/utils/chartUtils', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/chartUtils')>('@/utils/chartUtils');
+  return {
+    ...actual,
+    downloadChartAsSvg: vi.fn(),
+    downloadCsv: vi.fn(),
+  };
+});
+
+vi.mock('@/utils/analytics', () => ({
+  trackChartCsvDownloaded: vi.fn(),
+  trackChartSvgDownload: vi.fn(),
+}));
+
+describe('DashboardCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  test('given expanded downloads then toolbar buttons download CSV and SVG with analytics', async () => {
+    const csvData = [
+      ['Metric', 'Value'],
+      ['Net impact', 1],
+    ];
+
+    render(
+      <DashboardCard
+        mode="expanded"
+        zIndex={1}
+        expandDirection="down-right"
+        shrunkenHeader={<span>Budget</span>}
+        expandedTitle="Budgetary impact"
+        expandedContent={<svg width="100" height="100" />}
+        downloadFilename="budgetary-impact.svg"
+        csvFilename="budgetary-impact.csv"
+        csvData={csvData}
+      />
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /download csv/i }));
+    fireEvent.click(screen.getByRole('button', { name: /download as svg/i }));
+
+    expect(downloadCsv).toHaveBeenCalledWith(csvData, 'budgetary-impact.csv');
+    expect(trackChartCsvDownloaded).toHaveBeenCalled();
+    expect(downloadChartAsSvg).toHaveBeenCalledWith(expect.any(HTMLDivElement), {
+      title: 'Budgetary impact',
+      filename: 'budgetary-impact.svg',
+    });
+    expect(trackChartSvgDownload).toHaveBeenCalled();
+  });
+});

--- a/app/src/tests/unit/hooks/useHydrateCalculationCache.test.tsx
+++ b/app/src/tests/unit/hooks/useHydrateCalculationCache.test.tsx
@@ -1,6 +1,6 @@
-import { ReactNode, useEffect } from 'react';
+import { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHydrateCalculationCache } from '@/hooks/useHydrateCalculationCache';
 import { calculationKeys } from '@/libs/queryKeys';
@@ -68,41 +68,6 @@ describe('useHydrateCalculationCache', () => {
       targetType: 'report',
       startedAt: expect.any(Number),
     });
-  });
-
-  it('should hydrate parent cache before child passive effects can start a rerun', async () => {
-    const mockReport = createMockReport(true);
-    const startCalculationIfCacheMissing = vi.fn();
-
-    function ChildStartCheck() {
-      useEffect(() => {
-        const cachedStatus = queryClient.getQueryData<CalcStatus>(
-          calculationKeys.byReportId(mockReport.id!)
-        );
-        if (cachedStatus?.status !== 'complete') {
-          startCalculationIfCacheMissing();
-        }
-      }, []);
-
-      return null;
-    }
-
-    function ParentPage() {
-      useHydrateCalculationCache({ report: mockReport, outputType: 'societyWide' });
-      return <ChildStartCheck />;
-    }
-
-    render(<ParentPage />, { wrapper });
-
-    await waitFor(() => {
-      expect(
-        queryClient.getQueryData<CalcStatus>(calculationKeys.byReportId(mockReport.id!))
-      ).toMatchObject({
-        status: 'complete',
-        result: mockReport.output,
-      });
-    });
-    expect(startCalculationIfCacheMissing).not.toHaveBeenCalled();
   });
 
   it('should hydrate cache with persisted output for household report', () => {

--- a/app/src/tests/unit/hooks/useHydrateCalculationCache.test.tsx
+++ b/app/src/tests/unit/hooks/useHydrateCalculationCache.test.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { render, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHydrateCalculationCache } from '@/hooks/useHydrateCalculationCache';
 import { calculationKeys } from '@/libs/queryKeys';
@@ -68,6 +68,41 @@ describe('useHydrateCalculationCache', () => {
       targetType: 'report',
       startedAt: expect.any(Number),
     });
+  });
+
+  it('should hydrate parent cache before child passive effects can start a rerun', async () => {
+    const mockReport = createMockReport(true);
+    const startCalculationIfCacheMissing = vi.fn();
+
+    function ChildStartCheck() {
+      useEffect(() => {
+        const cachedStatus = queryClient.getQueryData<CalcStatus>(
+          calculationKeys.byReportId(mockReport.id!)
+        );
+        if (cachedStatus?.status !== 'complete') {
+          startCalculationIfCacheMissing();
+        }
+      }, []);
+
+      return null;
+    }
+
+    function ParentPage() {
+      useHydrateCalculationCache({ report: mockReport, outputType: 'societyWide' });
+      return <ChildStartCheck />;
+    }
+
+    render(<ParentPage />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<CalcStatus>(calculationKeys.byReportId(mockReport.id!))
+      ).toMatchObject({
+        status: 'complete',
+        result: mockReport.output,
+      });
+    });
+    expect(startCalculationIfCacheMissing).not.toHaveBeenCalled();
   });
 
   it('should hydrate cache with persisted output for household report', () => {

--- a/app/src/tests/unit/pages/ReportOutput.page.test.tsx
+++ b/app/src/tests/unit/pages/ReportOutput.page.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { useHydrateCalculationCache } from '@/hooks/useHydrateCalculationCache';
 import { useUserReportById } from '@/hooks/useUserReports';
 import ReportOutputPage from '@/pages/ReportOutput.page';
 import {
@@ -90,6 +91,10 @@ vi.mock('@/hooks/useStartCalculationOnLoad', () => ({
   useStartCalculationOnLoad: vi.fn(),
 }));
 
+vi.mock('@/hooks/useHydrateCalculationCache', () => ({
+  useHydrateCalculationCache: vi.fn(),
+}));
+
 vi.mock('@/hooks/useSaveSharedReport', () => ({
   useSaveSharedReport: vi.fn(() => ({
     saveSharedReport: vi.fn(),
@@ -118,6 +123,40 @@ describe('ReportOutputPage', () => {
 
     // Then
     expect(screen.getByRole('heading', { name: 'Test Report' })).toBeInTheDocument();
+  });
+
+  test('given user report has updatedAt then header timestamp uses updatedAt over createdAt', () => {
+    vi.mocked(useUserReportById).mockReturnValue({
+      userReport: {
+        ...MOCK_USER_REPORT,
+        createdAt: '2024-01-01T12:00:00.000Z',
+        updatedAt: '2024-04-30T12:00:00.000Z',
+      },
+      report: MOCK_REPORT_WITH_YEAR,
+      simulations: [MOCK_SIMULATION_GEOGRAPHY],
+      userSimulations: [],
+      userPolicies: [],
+      policies: [],
+      households: [],
+      userHouseholds: [],
+      geographies: [],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    expect(screen.getByText(/Ran Apr 30, 2024 at/)).toBeInTheDocument();
+    expect(screen.queryByText(/Jan 1, 2024/)).not.toBeInTheDocument();
+  });
+
+  test('given report has persisted output then calculation cache is hydrated from that output', () => {
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    expect(useHydrateCalculationCache).toHaveBeenCalledWith({
+      report: MOCK_REPORT_WITH_YEAR,
+      outputType: 'societyWide',
+    });
   });
 
   test('given reproduce subpage then breadcrumb returns to the current report', () => {

--- a/app/src/tests/unit/pages/ReportOutput.page.test.tsx
+++ b/app/src/tests/unit/pages/ReportOutput.page.test.tsx
@@ -102,6 +102,19 @@ vi.mock('@/hooks/useSaveSharedReport', () => ({
 describe('ReportOutputPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useUserReportById).mockReturnValue({
+      userReport: MOCK_USER_REPORT,
+      report: MOCK_REPORT_WITH_YEAR,
+      simulations: [MOCK_SIMULATION_GEOGRAPHY],
+      userSimulations: [],
+      userPolicies: [],
+      policies: [],
+      households: [],
+      userHouseholds: [],
+      geographies: [],
+      isLoading: false,
+      error: null,
+    });
   });
 
   test('given report with year then year is passed to layout', () => {
@@ -155,6 +168,58 @@ describe('ReportOutputPage', () => {
     render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
 
     expect(screen.getByText(/Ran Feb 3, 2026 at/)).toBeInTheDocument();
+  });
+
+  test('given report has only started timestamp then it is displayed', () => {
+    vi.mocked(useUserReportById).mockReturnValue({
+      userReport: MOCK_USER_REPORT,
+      report: {
+        ...MOCK_REPORT_WITH_YEAR,
+        startedAt: '2026-02-02T15:01:00Z',
+      },
+      simulations: [MOCK_SIMULATION_GEOGRAPHY],
+      userSimulations: [],
+      userPolicies: [],
+      policies: [],
+      households: [],
+      userHouseholds: [],
+      geographies: [],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    expect(screen.getByText(/Ran Feb 2, 2026 at/)).toBeInTheDocument();
+  });
+
+  test('given report has only requested timestamp then it is displayed', () => {
+    vi.mocked(useUserReportById).mockReturnValue({
+      userReport: MOCK_USER_REPORT,
+      report: {
+        ...MOCK_REPORT_WITH_YEAR,
+        requestedAt: '2026-02-01T15:00:00Z',
+      },
+      simulations: [MOCK_SIMULATION_GEOGRAPHY],
+      userSimulations: [],
+      userPolicies: [],
+      policies: [],
+      households: [],
+      userHouseholds: [],
+      geographies: [],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    expect(screen.getByText(/Ran Feb 1, 2026 at/)).toBeInTheDocument();
+  });
+
+  test('given report has no execution timestamp then association creation time remains fallback', () => {
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    expect(screen.getByText(/Ran Jan 1, 2024 at/)).toBeInTheDocument();
   });
 
   test('given society-wide report with complete calculation then renders without error', () => {

--- a/app/src/tests/unit/pages/ReportOutput.page.test.tsx
+++ b/app/src/tests/unit/pages/ReportOutput.page.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { useHydrateCalculationCache } from '@/hooks/useHydrateCalculationCache';
 import { useUserReportById } from '@/hooks/useUserReports';
 import ReportOutputPage from '@/pages/ReportOutput.page';
 import {
@@ -91,10 +90,6 @@ vi.mock('@/hooks/useStartCalculationOnLoad', () => ({
   useStartCalculationOnLoad: vi.fn(),
 }));
 
-vi.mock('@/hooks/useHydrateCalculationCache', () => ({
-  useHydrateCalculationCache: vi.fn(),
-}));
-
 vi.mock('@/hooks/useSaveSharedReport', () => ({
   useSaveSharedReport: vi.fn(() => ({
     saveSharedReport: vi.fn(),
@@ -123,69 +118,6 @@ describe('ReportOutputPage', () => {
 
     // Then
     expect(screen.getByRole('heading', { name: 'Test Report' })).toBeInTheDocument();
-  });
-
-  test('given report has finishedAt then header timestamp uses finishedAt over association timestamps', () => {
-    vi.mocked(useUserReportById).mockReturnValue({
-      userReport: {
-        ...MOCK_USER_REPORT,
-        createdAt: '2024-01-01T12:00:00.000Z',
-        updatedAt: '2024-04-30T12:00:00.000Z',
-      },
-      report: {
-        ...MOCK_REPORT_WITH_YEAR,
-        finishedAt: '2024-05-02T12:00:00.000Z',
-      },
-      simulations: [MOCK_SIMULATION_GEOGRAPHY],
-      userSimulations: [],
-      userPolicies: [],
-      policies: [],
-      households: [],
-      userHouseholds: [],
-      geographies: [],
-      isLoading: false,
-      error: null,
-    });
-
-    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
-
-    expect(screen.getByText(/Ran May 2, 2024 at/)).toBeInTheDocument();
-    expect(screen.queryByText(/Apr 30, 2024/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Jan 1, 2024/)).not.toBeInTheDocument();
-  });
-
-  test('given backend run timestamp is absent then header timestamp does not use association updatedAt', () => {
-    vi.mocked(useUserReportById).mockReturnValue({
-      userReport: {
-        ...MOCK_USER_REPORT,
-        createdAt: '2024-01-01T12:00:00.000Z',
-        updatedAt: '2024-04-30T12:00:00.000Z',
-      },
-      report: MOCK_REPORT_WITH_YEAR,
-      simulations: [MOCK_SIMULATION_GEOGRAPHY],
-      userSimulations: [],
-      userPolicies: [],
-      policies: [],
-      households: [],
-      userHouseholds: [],
-      geographies: [],
-      isLoading: false,
-      error: null,
-    });
-
-    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
-
-    expect(screen.getByText(/Ran Jan 1, 2024 at/)).toBeInTheDocument();
-    expect(screen.queryByText(/Apr 30, 2024/)).not.toBeInTheDocument();
-  });
-
-  test('given report has persisted output then calculation cache is hydrated from that output', () => {
-    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
-
-    expect(useHydrateCalculationCache).toHaveBeenCalledWith({
-      report: MOCK_REPORT_WITH_YEAR,
-      outputType: 'societyWide',
-    });
   });
 
   test('given reproduce subpage then breadcrumb returns to the current report', () => {

--- a/app/src/tests/unit/pages/ReportOutput.page.test.tsx
+++ b/app/src/tests/unit/pages/ReportOutput.page.test.tsx
@@ -134,6 +134,29 @@ describe('ReportOutputPage', () => {
     ).toBeInTheDocument();
   });
 
+  test('given report execution timestamp then it is displayed instead of association creation time', () => {
+    vi.mocked(useUserReportById).mockReturnValue({
+      userReport: MOCK_USER_REPORT,
+      report: {
+        ...MOCK_REPORT_WITH_YEAR,
+        finishedAt: '2026-02-03T15:02:00Z',
+      },
+      simulations: [MOCK_SIMULATION_GEOGRAPHY],
+      userSimulations: [],
+      userPolicies: [],
+      policies: [],
+      households: [],
+      userHouseholds: [],
+      geographies: [],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    expect(screen.getByText(/Ran Feb 3, 2026 at/)).toBeInTheDocument();
+  });
+
   test('given society-wide report with complete calculation then renders without error', () => {
     // Given
     render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);

--- a/app/src/tests/unit/pages/ReportOutput.page.test.tsx
+++ b/app/src/tests/unit/pages/ReportOutput.page.test.tsx
@@ -125,7 +125,36 @@ describe('ReportOutputPage', () => {
     expect(screen.getByRole('heading', { name: 'Test Report' })).toBeInTheDocument();
   });
 
-  test('given user report has updatedAt then header timestamp uses updatedAt over createdAt', () => {
+  test('given report has finishedAt then header timestamp uses finishedAt over association timestamps', () => {
+    vi.mocked(useUserReportById).mockReturnValue({
+      userReport: {
+        ...MOCK_USER_REPORT,
+        createdAt: '2024-01-01T12:00:00.000Z',
+        updatedAt: '2024-04-30T12:00:00.000Z',
+      },
+      report: {
+        ...MOCK_REPORT_WITH_YEAR,
+        finishedAt: '2024-05-02T12:00:00.000Z',
+      },
+      simulations: [MOCK_SIMULATION_GEOGRAPHY],
+      userSimulations: [],
+      userPolicies: [],
+      policies: [],
+      households: [],
+      userHouseholds: [],
+      geographies: [],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
+
+    expect(screen.getByText(/Ran May 2, 2024 at/)).toBeInTheDocument();
+    expect(screen.queryByText(/Apr 30, 2024/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Jan 1, 2024/)).not.toBeInTheDocument();
+  });
+
+  test('given backend run timestamp is absent then header timestamp does not use association updatedAt', () => {
     vi.mocked(useUserReportById).mockReturnValue({
       userReport: {
         ...MOCK_USER_REPORT,
@@ -146,8 +175,8 @@ describe('ReportOutputPage', () => {
 
     render(<ReportOutputPage reportId={MOCK_USER_REPORT_ID} subpage="overview" />);
 
-    expect(screen.getByText(/Ran Apr 30, 2024 at/)).toBeInTheDocument();
-    expect(screen.queryByText(/Jan 1, 2024/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Ran Jan 1, 2024 at/)).toBeInTheDocument();
+    expect(screen.queryByText(/Apr 30, 2024/)).not.toBeInTheDocument();
   });
 
   test('given report has persisted output then calculation cache is hydrated from that output', () => {

--- a/app/src/tests/unit/pages/report-output/SocietyWideOverviewDownloads.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideOverviewDownloads.test.tsx
@@ -91,7 +91,7 @@ describe('SocietyWideOverview chart downloads', () => {
           'Lose less than 5%',
           'Lose more than 5%',
         ],
-        ['All', '0.2', '0.1', '0.6', '0.05', '0.05'],
+        ['All', 0.2, 0.1, 0.6, 0.05, 0.05],
       ]),
     });
   });

--- a/app/src/tests/unit/pages/report-output/SocietyWideOverviewDownloads.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideOverviewDownloads.test.tsx
@@ -1,0 +1,98 @@
+import { render } from '@test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import SocietyWideOverview from '@/pages/report-output/SocietyWideOverview';
+import { createMockSocietyWideOutput } from '@/tests/fixtures/pages/reportOutputMocks';
+
+const { dashboardCardProps, mockUseCongressionalDistrictData } = vi.hoisted(() => ({
+  dashboardCardProps: [] as Record<string, any>[],
+  mockUseCongressionalDistrictData: vi.fn(),
+}));
+
+vi.mock('@/components/report/DashboardCard', () => ({
+  default: vi.fn((props: Record<string, any>) => {
+    dashboardCardProps.push(props);
+    return (
+      <section>
+        {props.shrunkenHeader}
+        {props.shrunkenBody}
+      </section>
+    );
+  }),
+}));
+
+vi.mock('@/contexts/CongressionalDistrictDataContext', () => ({
+  useCongressionalDistrictData: mockUseCongressionalDistrictData,
+}));
+
+vi.mock('@/hooks/useCurrentCountry', () => ({
+  useCurrentCountry: vi.fn(() => 'us'),
+}));
+
+vi.mock('@/components/visualization/USDistrictChoroplethMap', () => ({
+  USDistrictChoroplethMap: vi.fn(() => <div data-testid="district-map" />),
+}));
+
+vi.mock('@/utils/formatPowers', () => ({
+  formatBudgetaryImpact: vi.fn((value: number) => ({
+    display: Math.abs(value).toFixed(0),
+    label: '',
+  })),
+}));
+
+function createCongressionalDistrictContextMock() {
+  return {
+    reformPolicyId: '96491',
+    baselinePolicyId: '2',
+    year: '2026',
+    stateResponses: new Map(),
+    completedCount: 0,
+    loadingCount: 0,
+    totalDistrictsLoaded: 0,
+    totalStates: 51,
+    isComplete: false,
+    isLoading: false,
+    hasStarted: false,
+    errorCount: 0,
+    erroredStates: new Set(),
+    labelLookup: new Map([['AL-01', "Alabama's 1st congressional district"]]),
+    isStateLevelReport: false,
+    stateCode: null,
+    startFetch: vi.fn(),
+    validateAllLoaded: vi.fn(),
+    getCompletedStates: vi.fn(),
+    getLoadingStates: vi.fn(),
+  };
+}
+
+describe('SocietyWideOverview chart downloads', () => {
+  beforeEach(() => {
+    dashboardCardProps.length = 0;
+    mockUseCongressionalDistrictData.mockReturnValue(createCongressionalDistrictContextMock());
+    vi.clearAllMocks();
+  });
+
+  test('given winners and losers overview card then expanded toolbar has CSV export data', () => {
+    const output = createMockSocietyWideOutput();
+
+    render(<SocietyWideOverview output={output} />);
+
+    const winnersCardProps = dashboardCardProps.find(
+      (props) => props.downloadFilename === 'winners-losers-income-decile.svg'
+    );
+
+    expect(winnersCardProps).toMatchObject({
+      csvFilename: 'winners-losers-income-decile.csv',
+      csvData: expect.arrayContaining([
+        [
+          'Income decile',
+          'Gain more than 5%',
+          'Gain less than 5%',
+          'No change',
+          'Lose less than 5%',
+          'Lose more than 5%',
+        ],
+        ['All', '0.2', '0.1', '0.6', '0.05', '0.05'],
+      ]),
+    });
+  });
+});

--- a/app/src/tests/unit/pages/report-output/SocietyWideOverviewDownloads.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideOverviewDownloads.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@test-utils';
+import { fireEvent, render, screen } from '@test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import SocietyWideOverview from '@/pages/report-output/SocietyWideOverview';
 import { createMockSocietyWideOutput } from '@/tests/fixtures/pages/reportOutputMocks';
@@ -15,6 +15,7 @@ vi.mock('@/components/report/DashboardCard', () => ({
       <section>
         {props.shrunkenHeader}
         {props.shrunkenBody}
+        {props.expandedControls}
       </section>
     );
   }),
@@ -23,6 +24,36 @@ vi.mock('@/components/report/DashboardCard', () => ({
 vi.mock('@/contexts/CongressionalDistrictDataContext', () => ({
   useCongressionalDistrictData: mockUseCongressionalDistrictData,
 }));
+
+vi.mock('@/components/ui', async () => {
+  const actual = await vi.importActual<typeof import('@/components/ui')>('@/components/ui');
+  return {
+    ...actual,
+    SegmentedControl: vi.fn(
+      ({
+        options,
+        onValueChange,
+      }: {
+        options: Array<{ label: string; value: string; disabled?: boolean }>;
+        onValueChange: (value: string) => void;
+      }) => (
+        <div>
+          {options.map((option) => (
+            <button
+              key={option.value}
+              role="tab"
+              type="button"
+              disabled={option.disabled}
+              onClick={() => onValueChange(option.value)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )
+    ),
+  };
+});
 
 vi.mock('@/hooks/useCurrentCountry', () => ({
   useCurrentCountry: vi.fn(() => 'us'),
@@ -71,16 +102,60 @@ describe('SocietyWideOverview chart downloads', () => {
     vi.clearAllMocks();
   });
 
-  test('given winners and losers overview card then expanded toolbar has CSV export data', () => {
-    const output = createMockSocietyWideOutput();
+  function latestCardProps(filename: string) {
+    for (let index = dashboardCardProps.length - 1; index >= 0; index -= 1) {
+      if (dashboardCardProps[index].downloadFilename === filename) {
+        return dashboardCardProps[index];
+      }
+    }
+    return undefined;
+  }
 
+  const output = createMockSocietyWideOutput({
+    poverty_by_gender: {
+      poverty: {
+        male: { baseline: 0.1, reform: 0.09 },
+        female: { baseline: 0.2, reform: 0.18 },
+      },
+      deep_poverty: {
+        male: { baseline: 0.03, reform: 0.027 },
+        female: { baseline: 0.04, reform: 0.036 },
+      },
+    },
+    poverty_by_race: {
+      poverty: {
+        white: { baseline: 0.1, reform: 0.09 },
+        black: { baseline: 0.2, reform: 0.18 },
+        hispanic: { baseline: 0.3, reform: 0.24 },
+        other: { baseline: 0.4, reform: 0.36 },
+      },
+    },
+  });
+
+  test('given overview cards then expanded toolbars include default CSV export data', () => {
     render(<SocietyWideOverview output={output} />);
 
-    const winnersCardProps = dashboardCardProps.find(
-      (props) => props.downloadFilename === 'winners-losers-income-decile.svg'
-    );
+    expect(latestCardProps('budgetary-impact.svg')).toMatchObject({
+      csvFilename: 'budgetary-impact.csv',
+      csvData: expect.arrayContaining([
+        ['Category', 'Budgetary impact (billions)'],
+        ['Net impact', 0.001],
+      ]),
+    });
+    expect(latestCardProps('distributional-impact-income-average.svg')).toMatchObject({
+      csvFilename: 'distributional-impact-income-average.csv',
+      csvData: expect.arrayContaining([['Income decile', 'Average change']]),
+    });
+    expect(latestCardProps('poverty-impact-by-age.svg')).toMatchObject({
+      csvFilename: 'poverty-impact-by-age.csv',
+      csvData: expect.arrayContaining([['Age group', 'Baseline', 'Reform', 'Change']]),
+    });
+    expect(latestCardProps('inequality-impact.svg')).toMatchObject({
+      csvFilename: 'inequality-impact.csv',
+      csvData: expect.arrayContaining([['Metric', 'Baseline', 'Reform', 'Change']]),
+    });
 
-    expect(winnersCardProps).toMatchObject({
+    expect(latestCardProps('winners-losers-income-decile.svg')).toMatchObject({
       csvFilename: 'winners-losers-income-decile.csv',
       csvData: expect.arrayContaining([
         [
@@ -93,6 +168,40 @@ describe('SocietyWideOverview chart downloads', () => {
         ],
         ['All', 0.2, 0.1, 0.6, 0.05, 0.05],
       ]),
+    });
+  });
+
+  test('given decile mode changes then overview card CSV follows selected mode', () => {
+    render(<SocietyWideOverview output={output} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Relative' }));
+
+    expect(latestCardProps('distributional-impact-income-relative.svg')).toMatchObject({
+      csvFilename: 'distributional-impact-income-relative.csv',
+      csvData: expect.arrayContaining([['Income decile', 'Relative change']]),
+    });
+  });
+
+  test('given poverty controls change then overview card CSV follows selected breakdown', () => {
+    render(<SocietyWideOverview output={output} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'By gender' }));
+    expect(latestCardProps('poverty-impact-by-gender.svg')).toMatchObject({
+      csvFilename: 'poverty-impact-by-gender.csv',
+      csvData: expect.arrayContaining([['Sex', 'Baseline', 'Reform', 'Change']]),
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Deep poverty' }));
+    expect(latestCardProps('deep-poverty-impact-by-gender.svg')).toMatchObject({
+      csvFilename: 'deep-poverty-impact-by-gender.csv',
+      csvData: expect.arrayContaining([['Sex', 'Baseline', 'Reform', 'Change']]),
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Regular poverty' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'By race' }));
+    expect(latestCardProps('poverty-impact-by-race.svg')).toMatchObject({
+      csvFilename: 'poverty-impact-by-race.csv',
+      csvData: expect.arrayContaining([['Race', 'Baseline', 'Reform', 'Change']]),
     });
   });
 });

--- a/app/src/tests/unit/pages/report-output/chartCsvExports.test.ts
+++ b/app/src/tests/unit/pages/report-output/chartCsvExports.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from 'vitest';
+import type { SocietyWideReportOutput } from '@/api/societyWideCalculation';
+import {
+  getBudgetCsvRows,
+  getDetailedBudgetCsvRows,
+} from '@/pages/report-output/budgetary-impact/budgetChartUtils';
+import {
+  getDecileAverageCsvRows,
+  getDecileRelativeCsvRows,
+  getWinnersLosersCsvRows,
+} from '@/pages/report-output/distributional-impact/distributionalChartUtils';
+import { getInequalityCsvRows } from '@/pages/report-output/inequality-impact/inequalityChartUtils';
+import {
+  getPovertyByAgeCsvRows,
+  getPovertyByGenderCsvRows,
+  getPovertyByRaceCsvRows,
+} from '@/pages/report-output/poverty-impact/povertyChartUtils';
+import { createMockSocietyWideOutput } from '@/tests/fixtures/pages/reportOutputMocks';
+
+describe('report output CSV exports', () => {
+  test('given decile outputs then distributional CSVs include normalized headers', () => {
+    const output = createMockSocietyWideOutput({
+      decile: {
+        average: { '2': 20, '1': 10 },
+        relative: { '2': 0.02, '1': 0.01 },
+      },
+      wealth_decile: {
+        average: { '1': 100 },
+        relative: { '1': 0.1 },
+      },
+    }) as SocietyWideReportOutput;
+
+    expect(getDecileAverageCsvRows(output)).toEqual([
+      ['Income decile', 'Average change'],
+      ['1', 10],
+      ['2', 20],
+    ]);
+    expect(getDecileRelativeCsvRows(output)).toEqual([
+      ['Income decile', 'Relative change'],
+      ['1', 0.01],
+      ['2', 0.02],
+    ]);
+    expect(getDecileAverageCsvRows(output, 'wealth')).toEqual([
+      ['Wealth decile', 'Average change'],
+      ['1', 100],
+    ]);
+  });
+
+  test('given intra-decile output then winners and losers CSV puts All after deciles', () => {
+    const output = createMockSocietyWideOutput({
+      intra_decile: {
+        deciles: {
+          'Gain more than 5%': Array(10).fill(0.1),
+          'Gain less than 5%': Array(10).fill(0.2),
+          'No change': Array(10).fill(0.3),
+          'Lose less than 5%': Array(10).fill(0.2),
+          'Lose more than 5%': Array(10).fill(0.2),
+        },
+        all: {
+          'Gain more than 5%': 0.1,
+          'Gain less than 5%': 0.2,
+          'No change': 0.3,
+          'Lose less than 5%': 0.2,
+          'Lose more than 5%': 0.2,
+        },
+      },
+    }) as SocietyWideReportOutput;
+
+    const rows = getWinnersLosersCsvRows(output);
+
+    expect(rows[0]).toEqual([
+      'Income decile',
+      'Gain more than 5%',
+      'Gain less than 5%',
+      'No change',
+      'Lose less than 5%',
+      'Lose more than 5%',
+    ]);
+    expect(rows[1]).toEqual(['1', 0.1, 0.2, 0.3, 0.2, 0.2]);
+    expect(rows[11]).toEqual(['All', 0.1, 0.2, 0.3, 0.2, 0.2]);
+  });
+
+  test('given budget outputs then budget CSVs include headers and raw numeric values', () => {
+    const output = createMockSocietyWideOutput({
+      budget: {
+        budgetary_impact: 4e9,
+        baseline_net_income: 20e9,
+        benefit_spending_impact: -3e9,
+        households: 100,
+        state_tax_revenue_impact: 1e9,
+        tax_revenue_impact: 2e9,
+      },
+      detailed_budget: {
+        child_benefit: { baseline: 10, reform: 12, difference: 2 },
+      },
+    }) as SocietyWideReportOutput;
+    const metadata = {
+      variables: {
+        child_benefit: { label: 'Child benefit' },
+      },
+    } as any;
+
+    expect(getBudgetCsvRows(output, 'us')).toEqual([
+      ['Category', 'Budgetary impact (billions)'],
+      ['Federal tax revenues', 1],
+      ['State and local income tax revenues', 1],
+      ['Benefit spending', 3],
+      ['Net impact', 4],
+    ]);
+    expect(getDetailedBudgetCsvRows(output, metadata)).toEqual([
+      ['Program', 'Baseline', 'Reform', 'Difference'],
+      ['Child benefit', 10, 12, 2],
+    ]);
+  });
+
+  test('given poverty outputs then poverty CSVs include demographic breakdown values', () => {
+    const output = createMockSocietyWideOutput({
+      poverty_by_gender: {
+        poverty: {
+          male: { baseline: 0.1, reform: 0.09 },
+          female: { baseline: 0.2, reform: 0.18 },
+        },
+        deep_poverty: {
+          male: { baseline: 0.03, reform: 0.027 },
+          female: { baseline: 0.04, reform: 0.036 },
+        },
+      },
+      poverty_by_race: {
+        poverty: {
+          white: { baseline: 0.1, reform: 0.09 },
+          black: { baseline: 0.2, reform: 0.18 },
+          hispanic: { baseline: 0.3, reform: 0.24 },
+          other: { baseline: 0.4, reform: 0.36 },
+        },
+      },
+    }) as SocietyWideReportOutput;
+
+    expect(getPovertyByAgeCsvRows(output)[0]).toEqual([
+      'Age group',
+      'Baseline',
+      'Reform',
+      'Change',
+    ]);
+    expect(getPovertyByAgeCsvRows(output)[1]).toEqual(['Children', 0.15, 0.13, 0.13 / 0.15 - 1]);
+    expect(getPovertyByGenderCsvRows(output)).toContainEqual(['Male', 0.1, 0.09, 0.09 / 0.1 - 1]);
+    expect(getPovertyByRaceCsvRows(output)).toContainEqual([
+      'White (non-Hispanic)',
+      0.1,
+      0.09,
+      0.09 / 0.1 - 1,
+    ]);
+  });
+
+  test('given inequality output then inequality CSV includes each metric', () => {
+    const output = createMockSocietyWideOutput() as SocietyWideReportOutput;
+
+    expect(getInequalityCsvRows(output)).toEqual([
+      ['Metric', 'Baseline', 'Reform', 'Change'],
+      ['Gini index', 0.45, 0.44, 0.44 / 0.45 - 1],
+      ['Top 10% share', 0.35, 0.34, 0.34 / 0.35 - 1],
+      ['Top 1% share', 0.15, 0.14, 0.14 / 0.15 - 1],
+    ]);
+  });
+});

--- a/app/src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx
+++ b/app/src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx
@@ -1,7 +1,9 @@
 import { render } from '@test-utils';
 import { Tooltip, YAxis } from 'recharts';
 import { describe, expect, test, vi } from 'vitest';
-import WinnersLosersIncomeDecileSubPage from '@/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage';
+import WinnersLosersIncomeDecileSubPage, {
+  getWinnersLosersCsvRows,
+} from '@/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage';
 import { MOCK_WINNERS_LOSERS_OUTPUT } from '@/tests/fixtures/pages/report-output/distributional-impact/WinnersLosersDecileMocks';
 
 // Mock Recharts — capture props via vi.fn()
@@ -59,5 +61,35 @@ describe('WinnersLosersIncomeDecileSubPage', () => {
       expect(wrapperStyle).toBeDefined();
       expect(wrapperStyle?.zIndex).toBe(1000);
     });
+  });
+
+  test('given chart then Tooltip uses a fixed in-chart position so edge deciles stay visible', () => {
+    // When
+    render(<WinnersLosersIncomeDecileSubPage output={MOCK_WINNERS_LOSERS_OUTPUT} />);
+
+    // Then
+    const tooltipCalls = vi.mocked(Tooltip).mock.calls;
+    tooltipCalls.forEach((call) => {
+      const props = call[0] as Record<string, unknown>;
+      expect(props.position).toEqual({ x: 72, y: 0 });
+    });
+  });
+
+  test('given output then CSV rows include All and each income decile', () => {
+    // When
+    const rows = getWinnersLosersCsvRows(MOCK_WINNERS_LOSERS_OUTPUT);
+
+    // Then
+    expect(rows[0]).toEqual([
+      'Income decile',
+      'Gain more than 5%',
+      'Gain less than 5%',
+      'No change',
+      'Lose less than 5%',
+      'Lose more than 5%',
+    ]);
+    expect(rows).toHaveLength(12);
+    expect(rows[1][0]).toBe('All');
+    expect(rows[11][0]).toBe('10');
   });
 });

--- a/app/src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx
+++ b/app/src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx
@@ -76,7 +76,7 @@ describe('WinnersLosersIncomeDecileSubPage', () => {
     });
   });
 
-  test('given output then CSV rows include All and each income decile', () => {
+  test('given output then CSV rows include each income decile and All', () => {
     // When
     const rows = getWinnersLosersCsvRows(MOCK_WINNERS_LOSERS_OUTPUT);
 
@@ -90,8 +90,9 @@ describe('WinnersLosersIncomeDecileSubPage', () => {
       'Lose more than 5%',
     ]);
     expect(rows).toHaveLength(12);
-    expect(rows[1][0]).toBe('All');
-    expect(rows[11][0]).toBe('10');
+    expect(rows[1][0]).toBe('1');
+    expect(rows[10][0]).toBe('10');
+    expect(rows[11][0]).toBe('All');
   });
 });
 

--- a/app/src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx
+++ b/app/src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, test, vi } from 'vitest';
 import WinnersLosersIncomeDecileSubPage, {
   getWinnersLosersCsvRows,
 } from '@/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage';
+import WinnersLosersWealthDecileSubPage from '@/pages/report-output/distributional-impact/WinnersLosersWealthDecileSubPage';
 import { MOCK_WINNERS_LOSERS_OUTPUT } from '@/tests/fixtures/pages/report-output/distributional-impact/WinnersLosersDecileMocks';
 
 // Mock Recharts — capture props via vi.fn()
@@ -91,5 +92,21 @@ describe('WinnersLosersIncomeDecileSubPage', () => {
     expect(rows).toHaveLength(12);
     expect(rows[1][0]).toBe('All');
     expect(rows[11][0]).toBe('10');
+  });
+});
+
+describe('WinnersLosersWealthDecileSubPage', () => {
+  test('given chart then Tooltip uses a fixed in-chart position so edge deciles stay visible', () => {
+    const output = {
+      intra_wealth_decile: (MOCK_WINNERS_LOSERS_OUTPUT as any).intra_decile,
+    } as any;
+
+    render(<WinnersLosersWealthDecileSubPage output={output} />);
+
+    const tooltipCalls = vi.mocked(Tooltip).mock.calls;
+    tooltipCalls.forEach((call) => {
+      const props = call[0] as Record<string, unknown>;
+      expect(props.position).toEqual({ x: 72, y: 0 });
+    });
   });
 });

--- a/app/src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx
+++ b/app/src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx
@@ -97,6 +97,23 @@ describe('WinnersLosersIncomeDecileSubPage', () => {
 });
 
 describe('WinnersLosersWealthDecileSubPage', () => {
+  test('given chart then Tooltip has z-index to prevent bars covering it', () => {
+    const output = {
+      intra_wealth_decile: (MOCK_WINNERS_LOSERS_OUTPUT as any).intra_decile,
+    } as any;
+
+    render(<WinnersLosersWealthDecileSubPage output={output} />);
+
+    const tooltipCalls = vi.mocked(Tooltip).mock.calls;
+    expect(tooltipCalls.length).toBeGreaterThan(0);
+    tooltipCalls.forEach((call) => {
+      const props = call[0] as Record<string, unknown>;
+      const wrapperStyle = props.wrapperStyle as Record<string, unknown> | undefined;
+      expect(wrapperStyle).toBeDefined();
+      expect(wrapperStyle?.zIndex).toBe(1000);
+    });
+  });
+
   test('given chart then Tooltip uses a fixed in-chart position so edge deciles stay visible', () => {
     const output = {
       intra_wealth_decile: (MOCK_WINNERS_LOSERS_OUTPUT as any).intra_decile,

--- a/app/src/tests/unit/pages/report-output/fullChartCsvWiring.test.tsx
+++ b/app/src/tests/unit/pages/report-output/fullChartCsvWiring.test.tsx
@@ -1,0 +1,232 @@
+import { render } from '@test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import BudgetaryImpactByProgramSubPage from '@/pages/report-output/budgetary-impact/BudgetaryImpactByProgramSubPage';
+import BudgetaryImpactSubPage from '@/pages/report-output/budgetary-impact/BudgetaryImpactSubPage';
+import DistributionalImpactIncomeAverageSubPage from '@/pages/report-output/distributional-impact/DistributionalImpactIncomeAverageSubPage';
+import DistributionalImpactIncomeRelativeSubPage from '@/pages/report-output/distributional-impact/DistributionalImpactIncomeRelativeSubPage';
+import DistributionalImpactWealthAverageSubPage from '@/pages/report-output/distributional-impact/DistributionalImpactWealthAverageSubPage';
+import DistributionalImpactWealthRelativeSubPage from '@/pages/report-output/distributional-impact/DistributionalImpactWealthRelativeSubPage';
+import WinnersLosersIncomeDecileSubPage from '@/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage';
+import WinnersLosersWealthDecileSubPage from '@/pages/report-output/distributional-impact/WinnersLosersWealthDecileSubPage';
+import InequalityImpactSubPage from '@/pages/report-output/inequality-impact/InequalityImpactSubPage';
+import DeepPovertyImpactByAgeSubPage from '@/pages/report-output/poverty-impact/DeepPovertyImpactByAgeSubPage';
+import DeepPovertyImpactByGenderSubPage from '@/pages/report-output/poverty-impact/DeepPovertyImpactByGenderSubPage';
+import PovertyImpactByAgeSubPage from '@/pages/report-output/poverty-impact/PovertyImpactByAgeSubPage';
+import PovertyImpactByGenderSubPage from '@/pages/report-output/poverty-impact/PovertyImpactByGenderSubPage';
+import PovertyImpactByRaceSubPage from '@/pages/report-output/poverty-impact/PovertyImpactByRaceSubPage';
+import { createMockSocietyWideOutput } from '@/tests/fixtures/pages/reportOutputMocks';
+
+const { chartContainerProps, mockMetadata } = vi.hoisted(() => ({
+  chartContainerProps: [] as Record<string, any>[],
+  mockMetadata: {
+    variables: {
+      child_benefit: { label: 'Child benefit' },
+    },
+    economyOptions: { region: [{ name: 'us', label: 'the US' }] },
+  },
+}));
+
+vi.mock('@/components/ChartContainer', () => ({
+  ChartContainer: vi.fn((props: Record<string, any>) => {
+    chartContainerProps.push(props);
+    return <section>{props.children}</section>;
+  }),
+}));
+
+vi.mock('react-redux', async () => {
+  const actual = await vi.importActual<typeof import('react-redux')>('react-redux');
+  return {
+    ...actual,
+    useSelector: vi.fn((selector: any) => selector({ metadata: mockMetadata })),
+  };
+});
+
+vi.mock('@/hooks/useCurrentCountry', () => ({
+  useCurrentCountry: vi.fn(() => 'us'),
+}));
+
+vi.mock('@/hooks/useMediaQuery', () => ({
+  useMediaQuery: vi.fn(() => false),
+}));
+
+vi.mock('@/hooks/useViewportSize', () => ({
+  useViewportSize: vi.fn(() => ({ width: 1200, height: 900 })),
+}));
+
+vi.mock('recharts', () => ({
+  Bar: vi.fn(() => null),
+  BarChart: vi.fn(({ children }) => children),
+  CartesianGrid: vi.fn(() => null),
+  Cell: vi.fn(() => null),
+  Label: vi.fn(() => null),
+  Legend: vi.fn(() => null),
+  ReferenceLine: vi.fn(() => null),
+  ResponsiveContainer: vi.fn(({ children }) => children),
+  Tooltip: vi.fn(() => null),
+  XAxis: vi.fn(() => null),
+  YAxis: vi.fn(() => null),
+}));
+
+const winnersLosers = {
+  deciles: {
+    'Gain more than 5%': Array(10).fill(0.1),
+    'Gain less than 5%': Array(10).fill(0.2),
+    'No change': Array(10).fill(0.3),
+    'Lose less than 5%': Array(10).fill(0.2),
+    'Lose more than 5%': Array(10).fill(0.2),
+  },
+  all: {
+    'Gain more than 5%': 0.1,
+    'Gain less than 5%': 0.2,
+    'No change': 0.3,
+    'Lose less than 5%': 0.2,
+    'Lose more than 5%': 0.2,
+  },
+};
+
+const output = createMockSocietyWideOutput({
+  detailed_budget: {
+    child_benefit: { baseline: 10, reform: 12, difference: 2 },
+  },
+  wealth_decile: {
+    average: { '1': 100 },
+    relative: { '1': 0.1 },
+  },
+  intra_decile: winnersLosers,
+  intra_wealth_decile: winnersLosers,
+  poverty_by_gender: {
+    poverty: {
+      male: { baseline: 0.1, reform: 0.09 },
+      female: { baseline: 0.2, reform: 0.18 },
+    },
+    deep_poverty: {
+      male: { baseline: 0.03, reform: 0.027 },
+      female: { baseline: 0.04, reform: 0.036 },
+    },
+  },
+  poverty_by_race: {
+    poverty: {
+      white: { baseline: 0.1, reform: 0.09 },
+      black: { baseline: 0.2, reform: 0.18 },
+      hispanic: { baseline: 0.3, reform: 0.24 },
+      other: { baseline: 0.4, reform: 0.36 },
+    },
+  },
+}) as any;
+
+describe('full report output chart CSV wiring', () => {
+  beforeEach(() => {
+    chartContainerProps.length = 0;
+  });
+
+  test.each([
+    {
+      name: 'budgetary impact',
+      Component: BudgetaryImpactSubPage,
+      filename: 'budgetary-impact.csv',
+      header: ['Category', 'Budgetary impact (billions)'],
+    },
+    {
+      name: 'budgetary impact by program',
+      Component: BudgetaryImpactByProgramSubPage,
+      filename: 'budgetary-impact-by-program.csv',
+      header: ['Program', 'Baseline', 'Reform', 'Difference'],
+    },
+    {
+      name: 'income average distributional impact',
+      Component: DistributionalImpactIncomeAverageSubPage,
+      filename: 'distributional-impact-income-average.csv',
+      header: ['Income decile', 'Average change'],
+    },
+    {
+      name: 'income relative distributional impact',
+      Component: DistributionalImpactIncomeRelativeSubPage,
+      filename: 'distributional-impact-income-relative.csv',
+      header: ['Income decile', 'Relative change'],
+    },
+    {
+      name: 'wealth average distributional impact',
+      Component: DistributionalImpactWealthAverageSubPage,
+      filename: 'distributional-impact-wealth-average.csv',
+      header: ['Wealth decile', 'Average change'],
+    },
+    {
+      name: 'wealth relative distributional impact',
+      Component: DistributionalImpactWealthRelativeSubPage,
+      filename: 'distributional-impact-wealth-relative.csv',
+      header: ['Wealth decile', 'Relative change'],
+    },
+    {
+      name: 'income winners and losers',
+      Component: WinnersLosersIncomeDecileSubPage,
+      filename: 'winners-losers-income-decile.csv',
+      header: [
+        'Income decile',
+        'Gain more than 5%',
+        'Gain less than 5%',
+        'No change',
+        'Lose less than 5%',
+        'Lose more than 5%',
+      ],
+    },
+    {
+      name: 'wealth winners and losers',
+      Component: WinnersLosersWealthDecileSubPage,
+      filename: 'winners-losers-wealth-decile.csv',
+      header: [
+        'Wealth decile',
+        'Gain more than 5%',
+        'Gain less than 5%',
+        'No change',
+        'Lose less than 5%',
+        'Lose more than 5%',
+      ],
+    },
+    {
+      name: 'poverty by age',
+      Component: PovertyImpactByAgeSubPage,
+      filename: 'poverty-impact-by-age.csv',
+      header: ['Age group', 'Baseline', 'Reform', 'Change'],
+    },
+    {
+      name: 'poverty by gender',
+      Component: PovertyImpactByGenderSubPage,
+      filename: 'poverty-impact-by-gender.csv',
+      header: ['Sex', 'Baseline', 'Reform', 'Change'],
+    },
+    {
+      name: 'poverty by race',
+      Component: PovertyImpactByRaceSubPage,
+      filename: 'poverty-impact-by-race.csv',
+      header: ['Race', 'Baseline', 'Reform', 'Change'],
+    },
+    {
+      name: 'deep poverty by age',
+      Component: DeepPovertyImpactByAgeSubPage,
+      filename: 'deep-poverty-impact-by-age.csv',
+      header: ['Age group', 'Baseline', 'Reform', 'Change'],
+    },
+    {
+      name: 'deep poverty by gender',
+      Component: DeepPovertyImpactByGenderSubPage,
+      filename: 'deep-poverty-impact-by-gender.csv',
+      header: ['Sex', 'Baseline', 'Reform', 'Change'],
+    },
+    {
+      name: 'inequality impact',
+      Component: InequalityImpactSubPage,
+      filename: 'inequality-impact.csv',
+      header: ['Metric', 'Baseline', 'Reform', 'Change'],
+    },
+  ])(
+    'given $name then ChartContainer receives CSV filename and rows',
+    ({ Component, filename, header }) => {
+      render(<Component output={output} />);
+
+      expect(chartContainerProps[chartContainerProps.length - 1]).toMatchObject({
+        csvFilename: filename,
+        csvData: expect.arrayContaining([header]),
+      });
+    }
+  );
+});

--- a/app/src/tests/unit/utils/chartUtils.test.ts
+++ b/app/src/tests/unit/utils/chartUtils.test.ts
@@ -15,7 +15,12 @@ import {
   SAMPLE_POLICY_LABEL_EMPTY_STRING,
   SAMPLE_POLICY_LABEL_SHORT,
 } from '@/tests/fixtures/utils/chartUtilsMocks';
-import { getChartLogoImage, getNiceTicks, getReformPolicyLabel } from '@/utils/chartUtils';
+import {
+  buildCsvContent,
+  getChartLogoImage,
+  getNiceTicks,
+  getReformPolicyLabel,
+} from '@/utils/chartUtils';
 
 describe('chartUtils', () => {
   describe('getReformPolicyLabel', () => {
@@ -128,6 +133,18 @@ describe('chartUtils', () => {
         // Then
         expect(result).toBe(EXPECTED_LABEL_DEFAULT);
       });
+    });
+  });
+
+  describe('buildCsvContent', () => {
+    it('given numeric, empty, and quoted cells then writes escaped CSV content', () => {
+      expect(
+        buildCsvContent([
+          ['Label', 'Value'],
+          ['Federal "tax" revenues', 1.25],
+          ['Empty', null],
+        ])
+      ).toBe('"Label","Value"\r\n"Federal ""tax"" revenues","1.25"\r\n"Empty",""');
     });
   });
 

--- a/app/src/types/ingredients/Report.ts
+++ b/app/src/types/ingredients/Report.ts
@@ -20,6 +20,9 @@ export interface Report {
   apiVersion: string | null;
   simulationIds: string[];
   status: 'pending' | 'complete' | 'error';
+  requestedAt?: string | null;
+  startedAt?: string | null;
+  finishedAt?: string | null;
   outputType?: 'household' | 'economy'; // Discriminator for output type
   output?: EconomyOutput | HouseholdReportOutput | null; // Economy or household output
 }

--- a/app/src/types/ingredients/Report.ts
+++ b/app/src/types/ingredients/Report.ts
@@ -20,6 +20,9 @@ export interface Report {
   apiVersion: string | null;
   simulationIds: string[];
   status: 'pending' | 'complete' | 'error';
+  requestedAt?: string | null; // Base report execution timestamp, not user-specific last run
+  startedAt?: string | null; // Base report execution timestamp, not user-specific last run
+  finishedAt?: string | null; // Base report execution timestamp, not user-specific last run
   outputType?: 'household' | 'economy'; // Discriminator for output type
   output?: EconomyOutput | HouseholdReportOutput | null; // Economy or household output
 }

--- a/app/src/types/ingredients/Report.ts
+++ b/app/src/types/ingredients/Report.ts
@@ -20,9 +20,6 @@ export interface Report {
   apiVersion: string | null;
   simulationIds: string[];
   status: 'pending' | 'complete' | 'error';
-  requestedAt?: string | null;
-  startedAt?: string | null;
-  finishedAt?: string | null;
   outputType?: 'household' | 'economy'; // Discriminator for output type
   output?: EconomyOutput | HouseholdReportOutput | null; // Economy or household output
 }

--- a/app/src/types/metadata/reportMetadata.ts
+++ b/app/src/types/metadata/reportMetadata.ts
@@ -8,5 +8,8 @@ export interface ReportMetadata {
   year: string; // Report calculation year (e.g., '2025')
   api_version: string;
   status: 'pending' | 'complete' | 'error';
+  requested_at?: string | null;
+  started_at?: string | null;
+  finished_at?: string | null;
   output: string | null; // JSON-stringified object or null
 }

--- a/app/src/types/metadata/reportMetadata.ts
+++ b/app/src/types/metadata/reportMetadata.ts
@@ -7,6 +7,9 @@ export interface ReportMetadata {
   simulation_2_id: string | null;
   year: string; // Report calculation year (e.g., '2025')
   api_version: string;
-  status: 'pending' | 'complete' | 'error';
+  status: 'pending' | 'running' | 'complete' | 'error';
   output: string | null; // JSON-stringified object or null
+  requested_at?: string | null; // Base report execution timestamp from API v1 report run
+  started_at?: string | null; // Base report execution timestamp from API v1 report run
+  finished_at?: string | null; // Base report execution timestamp from API v1 report run
 }

--- a/app/src/types/metadata/reportMetadata.ts
+++ b/app/src/types/metadata/reportMetadata.ts
@@ -8,8 +8,5 @@ export interface ReportMetadata {
   year: string; // Report calculation year (e.g., '2025')
   api_version: string;
   status: 'pending' | 'complete' | 'error';
-  requested_at?: string | null;
-  started_at?: string | null;
-  finished_at?: string | null;
   output: string | null; // JSON-stringified object or null
 }

--- a/app/src/utils/analytics.ts
+++ b/app/src/utils/analytics.ts
@@ -60,6 +60,11 @@ export function trackChartCsvDownloaded() {
   trackEvent('chart_csv_downloaded');
 }
 
+/** Fires when user downloads an SVG image of a chart */
+export function trackChartSvgDownload() {
+  trackEvent('chart_svg_downloaded');
+}
+
 /** Fires when user copies Python reproduction code */
 export function trackPythonCodeCopied() {
   trackEvent('python_code_copied');

--- a/app/src/utils/chartUtils.ts
+++ b/app/src/utils/chartUtils.ts
@@ -5,6 +5,15 @@
 import { typography } from '@/designTokens';
 import { colors } from '@/designTokens/colors';
 
+export type CsvCell = string | number | null | undefined;
+export type CsvData = CsvCell[][];
+
+export function buildCsvContent(data: CsvData): string {
+  return data
+    .map((row) => row.map((cell) => `"${String(cell ?? '').replace(/"/g, '""')}"`).join(','))
+    .join('\r\n');
+}
+
 /**
  * Gets the label for the reform policy line in parameter charts
  *
@@ -37,8 +46,8 @@ export function getReformPolicyLabel(
  * @param data - 2D array of data to export
  * @param filename - Name of the file to download
  */
-export function downloadCsv(data: string[][], filename: string): void {
-  const csvContent = data.map((row) => row.map((cell) => `"${cell}"`).join(',')).join('\r\n');
+export function downloadCsv(data: CsvData, filename: string): void {
+  const csvContent = buildCsvContent(data);
   const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const tempLink = document.createElement('a');


### PR DESCRIPTION
## Summary
- Hydrate calculation cache from persisted report output so completed reports do not unnecessarily rerun on direct load.
- Prefer backend finished_at, then saved-report updatedAt, then createdAt for the report header timestamp.
- Add CSV export support to ChartContainer and wire winners/losers decile data to CSV.
- Pin winners/losers tooltips inside the chart so later deciles remain visible.

## Root cause
The report output page displayed the saved UserReport creation time as the run time and did not hydrate completed persisted outputs into the calculation cache. ChartContainer only exposed SVG downloads, and the winners/losers tooltip could follow the cursor off the visible chart area.

## Validation
- npx vitest run src/tests/unit/pages/ReportOutput.page.test.tsx src/tests/unit/components/ChartContainer.test.tsx src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx src/tests/unit/adapters/ReportAdapter.test.ts
- npx tsc --noEmit
- npx eslint src/pages/ReportOutput.page.tsx src/components/ChartContainer.tsx src/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.tsx src/adapters/ReportAdapter.ts src/types/ingredients/Report.ts src/types/metadata/reportMetadata.ts src/tests/unit/pages/ReportOutput.page.test.tsx src/tests/unit/components/ChartContainer.test.tsx src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx src/tests/unit/adapters/ReportAdapter.test.ts
- npx prettier --check src/pages/ReportOutput.page.tsx src/components/ChartContainer.tsx src/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.tsx src/adapters/ReportAdapter.ts src/types/ingredients/Report.ts src/types/metadata/reportMetadata.ts src/tests/unit/pages/ReportOutput.page.test.tsx src/tests/unit/components/ChartContainer.test.tsx src/tests/unit/pages/report-output/distributional-impact/WinnersLosersIncomeDecileSubPage.test.tsx src/tests/unit/adapters/ReportAdapter.test.ts

## Deployment note
- Needs PolicyEngine/policyengine-api#3546 to fully deploy before this app v2 PR is pushed.