### PR TITLE
Proxy UK Python (/uk/python) and API (/uk/api) docs through the website host

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -3,3 +3,5 @@
     added:
       - Add UK Universal Credit rebalancing analysis dashboard at /uk/uc-rebalancing
       - Add UK fuel duty rise cancellation analysis dashboard at /uk/cancelling-fuel-duty-rise
+    changed:
+      - Proxy UK Python package docs at /uk/python and UK API docs at /uk/api so the country-parameterized "Python" and "API" nav links work on UK pages

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -137,6 +137,16 @@ const nextConfig: NextConfig = {
           destination:
             "https://household-api-docs-policy-engine.vercel.app/us/api/:path*",
         },
+        {
+          source: "/uk/api",
+          destination:
+            "https://household-api-docs-policy-engine.vercel.app/uk/api/",
+        },
+        {
+          source: "/uk/api/:path*",
+          destination:
+            "https://household-api-docs-policy-engine.vercel.app/uk/api/:path*",
+        },
         // Python client docs — same household-api-docs deployment, served at top-level /us/python
         {
           source: "/us/python",
@@ -147,6 +157,16 @@ const nextConfig: NextConfig = {
           source: "/us/python/:path*",
           destination:
             "https://household-api-docs-policy-engine.vercel.app/us/python/:path*",
+        },
+        {
+          source: "/uk/python",
+          destination:
+            "https://household-api-docs-policy-engine.vercel.app/uk/python",
+        },
+        {
+          source: "/uk/python/:path*",
+          destination:
+            "https://household-api-docs-policy-engine.vercel.app/uk/python/:path*",
         },
         // Zone asset proxy — API docs uses assetPrefix: '/_zones/household-api-docs'
         {


### PR DESCRIPTION
## Summary

The website's "Python" and "API" nav links are country-parameterized (`/${countryId}/python`, `/${countryId}/api` in `Header.tsx`), but only the **US** variants were proxied through the website host. So on UK pages those links 404'd, even though the upstream `household-api-docs-policy-engine.vercel.app` deployment **already serves correct UK content**.

This PR adds the missing host rewrites in `website/next.config.ts`, mirroring the existing `/us/*` proxies:

- `/uk/api`, `/uk/api/:path*` → `.../uk/api/...`
- `/uk/python`, `/uk/python/:path*` → `.../uk/python`...

No `vercel.json` or `appZoneRoutes.ts` change is needed — these legacy host rewrites follow the same already-passing pattern as `/us/python` and `/us/api`.

## Verification (done before opening)

- **Upstream content is correct UK, not a US copy:** `/uk/python` renders `pip install "policyengine[uk]"`, uses `pe.uk.calculate_household`, GBP, UK regions, Universal Credit — 9 `policyengine-uk` refs, 0 `policyengine-us`. `/uk/api` documents `POST household.api.policyengine.org/uk/calculate`. Both return 200 upstream.
- **Shared asset proxy already covers UK:** the existing `/_zones/household-api-docs/:path*` rewrite serves both countries' `_next` assets (same setup `/us/python` uses in production today).
- **CI guards pass:** `guard-vercel-zone-rewrites` only inspects `vercel.json` (untouched); the multizone-tracking audit fetches `/uk/python` and finds the GA4 bootstrap (`G-2YHG89FY0N`) on the upstream page; `/uk/api` is skipped by the audit's `/api/` rule, identical to `/us/api`.

## Test plan

- [ ] After deploy, visit `/uk/python` and `/uk/api` and confirm they render (not 404).
- [ ] On a UK page, click the "Python" and "API" nav links and confirm they resolve.
- [ ] Confirm `/us/python` and `/us/api` still work (unchanged).

## Follow-ups (out of scope, optional)

- `app/scripts/generate-llms-txt.ts` hardcodes the US package/API link only — could add `policyengine-uk` / `/uk/api` lines.
- `website/src/app/sitemap.ts` lists neither US nor UK docs pages — adding `"api"`/`"python"` to `staticPages` would surface both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)