### PR TITLE
Add Household.fromUSDraft adapter and round-trip tests (issue 1044)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -32,7 +32,7 @@
     "chromatic": "VITE_APP_MODE=website chromatic --only-changed --build-script-name='storybook:build'"
   },
   "dependencies": {
-    "@policyengine/household-wizard": "^0.1.0",
+    "policyengine-household-wizard": "^0.1.0",
     "@policyengine/ui-kit": "^0.4.0",
     "@reduxjs/toolkit": "^2.8.2",
     "@tabler/icons-react": "^3.34.0",

--- a/app/package.json
+++ b/app/package.json
@@ -32,6 +32,7 @@
     "chromatic": "VITE_APP_MODE=website chromatic --only-changed --build-script-name='storybook:build'"
   },
   "dependencies": {
+    "@policyengine/household-wizard": "^0.1.0",
     "@policyengine/ui-kit": "^0.4.0",
     "@reduxjs/toolkit": "^2.8.2",
     "@tabler/icons-react": "^3.34.0",

--- a/app/src/models/household/fromUSDraft.ts
+++ b/app/src/models/household/fromUSDraft.ts
@@ -1,5 +1,4 @@
-import type { USHouseholdDraft } from 'policyengine-household-wizard';
-import { toV1HouseholdPayload } from 'policyengine-household-wizard';
+import { toV1HouseholdPayload, type USHouseholdDraft } from 'policyengine-household-wizard';
 import { Household } from '../Household';
 
 export interface FromUSDraftOptions {

--- a/app/src/models/household/fromUSDraft.ts
+++ b/app/src/models/household/fromUSDraft.ts
@@ -1,5 +1,5 @@
-import type { USHouseholdDraft } from '@policyengine/household-wizard';
-import { toV1HouseholdPayload } from '@policyengine/household-wizard';
+import type { USHouseholdDraft } from 'policyengine-household-wizard';
+import { toV1HouseholdPayload } from 'policyengine-household-wizard';
 import { Household } from '../Household';
 
 export interface FromUSDraftOptions {
@@ -9,7 +9,7 @@ export interface FromUSDraftOptions {
 
 /**
  * Build an app-v2 `Household` from a `USHouseholdDraft` produced by
- * `@policyengine/household-wizard`. The wizard's V1 envelope is the contract
+ * `policyengine-household-wizard`. The wizard's V1 envelope is the contract
  * we share with the package: this adapter pipes that envelope through
  * `Household.fromV1CreationPayload` so the household model only learns one
  * external schema.

--- a/app/src/models/household/fromUSDraft.ts
+++ b/app/src/models/household/fromUSDraft.ts
@@ -1,0 +1,45 @@
+import type { USHouseholdDraft } from '@policyengine/household-wizard';
+import { toV1HouseholdPayload } from '@policyengine/household-wizard';
+import { Household } from '../Household';
+
+export interface FromUSDraftOptions {
+  id?: string;
+  label?: string | null;
+}
+
+/**
+ * Build an app-v2 `Household` from a `USHouseholdDraft` produced by
+ * `@policyengine/household-wizard`. The wizard's V1 envelope is the contract
+ * we share with the package: this adapter pipes that envelope through
+ * `Household.fromV1CreationPayload` so the household model only learns one
+ * external schema.
+ *
+ * Verbose group keys (`"your tax unit"`, `"your household"`, …) keep the
+ * resulting Household readable in app-v2's UI, matching the names produced
+ * by `Household.starter` and friends.
+ */
+export function householdFromUSDraft(
+  draft: USHouseholdDraft,
+  options: FromUSDraftOptions = {},
+): Household {
+  if (draft.state === null) {
+    throw new Error('USHouseholdDraft requires a state before conversion to Household.');
+  }
+  if (draft.people.length === 0) {
+    throw new Error('USHouseholdDraft requires at least one person.');
+  }
+
+  const envelope = toV1HouseholdPayload(draft, {
+    groupKeyStyle: 'verbose',
+    includeMaritalUnit: draft.maritalStatus === 'married',
+  });
+
+  return Household.fromV1CreationPayload(
+    {
+      country_id: envelope.country_id,
+      data: envelope.data,
+      label: options.label ?? envelope.label ?? undefined,
+    },
+    { id: options.id, label: options.label ?? null },
+  );
+}

--- a/app/src/models/household/fromUSDraft.ts
+++ b/app/src/models/household/fromUSDraft.ts
@@ -20,7 +20,7 @@ export interface FromUSDraftOptions {
  */
 export function householdFromUSDraft(
   draft: USHouseholdDraft,
-  options: FromUSDraftOptions = {},
+  options: FromUSDraftOptions = {}
 ): Household {
   if (draft.state === null) {
     throw new Error('USHouseholdDraft requires a state before conversion to Household.');
@@ -40,6 +40,6 @@ export function householdFromUSDraft(
       data: envelope.data,
       label: options.label ?? envelope.label ?? undefined,
     },
-    { id: options.id, label: options.label ?? null },
+    { id: options.id, label: options.label ?? null }
   );
 }

--- a/app/src/tests/fixtures/usHouseholdDrafts/adult-with-child.json
+++ b/app/src/tests/fixtures/usHouseholdDrafts/adult-with-child.json
@@ -1,0 +1,23 @@
+{
+  "name": "single adult with one child dependent in TX",
+  "draft": {
+    "state": "TX",
+    "county": null,
+    "zip": null,
+    "maritalStatus": "single",
+    "year": 2026,
+    "people": [
+      {
+        "id": "adult-1",
+        "kind": "adult",
+        "age": 28,
+        "employmentIncome": 32000
+      },
+      {
+        "id": "dependent-1",
+        "kind": "dependent",
+        "age": 6
+      }
+    ]
+  }
+}

--- a/app/src/tests/fixtures/usHouseholdDrafts/county-case.json
+++ b/app/src/tests/fixtures/usHouseholdDrafts/county-case.json
@@ -1,0 +1,34 @@
+{
+  "name": "household in Alameda County, CA with explicit county",
+  "draft": {
+    "state": "CA",
+    "county": "ALAMEDA_COUNTY_CA",
+    "zip": "94703",
+    "maritalStatus": "married",
+    "year": 2026,
+    "people": [
+      {
+        "id": "adult-1",
+        "kind": "adult",
+        "age": 35,
+        "employmentIncome": 110000
+      },
+      {
+        "id": "adult-2",
+        "kind": "adult",
+        "age": 34,
+        "employmentIncome": 0
+      },
+      {
+        "id": "dependent-1",
+        "kind": "dependent",
+        "age": 4
+      },
+      {
+        "id": "dependent-2",
+        "kind": "dependent",
+        "age": 1
+      }
+    ]
+  }
+}

--- a/app/src/tests/fixtures/usHouseholdDrafts/disabled-person.json
+++ b/app/src/tests/fixtures/usHouseholdDrafts/disabled-person.json
@@ -1,0 +1,20 @@
+{
+  "name": "disabled adult with SSI and SSDI in WV",
+  "draft": {
+    "state": "WV",
+    "county": null,
+    "zip": null,
+    "maritalStatus": "single",
+    "year": 2026,
+    "people": [
+      {
+        "id": "adult-1",
+        "kind": "adult",
+        "age": 45,
+        "isDisabled": true,
+        "ssiAmount": 9432,
+        "ssdiAmount": 18000
+      }
+    ]
+  }
+}

--- a/app/src/tests/fixtures/usHouseholdDrafts/married-adults.json
+++ b/app/src/tests/fixtures/usHouseholdDrafts/married-adults.json
@@ -1,0 +1,24 @@
+{
+  "name": "married adults in NY",
+  "draft": {
+    "state": "NY",
+    "county": null,
+    "zip": null,
+    "maritalStatus": "married",
+    "year": 2026,
+    "people": [
+      {
+        "id": "adult-1",
+        "kind": "adult",
+        "age": 35,
+        "employmentIncome": 80000
+      },
+      {
+        "id": "adult-2",
+        "kind": "adult",
+        "age": 33,
+        "employmentIncome": 60000
+      }
+    ]
+  }
+}

--- a/app/src/tests/fixtures/usHouseholdDrafts/single-adult.json
+++ b/app/src/tests/fixtures/usHouseholdDrafts/single-adult.json
@@ -1,0 +1,18 @@
+{
+  "name": "single adult, CA, $50k wages",
+  "draft": {
+    "state": "CA",
+    "county": null,
+    "zip": null,
+    "maritalStatus": "single",
+    "year": 2026,
+    "people": [
+      {
+        "id": "adult-1",
+        "kind": "adult",
+        "age": 30,
+        "employmentIncome": 50000
+      }
+    ]
+  }
+}

--- a/app/src/tests/fixtures/usHouseholdDrafts/student.json
+++ b/app/src/tests/fixtures/usHouseholdDrafts/student.json
@@ -1,0 +1,24 @@
+{
+  "name": "single full-time student dependent in MA",
+  "draft": {
+    "state": "MA",
+    "county": null,
+    "zip": null,
+    "maritalStatus": "single",
+    "year": 2026,
+    "people": [
+      {
+        "id": "adult-1",
+        "kind": "adult",
+        "age": 48,
+        "employmentIncome": 95000
+      },
+      {
+        "id": "dependent-1",
+        "kind": "dependent",
+        "age": 19,
+        "isFullTimeStudent": true
+      }
+    ]
+  }
+}

--- a/app/src/tests/unit/models/household/fromUSDraft.test.ts
+++ b/app/src/tests/unit/models/household/fromUSDraft.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { USHouseholdDraft } from '@policyengine/household-wizard';
+import type { USHouseholdDraft } from 'policyengine-household-wizard';
 import singleAdult from '../../../fixtures/usHouseholdDrafts/single-adult.json' with { type: 'json' };
 import marriedAdults from '../../../fixtures/usHouseholdDrafts/married-adults.json' with { type: 'json' };
 import adultWithChild from '../../../fixtures/usHouseholdDrafts/adult-with-child.json' with { type: 'json' };

--- a/app/src/tests/unit/models/household/fromUSDraft.test.ts
+++ b/app/src/tests/unit/models/household/fromUSDraft.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { USHouseholdDraft } from '@policyengine/household-wizard';
+import singleAdult from '../../../fixtures/usHouseholdDrafts/single-adult.json' with { type: 'json' };
+import marriedAdults from '../../../fixtures/usHouseholdDrafts/married-adults.json' with { type: 'json' };
+import adultWithChild from '../../../fixtures/usHouseholdDrafts/adult-with-child.json' with { type: 'json' };
+import disabledPerson from '../../../fixtures/usHouseholdDrafts/disabled-person.json' with { type: 'json' };
+import student from '../../../fixtures/usHouseholdDrafts/student.json' with { type: 'json' };
+import countyCase from '../../../fixtures/usHouseholdDrafts/county-case.json' with { type: 'json' };
+
+import { householdFromUSDraft } from '@/models/household/fromUSDraft';
+
+interface Fixture {
+  name: string;
+  draft: USHouseholdDraft;
+}
+
+const FIXTURES: Fixture[] = [
+  singleAdult as Fixture,
+  marriedAdults as Fixture,
+  adultWithChild as Fixture,
+  disabledPerson as Fixture,
+  student as Fixture,
+  countyCase as Fixture,
+];
+
+describe('householdFromUSDraft', () => {
+  it.each(FIXTURES)(
+    '$name: produces a Household with the expected country, year, and person count',
+    ({ draft }) => {
+      const household = householdFromUSDraft(draft);
+      expect(household.countryId).toBe('us');
+      expect(household.year).toBe(draft.year);
+      expect(household.personCount).toBe(draft.people.length);
+    },
+  );
+
+  it.each(FIXTURES)(
+    '$name: keeps adult and child counts at the draft year by age threshold',
+    ({ draft }) => {
+      const household = householdFromUSDraft(draft);
+      const year = String(draft.year);
+      // app-v2 partitions people by age (>=18 is an adult); the wizard's
+      // `kind` is a UI hint, not a tax-unit role. Use age to compare.
+      const expectedAdults = draft.people.filter(
+        (person) => (person.age ?? 0) >= 18,
+      ).length;
+      const expectedChildren = draft.people.filter(
+        (person) => (person.age ?? 0) < 18,
+      ).length;
+      expect(household.getAdultCount(year)).toBe(expectedAdults);
+      expect(household.getChildCount(year)).toBe(expectedChildren);
+    },
+  );
+
+  it.each(FIXTURES)('$name: configures the household group with state and county', ({ draft }) => {
+    const household = householdFromUSDraft(draft);
+    const year = String(draft.year);
+    const householdGroupName = household.getPreferredGroupName('households');
+    expect(householdGroupName).toBeDefined();
+    expect(
+      household.getGroupVariableAtYear('households', householdGroupName!, 'state_name', year),
+    ).toBe(draft.state);
+    if (draft.county) {
+      expect(
+        household.getGroupVariableAtYear('households', householdGroupName!, 'county', year),
+      ).toBe(draft.county);
+    }
+  });
+
+  it.each(FIXTURES)('$name: round-trips through the V1 creation envelope', ({ draft }) => {
+    const household = householdFromUSDraft(draft);
+    const envelope = household.toV1CreationPayload();
+    expect(envelope.country_id).toBe('us');
+    expect(envelope.data.households).toBeDefined();
+    expect(envelope.data.people).toBeDefined();
+    expect(Object.keys(envelope.data.people).length).toBe(draft.people.length);
+  });
+
+  it('throws when the draft is missing a state', () => {
+    expect(() =>
+      householdFromUSDraft({
+        ...(singleAdult as Fixture).draft,
+        state: null,
+      }),
+    ).toThrowError(/state/);
+  });
+
+  it('throws when the draft has no people', () => {
+    expect(() =>
+      householdFromUSDraft({
+        ...(singleAdult as Fixture).draft,
+        people: [],
+      }),
+    ).toThrowError(/at least one person/);
+  });
+
+  it('writes the supplied label onto the Household', () => {
+    const household = householdFromUSDraft((singleAdult as Fixture).draft, {
+      label: 'Test household',
+    });
+    expect(household.label).toBe('Test household');
+  });
+
+  it('populates a marital unit when the draft is married', () => {
+    const household = householdFromUSDraft((marriedAdults as Fixture).draft);
+    const maritalUnits = household.getGroupCollection('maritalUnits');
+    expect(maritalUnits).toBeDefined();
+    const groups = Object.values(maritalUnits!);
+    expect(groups.length).toBeGreaterThan(0);
+    expect(groups[0].members).toHaveLength(2);
+  });
+});

--- a/app/src/tests/unit/models/household/fromUSDraft.test.ts
+++ b/app/src/tests/unit/models/household/fromUSDraft.test.ts
@@ -1,13 +1,12 @@
-import { describe, expect, it } from 'vitest';
 import type { USHouseholdDraft } from 'policyengine-household-wizard';
-import singleAdult from '../../../fixtures/usHouseholdDrafts/single-adult.json' with { type: 'json' };
-import marriedAdults from '../../../fixtures/usHouseholdDrafts/married-adults.json' with { type: 'json' };
-import adultWithChild from '../../../fixtures/usHouseholdDrafts/adult-with-child.json' with { type: 'json' };
-import disabledPerson from '../../../fixtures/usHouseholdDrafts/disabled-person.json' with { type: 'json' };
-import student from '../../../fixtures/usHouseholdDrafts/student.json' with { type: 'json' };
-import countyCase from '../../../fixtures/usHouseholdDrafts/county-case.json' with { type: 'json' };
-
+import { describe, expect, it } from 'vitest';
 import { householdFromUSDraft } from '@/models/household/fromUSDraft';
+import adultWithChild from '../../../fixtures/usHouseholdDrafts/adult-with-child.json' with { type: 'json' };
+import countyCase from '../../../fixtures/usHouseholdDrafts/county-case.json' with { type: 'json' };
+import disabledPerson from '../../../fixtures/usHouseholdDrafts/disabled-person.json' with { type: 'json' };
+import marriedAdults from '../../../fixtures/usHouseholdDrafts/married-adults.json' with { type: 'json' };
+import singleAdult from '../../../fixtures/usHouseholdDrafts/single-adult.json' with { type: 'json' };
+import student from '../../../fixtures/usHouseholdDrafts/student.json' with { type: 'json' };
 
 interface Fixture {
   name: string;
@@ -31,7 +30,7 @@ describe('householdFromUSDraft', () => {
       expect(household.countryId).toBe('us');
       expect(household.year).toBe(draft.year);
       expect(household.personCount).toBe(draft.people.length);
-    },
+    }
   );
 
   it.each(FIXTURES)(
@@ -41,15 +40,11 @@ describe('householdFromUSDraft', () => {
       const year = String(draft.year);
       // app-v2 partitions people by age (>=18 is an adult); the wizard's
       // `kind` is a UI hint, not a tax-unit role. Use age to compare.
-      const expectedAdults = draft.people.filter(
-        (person) => (person.age ?? 0) >= 18,
-      ).length;
-      const expectedChildren = draft.people.filter(
-        (person) => (person.age ?? 0) < 18,
-      ).length;
+      const expectedAdults = draft.people.filter((person) => (person.age ?? 0) >= 18).length;
+      const expectedChildren = draft.people.filter((person) => (person.age ?? 0) < 18).length;
       expect(household.getAdultCount(year)).toBe(expectedAdults);
       expect(household.getChildCount(year)).toBe(expectedChildren);
-    },
+    }
   );
 
   it.each(FIXTURES)('$name: configures the household group with state and county', ({ draft }) => {
@@ -58,11 +53,11 @@ describe('householdFromUSDraft', () => {
     const householdGroupName = household.getPreferredGroupName('households');
     expect(householdGroupName).toBeDefined();
     expect(
-      household.getGroupVariableAtYear('households', householdGroupName!, 'state_name', year),
+      household.getGroupVariableAtYear('households', householdGroupName!, 'state_name', year)
     ).toBe(draft.state);
     if (draft.county) {
       expect(
-        household.getGroupVariableAtYear('households', householdGroupName!, 'county', year),
+        household.getGroupVariableAtYear('households', householdGroupName!, 'county', year)
       ).toBe(draft.county);
     }
   });
@@ -81,7 +76,7 @@ describe('householdFromUSDraft', () => {
       householdFromUSDraft({
         ...(singleAdult as Fixture).draft,
         state: null,
-      }),
+      })
     ).toThrowError(/state/);
   });
 
@@ -90,7 +85,7 @@ describe('householdFromUSDraft', () => {
       householdFromUSDraft({
         ...(singleAdult as Fixture).draft,
         people: [],
-      }),
+      })
     ).toThrowError(/at least one person/);
   });
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "html-to-image": "^1.11.13",
         "jsonp": "^0.2.1",
         "lucide-react": "^0.575.0",
+        "policyengine-household-wizard": "^0.1.0",
         "radix-ui": "^1.4.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2165,6 +2166,8 @@
     "point-in-polygon": ["point-in-polygon@1.1.0", "", {}, "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="],
 
     "policyengine-app-v2": ["policyengine-app-v2@workspace:app"],
+
+    "policyengine-household-wizard": ["policyengine-household-wizard@0.1.0", "", { "peerDependencies": { "react": ">=19", "react-dom": ">=19" } }, "sha512-VHQIdZsZq4eWMZa+xgLrW0wZvClV3MXPE/TcMnZGP+QHOBGQZbEiFmHhL/roWIpZMEB8d7IB3Fl+W+DZsuRUug=="],
 
     "polished": ["polished@4.3.1", "", { "dependencies": { "@babel/runtime": "^7.17.8" } }, "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA=="],
 


### PR DESCRIPTION
Implements the "App-v2 round-trip fixtures pass before consumer migration" acceptance criterion from #1044.

## Summary

- `householdFromUSDraft(draft)` in `app/src/models/household/fromUSDraft.ts` builds an app-v2 `Household` from `@policyengine/household-wizard`'s `USHouseholdDraft`. The implementation pipes the wizard's V1 envelope through `Household.fromV1CreationPayload`, so the household model only learns one external schema. Verbose group keys keep names like `"your household"` readable in app-v2 UI.
- Six round-trip fixtures under `app/src/tests/fixtures/usHouseholdDrafts/`: single adult, married adults, adult with child, disabled person, student, county case — matching the fixture set the wizard package ships.
- 28 vitest cases in `fromUSDraft.test.ts` cover:
  - country, year, person counts (by age, since the wizard's `kind` is a UI hint while app-v2 partitions by age)
  - state and county on the household group
  - V1 envelope round-trip
  - error paths (missing state, no people)
  - marital-unit population for married drafts

## Test plan

- [x] `bun run vitest run src/tests/unit/models/household/fromUSDraft.test.ts` — 28/28 pass locally
- [x] `bun run vitest` — full suite still passes (3,517 / 3,527 — 10 skipped unrelated)
- [x] `bun run typecheck` — clean once the wizard package is resolvable

## Gate

This PR depends on [`@policyengine/household-wizard`](https://github.com/PolicyEngine/policyengine-household-wizard) v0.1.0 being published to npm. The wizard repo's first release PR is at PolicyEngine/policyengine-household-wizard#1. CI here will fail at `bun install` until the wizard is on npm; once it lands, this PR's checks will go green on a re-run.

## Follow-ups (separate PRs)

- Cliff Watch consumes the wizard's primitives + draft (issue #1044 Phase 4, first consumer).
- Coverage Compass consumes the wizard's primitives + draft (issue #1044 Phase 4, second consumer).

Refs #1044
