### PR TITLE
Route OBBBA household explorer as multizone

### DIFF
--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -451,7 +451,7 @@
     "slug": "obbba-household-explorer",
     "title": "OBBBA household impact explorer",
     "description": "Interactive scatter plot to explore household-level impacts of the One Big Beautiful Bill Act",
-    "source": "https://policyengine.github.io/obbba-household-by-household",
+    "source": "https://obbba-household-by-household.vercel.app/us/obbba-household-explorer",
     "tags": ["us", "featured", "policy", "reconciliation"],
     "countryId": "us"
   },
@@ -495,7 +495,7 @@
     "slug": "obbba-household-by-household",
     "title": "The One Big Beautiful Bill Act, household by household",
     "description": "Our latest interactive shows how the reconciliation bill affects each of 20,000 representative households across income levels, states, and provisions.",
-    "source": "https://policyengine.github.io/obbba-household-by-household",
+    "source": "https://obbba-household-by-household.vercel.app/us/obbba-household-explorer",
     "tags": ["us", "policy", "featured", "reconciliation", "interactives"],
     "countryId": "us",
     "displayWithResearch": true,

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -20,6 +20,16 @@ const nextConfig: NextConfig = {
         destination: "/:countryId/research",
         permanent: true,
       },
+      {
+        source: "/us/obbba-household-by-household",
+        destination: "/us/obbba-household-explorer",
+        permanent: true,
+      },
+      {
+        source: "/us/obbba-household-by-household/:path*",
+        destination: "/us/obbba-household-explorer/:path*",
+        permanent: true,
+      },
     ];
   },
 
@@ -62,6 +72,9 @@ const nextConfig: NextConfig = {
         // West Virginia SB 392 income tax cut calculator (Vercel)
         { source: "/us/wv-sb392-tax-cut", destination: "https://wv-sb392-tax-cut.vercel.app/us/wv-sb392-tax-cut" },
         { source: "/us/wv-sb392-tax-cut/:path*", destination: "https://wv-sb392-tax-cut.vercel.app/us/wv-sb392-tax-cut/:path*" },
+        // OBBBA household impact explorer (Vercel)
+        { source: "/us/obbba-household-explorer", destination: "https://obbba-household-by-household.vercel.app/us/obbba-household-explorer" },
+        { source: "/us/obbba-household-explorer/:path*", destination: "https://obbba-household-by-household.vercel.app/us/obbba-household-explorer/:path*" },
         // Household API docs (Vercel) — beforeFiles so it intercepts before Next.js trailing slash redirect
         { source: "/us/api", destination: "https://household-api-docs-policy-engine.vercel.app/us/api/" },
         { source: "/us/api/:path*", destination: "https://household-api-docs-policy-engine.vercel.app/us/api/:path*" },


### PR DESCRIPTION
## Summary
- Add Next website rewrites for /us/obbba-household-explorer to the Vercel-hosted OBBBA household explorer
- Redirect the older /us/obbba-household-by-household slug to the canonical explorer route
- Update app metadata sources to the Vercel-hosted route

## Companion change
- PolicyEngine/obbba-household-by-household@7022849 configures the SvelteKit app for the /us/obbba-household-explorer base path, adds GA/tool_engaged tracking, and deploys to https://obbba-household-by-household.vercel.app

## Verification
- cd ../policyengine-app-v2-obbba-multizone && bun install --frozen-lockfile
- bun run design-system:build
- cd website && bun run lint
- cd website && bun run typecheck
- cd website && bun run test
- cd website && bun run build:next
- node .github/scripts/audit-multizone-tracking.mjs
- curl local built website /us/obbba-household-explorer returns Svelte app HTML, not iframe shell
- curl local built website /us/obbba-household-by-household returns 308 to /us/obbba-household-explorer