### PR TITLE
Clean up multizone asset routes

### DIFF
--- a/app/public/assets/posts/encode-policy-multi-agent-ai/index.html
+++ b/app/public/assets/posts/encode-policy-multi-agent-ai/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Automating Tax and Benefit Policy Modeling with Multi-Agent AI</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -56,6 +56,16 @@ const nextConfig: NextConfig = {
         destination: "/us/obbba-household-explorer",
         permanent: true,
       },
+      {
+        source: "/us/california-wealth-tax/embed",
+        destination: "/us/california-wealth-tax",
+        permanent: true,
+      },
+      {
+        source: "/us/california-wealth-tax/embed/:path*",
+        destination: "/us/california-wealth-tax/:path*",
+        permanent: true,
+      },
     ];
   },
 
@@ -98,9 +108,6 @@ const nextConfig: NextConfig = {
         // Model documentation (Vercel)
         { source: "/:countryId/model", destination: "https://policyengine-model-phi.vercel.app/?country=:countryId" },
         { source: "/:countryId/model/:path*", destination: "https://policyengine-model-phi.vercel.app/:path*?country=:countryId" },
-        // California wealth tax calculator embed (Vercel)
-        { source: "/us/california-wealth-tax/embed", destination: "https://california-wealth-tax.vercel.app/us/california-wealth-tax/embed" },
-        { source: "/us/california-wealth-tax/embed/:path*", destination: "https://california-wealth-tax.vercel.app/us/california-wealth-tax/embed/:path*" },
       ],
     };
   },

--- a/website/src/data/appZoneRoutes.ts
+++ b/website/src/data/appZoneRoutes.ts
@@ -79,9 +79,7 @@ export const appZoneRoutes: AppZoneRoute[] = [
   {
     source: "/us/california-wealth-tax",
     destination:
-      "https://california-wealth-tax.vercel.app/us/california-wealth-tax/embed",
-    deepDestination:
-      "https://california-wealth-tax.vercel.app/us/california-wealth-tax/embed/:path*",
+      "https://california-wealth-tax.vercel.app/us/california-wealth-tax",
   },
   {
     source: "/uk/uk-land-value-tax",


### PR DESCRIPTION
## Summary
- proxy California wealth tax to its canonical /us/california-wealth-tax child route instead of the legacy /embed route
- redirect legacy /us/california-wealth-tax/embed host URLs to the canonical route
- remove the leftover /vite.svg favicon reference from the static multi-agent AI asset page

## Verification
- bun run --cwd website typecheck
- bun run --cwd website build
- bun run --cwd website lint (after restoring website/public/assets symlink, as in prior local builds)
- production child smoke: california canonical route/assets 200 and /embed redirects; public-services static/data assets 200; WPTRA watermark asset 200