### PR TITLE
Rename cliff-watch route to cliffwatch and mirror on UK

### DIFF
--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -255,8 +255,8 @@
   },
   {
     "type": "iframe",
-    "slug": "cliff-watch",
-    "title": "Cliff Watch",
+    "slug": "cliffwatch",
+    "title": "CliffWatch",
     "description": "Interactive calculator showing how benefits, refundable tax credits, taxes, and net income change for US households as earnings rise",
     "source": "https://cliff-watch.vercel.app/",
     "tags": ["us", "featured", "policy", "interactives"],

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -66,6 +66,17 @@ const nextConfig: NextConfig = {
         destination: "/us/california-wealth-tax/:path*",
         permanent: true,
       },
+      // CliffWatch renamed from cliff-watch → cliffwatch
+      {
+        source: "/:countryId/cliff-watch",
+        destination: "/:countryId/cliffwatch",
+        permanent: true,
+      },
+      {
+        source: "/:countryId/cliff-watch/:path*",
+        destination: "/:countryId/cliffwatch/:path*",
+        permanent: true,
+      },
     ];
   },
 

--- a/website/src/data/appZoneRoutes.ts
+++ b/website/src/data/appZoneRoutes.ts
@@ -115,9 +115,14 @@ export const appZoneRoutes: AppZoneRoute[] = [
       "https://coverage-compass-policy-engine.vercel.app/us/coverage-compass",
   },
   {
-    source: "/us/cliff-watch",
+    source: "/us/cliffwatch",
     destination: "https://cliff-watch.vercel.app/",
     deepDestination: "https://cliff-watch.vercel.app/:path*",
+  },
+  {
+    source: "/uk/cliffwatch",
+    destination: "https://cliff-watch.vercel.app/?country=uk",
+    deepDestination: "https://cliff-watch.vercel.app/:path*?country=uk",
   },
   {
     source: "/us/marriage",


### PR DESCRIPTION
## Summary

- `/us/cliffwatch` is now the canonical multizone route (replacing `/us/cliff-watch`).
- `/uk/cliffwatch` mirrors it with `?country=uk` appended (same pattern as `/uk/marriage`), so PolicyEngine.org users on either country prefix land on the cliff-watch app.
- Permanent redirects from `/:countryId/cliff-watch` and `/:countryId/cliff-watch/:path*` preserve every existing inbound link.
- `app/src/data/apps/apps.json`: slug + title updated to `cliffwatch` / `CliffWatch` to match the app's new branding.

## Test plan

- [ ] `/us/cliffwatch` resolves to the cliff-watch deployment.
- [ ] `/uk/cliffwatch` resolves to the same with `?country=uk`.
- [ ] `/us/cliff-watch` and `/uk/cliff-watch` 308-redirect to the new paths.
- [ ] `/us/cliff-watch/about` 308-redirects to `/us/cliffwatch/about`.

## Follow-up

The cliff-watch app currently only models US households. UK display (state → region, county → local authority, currency) is a separate piece of work — for now `/uk/cliffwatch` shows the US wizard.

Refs #1044
