### PR TITLE
Serve 2x assets on retina screens via srcset

### DIFF
--- a/website/src/components/ui/OptimisedImage.tsx
+++ b/website/src/components/ui/OptimisedImage.tsx
@@ -1,4 +1,4 @@
-import type { ImgHTMLAttributes } from 'react';
+import type { ImgHTMLAttributes } from "react";
 
 /**
  * Wraps an <img> to serve images through Vercel's edge image optimisation.
@@ -17,7 +17,10 @@ interface StaticImageData {
   width: number;
 }
 
-interface OptimisedImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'> {
+interface OptimisedImageProps extends Omit<
+  ImgHTMLAttributes<HTMLImageElement>,
+  "src"
+> {
   /** Desired display width in pixels — used for resizing on the edge. */
   width?: number;
   /** Image quality 1–100 (default 80). */
@@ -39,36 +42,22 @@ function snapWidth(w: number): number {
   return ALLOWED_WIDTHS[ALLOWED_WIDTHS.length - 1];
 }
 
-function optimisedSrc(src: string, width?: number, quality = 80): string {
-  // Only optimise local paths served from the same origin
-  if (!src.startsWith('/')) {
-    return src;
-  }
+/**
+ * True when the asset should bypass Vercel's image optimiser (external URLs,
+ * already-optimised Next.js static chunks, SVGs, local dev, or missing width).
+ */
+function shouldSkipOptimisation(src: string, width?: number): boolean {
+  if (!src.startsWith("/")) return true;
+  if (src.startsWith("/_next/")) return true;
+  if (src.endsWith(".svg")) return true;
+  if (process.env.NODE_ENV === "development") return true;
+  if (!width) return true;
+  return false;
+}
 
-  // Skip _next/static paths — already optimized at build time by Next.js
-  if (src.startsWith('/_next/')) {
-    return src;
-  }
-
-  // Skip SVGs — vector images can't be raster-optimized
-  if (src.endsWith('.svg')) {
-    return src;
-  }
-
-  // Skip in dev — Vercel image API isn't available locally
-  if (process.env.NODE_ENV === 'development') {
-    return src;
-  }
-
-  // Vercel's image endpoint requires an explicit width.
-  // Fall back to the original asset path when callers omit one.
-  if (!width) {
-    return src;
-  }
-
-  const dpr = 1;
+function optimisedSrc(src: string, width: number, quality = 80): string {
   const params = new URLSearchParams({ url: src, q: String(quality) });
-  params.set('w', String(snapWidth(Math.round(width * dpr))));
+  params.set("w", String(snapWidth(Math.round(width))));
   return `/_vercel/image?${params}`;
 }
 
@@ -76,12 +65,42 @@ export default function OptimisedImage({
   src,
   width,
   quality = 80,
-  alt = '',
+  alt = "",
   ...rest
 }: OptimisedImageProps) {
   // Resolve Next.js static imports (StaticImageData) to their .src string
-  const rawSrc = typeof src === 'object' && src !== null && 'src' in src ? src.src : src;
-  const resolvedSrc = typeof rawSrc === 'string' ? optimisedSrc(rawSrc, width, quality) : undefined;
+  const rawSrc =
+    typeof src === "object" && src !== null && "src" in src ? src.src : src;
 
-  return <img {...rest} src={resolvedSrc} width={width} loading="lazy" alt={alt} />;
+  if (typeof rawSrc !== "string") {
+    return (
+      <img {...rest} src={undefined} width={width} loading="lazy" alt={alt} />
+    );
+  }
+
+  if (shouldSkipOptimisation(rawSrc, width)) {
+    return (
+      <img {...rest} src={rawSrc} width={width} loading="lazy" alt={alt} />
+    );
+  }
+
+  // width is guaranteed by shouldSkipOptimisation above
+  const w = width!;
+  const src1x = optimisedSrc(rawSrc, w, quality);
+  const src2x = optimisedSrc(rawSrc, w * 2, quality);
+
+  // If 1x and 2x snap to the same allowed width, the browser would download
+  // the same file twice via srcset — skip the descriptor in that case.
+  const srcSet = src1x === src2x ? undefined : `${src1x} 1x, ${src2x} 2x`;
+
+  return (
+    <img
+      {...rest}
+      src={src1x}
+      srcSet={srcSet}
+      width={w}
+      loading="lazy"
+      alt={alt}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- Images across the site appear soft/blurry on retina and high-DPI displays. Cause: `OptimisedImage` hardcoded `dpr = 1`, so an image asked to fill (say) a 640px slot was fetched at 640px of pixel data and then upscaled by the browser to ~1280 physical pixels on every modern laptop and phone.
- Adds a 1x/2x `srcset` so the browser picks the right asset per device. Low-DPI screens keep using the 1x file (no bandwidth waste); high-DPI screens get the sharper 2x.
- When the snapped 1x and 2x widths collide on the same `ALLOWED_WIDTHS` bucket (e.g. `width=1080` → 2x snaps to 1920, but `width=1200` → 2x also snaps to 1920 → same as 1x at the next-higher bucket in some configurations), the `srcset` descriptor is dropped to avoid the browser double-fetching identical files.
- Factored bypass conditions (external URLs, SVGs, `/_next/*`, dev mode, missing width) into `shouldSkipOptimisation()` so the main render branch reads as straight `srcset` construction.

## Affected surfaces
Every consumer of `OptimisedImage` — including:
- Home hero, blog preview cards, tracker preview
- Team page photos
- Research grid and post hero images
- Events page card images
- Citations grid

## Test plan
- [ ] Load `/us` on a retina display and confirm the hero photo and blog preview cards render sharply (compare to before this PR)
- [ ] Open devtools → Network → Img and confirm requests now include `&w=` values at ~2× the rendered width
- [ ] Confirm low-DPI window (devtools device emulation with DPR=1) still requests the smaller `w=` value
- [ ] Confirm SVGs, external URLs, and `/_next/*` paths still fall through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)