### PR TITLE
Add shell header to encoded policy article

### DIFF
--- a/app/public/assets/posts/encode-policy-multi-agent-ai/index.html
+++ b/app/public/assets/posts/encode-policy-multi-agent-ai/index.html
@@ -14,8 +14,119 @@
     />
     <script type="module" crossorigin src="./assets/index-DC8RyDPP.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-BJx1p784.css" />
+    <style>
+      .pe-site-header {
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        background: #ffffff;
+        border-bottom: 1px solid #d8e2e8;
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+      }
+
+      .pe-site-header__inner {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 24px;
+        max-width: 1180px;
+        margin: 0 auto;
+        min-height: 72px;
+        padding: 0 24px;
+      }
+
+      .pe-site-header__logo {
+        display: inline-flex;
+        align-items: center;
+        min-width: 156px;
+      }
+
+      .pe-site-header__logo img {
+        display: block;
+        width: 156px;
+        height: auto;
+      }
+
+      .pe-site-header__nav {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 24px;
+        color: #2c3e4f;
+        font-size: 15px;
+        font-weight: 500;
+        line-height: 1;
+      }
+
+      .pe-site-header__nav a {
+        color: inherit;
+        text-decoration: none;
+        white-space: nowrap;
+      }
+
+      .pe-site-header__nav a:hover {
+        color: #0c7c8c;
+      }
+
+      .pe-site-header__nav .pe-site-header__donate {
+        border: 1px solid #0c7c8c;
+        border-radius: 4px;
+        color: #0c7c8c;
+        padding: 9px 14px;
+      }
+
+      .pe-site-header__country {
+        border-left: 1px solid #d8e2e8;
+        margin-left: 4px;
+        padding-left: 24px;
+      }
+
+      @media (max-width: 760px) {
+        .pe-site-header__inner {
+          align-items: flex-start;
+          flex-direction: column;
+          gap: 12px;
+          min-height: 0;
+          padding: 16px 20px;
+        }
+
+        .pe-site-header__nav {
+          flex-wrap: wrap;
+          gap: 12px 18px;
+          justify-content: flex-start;
+          font-size: 14px;
+          line-height: 1.25;
+        }
+
+        .pe-site-header__country {
+          border-left: 0;
+          margin-left: 0;
+          padding-left: 0;
+        }
+      }
+    </style>
   </head>
   <body>
+    <header class="pe-site-header" aria-label="PolicyEngine">
+      <div class="pe-site-header__inner">
+        <a class="pe-site-header__logo" href="/us" aria-label="PolicyEngine US home">
+          <img src="/assets/logos/policyengine/teal.svg" alt="PolicyEngine" />
+        </a>
+        <nav class="pe-site-header__nav" aria-label="PolicyEngine navigation">
+          <a href="/us/research">Research</a>
+          <a href="/us/model">Model</a>
+          <a href="/us/api">API</a>
+          <a href="/us/team">About</a>
+          <a class="pe-site-header__donate" href="/us/donate">Donate</a>
+          <a class="pe-site-header__country" href="/uk">United Kingdom</a>
+        </nav>
+      </div>
+    </header>
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a PolicyEngine site header to the static encoded-policy article shell
- keep the repaired asset base path from #1030

## Verification
- PATH="/Users/maxghenis/.bun/bin:/Users/maxghenis/.local/bin:/Users/maxghenis/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/maxghenis/.cargo/bin:/Users/maxghenis/.codex/tmp/arg0/codex-arg0MDXqWA:/Applications/Codex.app/Contents/Resources:/Applications/Obsidian.app/Contents/MacOS" bun run build