### PR TITLE
Restore full author list to /research filter dropdown

### DIFF
--- a/website/src/app/[countryId]/research/ResearchClient.tsx
+++ b/website/src/app/[countryId]/research/ResearchClient.tsx
@@ -52,16 +52,18 @@ import {
   type ResearchItem,
 } from "@/data/posts/postTransformers";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+import authorsData from "@/data/posts/authors.json";
 
 /* ─── Constants ─── */
 
-const mockAuthors = [
-  { key: "max-ghenis", name: "Max Ghenis" },
-  { key: "nikhil-woodruff", name: "Nikhil Woodruff" },
-  { key: "pavel-makarchuk", name: "Pavel Makarchuk" },
-  { key: "vahid-ahmadi", name: "Vahid Ahmadi" },
-  { key: "ben-ogorek", name: "Ben Ogorek" },
-];
+// All authors from authors.json, sorted alphabetically by display name. The
+// dropdown previously hardcoded a 5-name subset; pulling from authors.json
+// keeps it in sync as authors are added without a code edit.
+const allAuthors = Object.entries(
+  authorsData as Record<string, { name: string }>,
+)
+  .map(([key, value]) => ({ key, name: value.name }))
+  .sort((a, b) => a.name.localeCompare(b.name));
 
 const typeOptions = [
   { value: "article", label: "Article" },
@@ -1034,7 +1036,7 @@ export default function ResearchClient({
               onLocationsChange={setSelectedLocations}
               selectedAuthors={selectedAuthors}
               onAuthorsChange={setSelectedAuthors}
-              availableAuthors={mockAuthors}
+              availableAuthors={allAuthors}
               countryId={countryId}
             />
           </div>


### PR DESCRIPTION
## Summary
The Author filter on `/us/research` and `/uk/research` hardcoded a 5-name `mockAuthors` array (Max, Nikhil, Pavel, Vahid, Ben) with a TODO saying "import from authors.json in production." That left ~15 PolicyEngine contributors invisible in the filter, so posts authored by Daphne, Anthony, Sakshi, Kevin Foster, David Trimmer, Ziming Hua, Maria Juaristi, Elena Cura, Nicholas Rodelo, Arthur Wright, Donglai Xu, Lin Tao, Ben Gross, Jason DeBacker, Michael Smit, ChatGPT, etc. couldn't be filtered to.

## Fix
Replace `mockAuthors` with a derivation from `website/src/data/posts/authors.json` (the canonical list of 20 authors), sorted alphabetically by display name. Adding a new author to `authors.json` is now enough — no code edit needed.

## Files
- `website/src/app/[countryId]/research/ResearchClient.tsx`: import authors.json, derive `allAuthors` from it, drop the `mockAuthors` array, pass `allAuthors` to `<ResearchFilters>`.

## Verification
- `bun run build` — clean
- Dropdown will list all 20 contributors alphabetically after deploy.
