### PR TITLE
Point 2024 election zone to PolicyEngine deployment

### DIFF
--- a/website/src/data/appZoneRoutes.ts
+++ b/website/src/data/appZoneRoutes.ts
@@ -186,7 +186,7 @@ export const appZoneRoutes: AppZoneRoute[] = [
   {
     source: "/us/2024-election-calculator",
     destination:
-      "https://2024-election-dashboard.vercel.app/us/2024-election-calculator",
+      "https://2024-election-dashboard-omega.vercel.app/us/2024-election-calculator",
   },
   {
     source: "/us/obbba-household-explorer",


### PR DESCRIPTION
## Summary\n- update the /us/2024-election-calculator zone rewrite to the PolicyEngine-owned Vercel deployment alias\n- keeps the route on policyengine.org while using the child deployment that includes the shared PolicyEngine header\n\n## Tests\n- bun run --filter=@policyengine/website typecheck\n- direct fetch of https://2024-election-dashboard-omega.vercel.app/us/2024-election-calculator returned 200