### PR TITLE
Stop filter accordions from shrinking when sibling expands

### DIFF
--- a/website/src/app/[countryId]/research/ResearchClient.tsx
+++ b/website/src/app/[countryId]/research/ResearchClient.tsx
@@ -419,6 +419,13 @@ function FilterSection({
         backgroundColor: isExpanded ? "rgba(230, 255, 250, 0.3)" : colors.white,
         transition: "border-color 0.2s ease, background-color 0.2s ease",
         overflow: "hidden",
+        // Collapsed sections must keep their full header height when a sibling
+        // section expands — the parent flex column has `maxHeight: availableHeight;
+        // overflow: hidden`, and the default `flex-shrink: 1` would otherwise
+        // squish the headers down (visible bug: clicking "Author" shrinks the
+        // "Type" / "Topic" / "Location" headers because the expanded Author panel
+        // takes most of the available column height).
+        flexShrink: 0,
       }}
     >
       <button


### PR DESCRIPTION
## Bug
On `/us/research`, clicking the **Author** accordion to expand it visibly compresses the **Type / Topic / Location** section headers above. Same on `/uk/research`.

## Cause
The filter sidebar is a `display: flex; flexDirection: column` container with `maxHeight: availableHeight; overflow: hidden`. Each `FilterSection` wrapper has no `flex-shrink` set (default = `1`). When Author expands and its `maxHeight: availableHeight - 16` panel claims most of the available column height, flexbox squishes the sibling collapsed-header sections to make total content fit.

Got more visible recently because #1041 grew the Author list from 5 hardcoded entries to all 20 contributors from `authors.json`, so the expanded panel routinely fills the available height.

## Fix
Set `flexShrink: 0` on the `FilterSection` wrapper `<div>`. Collapsed sections now keep their ~40px header height; the expanded section gets the remaining space and scrolls internally (the inner panel already has `overflow: auto`).

## Verification
- `bun run build` — clean
- Local manual: open Author, then Type/Topic/Location headers stay at ~40px each instead of compressing.
