### PR TITLE
Embed QBI calculator at /us/qbi-calculator via multizone

### DIFF
--- a/.github/scripts/guard-vercel-zone-rewrites.mjs
+++ b/.github/scripts/guard-vercel-zone-rewrites.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Guards `vercel.json` against new multizone-shaped rewrites.
+ *
+ * Multizone routes belong in `website/src/data/appZoneRoutes.ts` so they
+ * flow through `website/next.config.ts`'s `beforeFiles` and get audited
+ * by `app-zone-shell-audit` and `multizone-tracking-audit`. Anything
+ * added to `vercel.json` bypasses both.
+ *
+ * A handful of legacy entries predate the multizone migration and are
+ * grandfathered via LEGACY_VERCEL_JSON_ZONE_SLUGS. **Do not add new
+ * slugs to that set** — when a legacy entry gets migrated to
+ * `appZoneRoutes.ts`, the slug should be removed from the set in the
+ * same PR.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_VERCEL_JSON = "vercel.json";
+
+// Slugs whose vercel.json zone rewrites exist on `main` today. Any
+// rewrite outside this set will be flagged. Shrink as legacy entries
+// move to appZoneRoutes.ts.
+export const LEGACY_VERCEL_JSON_ZONE_SLUGS = new Set([
+  "api",
+  "california-wealth-tax",
+  "keep-your-pay-act",
+  "model",
+  "oregon-kicker-refund",
+  "taxsim",
+  "watca",
+]);
+
+/**
+ * Return the zone slug for a rewrite source, or null if the source
+ * isn't shaped like a country-prefixed multizone route.
+ *
+ *   /us/taxsim                  -> "taxsim"
+ *   /us/taxsim/:path*           -> "taxsim"
+ *   /uk/api/                    -> "api"
+ *   /:countryId/model/:path*    -> "model"
+ *   /us/california-wealth-tax/embed -> "california-wealth-tax"
+ *   /robots.txt                 -> null
+ *   /slides/:path*              -> null  (top-level zone, not country)
+ *   /(.*)                       -> null  (SPA catch-all)
+ */
+export function extractZoneSlug(source) {
+  if (typeof source !== "string") return null;
+  // First segment is a literal country (us/uk) or a Next.js parameter
+  // standing in for one (typically :countryId, but accept any :name
+  // since the shape is what matters).
+  const match = source.match(/^\/(?:us|uk|:[A-Za-z_]\w*)\/([A-Za-z0-9][A-Za-z0-9-]*)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * A rewrite is "zone-shaped" if its source has a country prefix and
+ * its destination points at a vercel.app host.
+ */
+export function isZoneShaped(rewrite) {
+  if (!rewrite || typeof rewrite.destination !== "string") return false;
+  if (!extractZoneSlug(rewrite.source)) return false;
+  try {
+    const url = new URL(rewrite.destination);
+    return url.hostname.endsWith(".vercel.app");
+  } catch {
+    return false;
+  }
+}
+
+export function findUnauthorizedZoneRewrites(rewrites, allowedSlugs = LEGACY_VERCEL_JSON_ZONE_SLUGS) {
+  if (!Array.isArray(rewrites)) return [];
+  return rewrites
+    .filter(isZoneShaped)
+    .filter((rewrite) => !allowedSlugs.has(extractZoneSlug(rewrite.source)));
+}
+
+function formatRewrite({ source, destination }) {
+  return `  - ${source} -> ${destination}`;
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const path = argv[0] || DEFAULT_VERCEL_JSON;
+  const raw = readFileSync(path, "utf8");
+  const config = JSON.parse(raw);
+  const unauthorized = findUnauthorizedZoneRewrites(config.rewrites);
+
+  if (unauthorized.length === 0) {
+    console.log(`${path}: no unauthorized zone-shaped rewrites.`);
+    return 0;
+  }
+
+  console.error(`${path} has zone-shaped rewrites that bypass the multizone audit:\n`);
+  for (const rewrite of unauthorized) {
+    console.error(formatRewrite(rewrite));
+  }
+  console.error(
+    `\nNew multizone routes go in website/src/data/appZoneRoutes.ts so they\n` +
+      `flow through website/next.config.ts beforeFiles and get covered by\n` +
+      `the app-zone-shell-audit and multizone-tracking-audit checks. The\n` +
+      `legacy vercel.json entries are tracked for migration; do not add to\n` +
+      `them. See CLAUDE.md "Embedded sites".`,
+  );
+  return 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().then((code) => process.exit(code));
+}

--- a/.github/scripts/guard-vercel-zone-rewrites.test.mjs
+++ b/.github/scripts/guard-vercel-zone-rewrites.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  LEGACY_VERCEL_JSON_ZONE_SLUGS,
+  extractZoneSlug,
+  isZoneShaped,
+  findUnauthorizedZoneRewrites,
+} from "./guard-vercel-zone-rewrites.mjs";
+
+describe("extractZoneSlug", () => {
+  test("extracts the slug after /us or /uk", () => {
+    assert.equal(extractZoneSlug("/us/taxsim"), "taxsim");
+    assert.equal(extractZoneSlug("/uk/api"), "api");
+    assert.equal(extractZoneSlug("/us/oregon-kicker-refund"), "oregon-kicker-refund");
+  });
+
+  test("strips deep-path suffixes", () => {
+    assert.equal(extractZoneSlug("/us/taxsim/:path*"), "taxsim");
+    assert.equal(extractZoneSlug("/uk/api/"), "api");
+    assert.equal(extractZoneSlug("/us/california-wealth-tax/embed"), "california-wealth-tax");
+  });
+
+  test("handles parameterized country prefixes", () => {
+    assert.equal(extractZoneSlug("/:countryId/model"), "model");
+    assert.equal(extractZoneSlug("/:countryId/model/:path*"), "model");
+  });
+
+  test("returns null for non-zone sources", () => {
+    assert.equal(extractZoneSlug("/robots.txt"), null);
+    assert.equal(extractZoneSlug("/slides/:path*"), null);
+    assert.equal(extractZoneSlug("/(.*)"), null);
+    assert.equal(extractZoneSlug("/_tracker/:path*"), null);
+    assert.equal(extractZoneSlug(""), null);
+    assert.equal(extractZoneSlug(undefined), null);
+  });
+});
+
+describe("isZoneShaped", () => {
+  test("flags country-prefixed sources pointing at vercel.app", () => {
+    assert.equal(
+      isZoneShaped({ source: "/us/taxsim", destination: "https://taxsim.vercel.app/us/taxsim" }),
+      true,
+    );
+    assert.equal(
+      isZoneShaped({
+        source: "/uk/api/:path*",
+        destination: "https://household-api-docs-policy-engine.vercel.app/uk/api/:path*",
+      }),
+      true,
+    );
+  });
+
+  test("ignores non-vercel.app destinations", () => {
+    assert.equal(
+      isZoneShaped({
+        source: "/us/something",
+        destination: "https://policyengine.org/us/something",
+      }),
+      false,
+    );
+    assert.equal(
+      isZoneShaped({
+        source: "/_tracker/:path*",
+        destination: "https://something.modal.run/_tracker/:path*",
+      }),
+      false,
+    );
+  });
+
+  test("ignores non-country-prefixed sources even when destination is vercel.app", () => {
+    assert.equal(
+      isZoneShaped({
+        source: "/slides/:path*",
+        destination: "https://policyengine-slides.vercel.app/slides/:path*",
+      }),
+      false,
+    );
+  });
+
+  test("tolerates malformed inputs", () => {
+    assert.equal(isZoneShaped(null), false);
+    assert.equal(isZoneShaped({}), false);
+    assert.equal(isZoneShaped({ source: "/us/x", destination: "not-a-url" }), false);
+  });
+});
+
+describe("findUnauthorizedZoneRewrites", () => {
+  const legacyRewrite = {
+    source: "/us/taxsim",
+    destination: "https://policyengine-taxsim-policy-engine.vercel.app/us/taxsim",
+  };
+  const newRewrite = {
+    source: "/us/qbi-calculator",
+    destination: "https://qbi-visualizer.vercel.app/us/qbi-calculator",
+  };
+
+  test("returns nothing when all zone rewrites are on the allowlist", () => {
+    assert.deepEqual(findUnauthorizedZoneRewrites([legacyRewrite]), []);
+  });
+
+  test("flags rewrites whose slug isn't on the allowlist", () => {
+    const result = findUnauthorizedZoneRewrites([legacyRewrite, newRewrite]);
+    assert.deepEqual(result, [newRewrite]);
+  });
+
+  test("accepts a custom allowlist", () => {
+    const allowed = new Set(["qbi-calculator"]);
+    assert.deepEqual(findUnauthorizedZoneRewrites([newRewrite], allowed), []);
+  });
+
+  test("ignores non-array input", () => {
+    assert.deepEqual(findUnauthorizedZoneRewrites(undefined), []);
+    assert.deepEqual(findUnauthorizedZoneRewrites(null), []);
+  });
+});
+
+describe("LEGACY_VERCEL_JSON_ZONE_SLUGS", () => {
+  test("matches the current main snapshot exactly", () => {
+    // If this assertion fails, you've either added a new zone rewrite to
+    // vercel.json (route it through appZoneRoutes.ts instead) or migrated
+    // a legacy one to appZoneRoutes.ts (drop the slug from this set).
+    assert.deepEqual(
+      [...LEGACY_VERCEL_JSON_ZONE_SLUGS].sort(),
+      [
+        "api",
+        "california-wealth-tax",
+        "keep-your-pay-act",
+        "model",
+        "oregon-kicker-refund",
+        "taxsim",
+        "watca",
+      ],
+    );
+  });
+});

--- a/.github/workflows/guard-vercel-zone-rewrites.yml
+++ b/.github/workflows/guard-vercel-zone-rewrites.yml
@@ -1,0 +1,33 @@
+name: Guard vercel.json zone rewrites
+
+on:
+  pull_request:
+    paths:
+      - "vercel.json"
+      - ".github/scripts/guard-vercel-zone-rewrites.mjs"
+      - ".github/scripts/guard-vercel-zone-rewrites.test.mjs"
+      - ".github/workflows/guard-vercel-zone-rewrites.yml"
+  push:
+    branches: [main]
+    paths:
+      - "vercel.json"
+      - ".github/scripts/guard-vercel-zone-rewrites.mjs"
+      - ".github/scripts/guard-vercel-zone-rewrites.test.mjs"
+      - ".github/workflows/guard-vercel-zone-rewrites.yml"
+
+jobs:
+  guard:
+    name: Guard vercel.json zone rewrites
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run guard unit tests
+        run: node --test .github/scripts/guard-vercel-zone-rewrites.test.mjs
+
+      - name: Check vercel.json for unauthorized zone-shaped rewrites
+        run: node .github/scripts/guard-vercel-zone-rewrites.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ External PolicyEngine Next.js apps are stitched into `policyengine.org` as **Nex
 
 `changelog_entry.yaml` gets the user-facing line.
 
-Why not `vercel.json`? The root `vercel.json` still hosts a few legacy zone rewrites and host-only routes (favicons, SPA catch-all), but multizone is the source of truth going forward — new entries in `vercel.json` will collide with the website's own `beforeFiles` ordering and bypass the multizone audit CI. Adding to `appZoneRoutes.ts` is the only path that gets validated by `app-zone-shell-audit` and `multizone-tracking-audit`.
+Why not `vercel.json`? The root `vercel.json` still hosts a few legacy zone rewrites and host-only routes (favicons, SPA catch-all), but multizone is the source of truth going forward — new entries in `vercel.json` will collide with the website's own `beforeFiles` ordering and bypass the multizone audit CI. Adding to `appZoneRoutes.ts` is the only path that gets validated by `app-zone-shell-audit` and `multizone-tracking-audit`. The `guard-vercel-zone-rewrites` workflow fails the PR if a new country-prefixed `*.vercel.app` rewrite slips into `vercel.json`.
 
 Reference PRs to copy from: [#1047 South Carolina 2026](https://github.com/PolicyEngine/policyengine-app-v2/pull/1047), [#1027 multizone apps registry](https://github.com/PolicyEngine/policyengine-app-v2/pull/1027).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,40 +101,34 @@ const PolicyEngineLogo = "/assets/logos/policyengine/white.svg";
 
 ## Embedded sites
 
-### Vercel rewrites (server-side proxy)
+### Next.js multizones (default for all new tools)
 
-Some external apps are served via Vercel rewrites in `vercel.json`, not iframes. This is required for Next.js apps (CSR/SSR) because they render blank in cross-origin iframes.
+External PolicyEngine Next.js apps are stitched into `policyengine.org` as **Next.js multizones**. The website host (`website/next.config.ts`) proxies a public path to the zone's standalone Vercel deployment via `rewrites()`; the zone itself sets a matching `basePath` (or `assetPrefix` for root-served zones) so its `_next/*` assets resolve through the same proxy.
 
-| Route        | Destination                                  | Source repo             |
-| ------------ | -------------------------------------------- | ----------------------- |
-| `/slides/*`  | `policyengine-slides.vercel.app/slides/*`    | `policyengine-slides`   |
-| `/_tracker/*`| `policyengine--state-legislative-tracker...`  | state legislative tracker |
-| `/us/api/*`  | `household-api-docs-policy-engine.vercel.app/us/api/*` | `household-api-docs` |
+**To add a new zone embed, edit two files — and *not* `vercel.json`:**
 
-**Important**: Rewrite rules in `vercel.json` must appear before the SPA catch-all (`{ "source": "/(.*)", "destination": "/website.html" }`), otherwise the catch-all intercepts first.
+1. `website/src/data/appZoneRoutes.ts` — add a `{ source, destination }` entry. `appZoneRewrites` flattens this into the deep-path rewrite pair and feeds `beforeFiles` in `website/next.config.ts`.
+2. The zone repo — set `basePath: '/us/<slug>'` (path-mounted) or `assetPrefix: '/_zones/<slug>'` (root-served). See the `policyengine-interactive-tools` skill / `complete:audit-multizone` for the full rule set.
 
-### GitHub Pages iframes
+`changelog_entry.yaml` gets the user-facing line.
 
-Simple static sites (GitHub Pages) can be embedded via iframes in `app/src/pages/`:
+Why not `vercel.json`? The root `vercel.json` still hosts a few legacy zone rewrites and host-only routes (favicons, SPA catch-all), but multizone is the source of truth going forward — new entries in `vercel.json` will collide with the website's own `beforeFiles` ordering and bypass the multizone audit CI. Adding to `appZoneRoutes.ts` is the only path that gets validated by `app-zone-shell-audit` and `multizone-tracking-audit`.
+
+Reference PRs to copy from: [#1047 South Carolina 2026](https://github.com/PolicyEngine/policyengine-app-v2/pull/1047), [#1027 multizone apps registry](https://github.com/PolicyEngine/policyengine-app-v2/pull/1027).
+
+### GitHub Pages iframes (legacy)
+
+A few static GitHub Pages sites are still embedded via iframes in `app/src/pages/`. Do not add new ones — use multizones.
 
 | Route                             | Component                   | Embed source                                 |
 | --------------------------------- | --------------------------- | -------------------------------------------- |
-| `/:countryId/ai-inequality`       | `AIGrowthResearch.page.tsx` | `policyengine.github.io/ai-inequality`       |
 | `/:countryId/2025-year-in-review` | `YearInReview.page.tsx`     | `policyengine.github.io/2025-year-in-review` |
-
-When renaming an embedded repo:
-
-1. Update the iframe `src` URL in the page component
-2. Update `PUBLIC_URL` in the embedded repo's CI workflow
-3. Search the org for other references: `gh api search/code?q=org:PolicyEngine+OLD_NAME`
 
 CI automatically checks these embed URLs on every push and PR (the `check-embeds` job in `pr.yaml` and `push.yaml`).
 
-### Choosing iframe vs Vercel rewrite
+### Host-only `vercel.json` rewrites
 
-- **Static sites (GitHub Pages)** → iframe works fine
-- **Next.js / CSR apps** → must use Vercel rewrite (Next.js `BAILOUT_TO_CLIENT_SIDE_RENDERING` renders blank in cross-origin iframes)
-- Vercel rewrites don't need React Router routes — the rewrite handles everything server-side
+The root `vercel.json` is still used for host-internal rewrites (favicons, the SPA catch-all, a handful of pre-multizone external proxies). Treat any `/us/*` → `*.vercel.app` shape there as legacy — do not add to it.
 
 ## Before committing
 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     added:
-      - Add South Carolina 2026 tax changes calculator at /us/south-carolina-2026-tax-changes
+      - Add QBI deduction calculator multizone at /us/qbi-calculator

--- a/website/src/data/appZoneRoutes.ts
+++ b/website/src/data/appZoneRoutes.ts
@@ -83,6 +83,11 @@ export const appZoneRoutes: AppZoneRoute[] = [
       "https://south-carolina-2026-tax-changes.vercel.app/us/south-carolina-2026-tax-changes",
   },
   {
+    source: "/us/qbi-calculator",
+    destination:
+      "https://qbi-visualizer.vercel.app/us/qbi-calculator",
+  },
+  {
     source: "/us/watca",
     destination: "https://working-americans-tax-cut-act-one.vercel.app/us/watca",
   },


### PR DESCRIPTION
## Summary

Three coordinated changes that embed the QBI calculator at `policyengine.org/us/qbi-calculator` via the multizone system, and harden the docs + CI so the next PR doesn't repeat the wrong-file mistake this branch initially made:

1. **`website/src/data/appZoneRoutes.ts`** — adds the `/us/qbi-calculator` zone, matching every multizone tool added since #1027.
2. **`CLAUDE.md`** — "Embedded sites" section rewritten to lead with multizone (`appZoneRoutes.ts` + `website/next.config.ts`), demotes `vercel.json` to host-only/legacy with an explicit "do not add to it" line.
3. **`guard-vercel-zone-rewrites` workflow** — defense in depth. Fails any PR that adds a country-prefixed `*.vercel.app` rewrite to `vercel.json` outside a hardcoded legacy allowlist (api, california-wealth-tax, keep-your-pay-act, model, oregon-kicker-refund, taxsim, watca). Unit-tested; the allowlist is asserted exactly so a PR can't quietly grow it.

## Companion PR

Requires PolicyEngine/qbi-visualizer#25, which configures the zone's Next.js `basePath` and renders the PolicyEngine shell. Once both Vercel productions are live, `policyengine.org/us/qbi-calculator` serves the calculator under the standard PE chrome.

## Expected CI state

The `Audit PolicyEngine shell on app-zone routes` check fails on this PR because the destination (`qbi-visualizer.vercel.app`) hasn't been redeployed with the shell yet — qbi-visualizer.vercel.app only deploys from `main`. This matches the precedent on #1047 (South Carolina 2026), which merged with the same failure; the daily cron run of the audit will go green once qbi-visualizer#25 lands.

**Merge order:** qbi-visualizer#25 → wait for its production deploy → this PR.

## Test plan

- [ ] Vercel preview builds
- [ ] `Guard vercel.json zone rewrites` check passes (unit tests + current `vercel.json` scan)
- [ ] After qbi-visualizer#25 deploys, `qbi-visualizer.vercel.app/us/qbi-calculator` renders the PE shell + calculator
- [ ] After this lands, `policyengine.org/us/qbi-calculator` serves the same content
- [ ] Internal routes `/us/qbi-calculator/forms` and `/us/qbi-calculator/law` work
- [ ] API calls to `/us/qbi-calculator/api/*` reach the Modal backend
