### PR TITLE
Add chatbot CTA to hero; feature latest UK tools in research banner

### DIFF
--- a/app/src/components/home/HeroCTA.tsx
+++ b/app/src/components/home/HeroCTA.tsx
@@ -3,6 +3,8 @@ import { CALCULATOR_URL } from '@/constants';
 import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 
+const CHAT_URL = 'https://policyengine-uk-chat.vercel.app/';
+
 const ctaVariant = {
   hidden: { opacity: 0, y: 20 },
   visible: {
@@ -11,6 +13,17 @@ const ctaVariant = {
     transition: { duration: 0.6, type: 'spring' as const, stiffness: 80, damping: 18 },
   },
 };
+
+const buttonBase = {
+  display: 'inline-block',
+  padding: `${spacing.lg} ${spacing['3xl']}`,
+  borderRadius: 40,
+  fontFamily: typography.fontFamily.primary,
+  fontWeight: typography.fontWeight.semibold,
+  fontSize: typography.fontSize.lg,
+  textDecoration: 'none',
+  transition: 'box-shadow 0.3s ease',
+} as const;
 
 export default function HeroCTA() {
   const countryId = useCurrentCountry();
@@ -21,7 +34,10 @@ export default function HeroCTA() {
       style={{
         position: 'relative',
         zIndex: 1,
-        textAlign: 'center',
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'center',
+        gap: spacing.md,
       }}
     >
       <motion.a
@@ -29,20 +45,29 @@ export default function HeroCTA() {
         whileHover={{ scale: 1.03 }}
         whileTap={{ scale: 0.98 }}
         style={{
-          display: 'inline-block',
+          ...buttonBase,
           background: colors.primary[500],
           color: colors.white,
-          padding: `${spacing.lg} ${spacing['3xl']}`,
-          borderRadius: 40,
-          fontFamily: typography.fontFamily.primary,
-          fontWeight: typography.fontWeight.semibold,
-          fontSize: typography.fontSize.lg,
-          textDecoration: 'none',
           boxShadow: `0 2px 12px ${colors.primary.alpha[40]}`,
-          transition: 'box-shadow 0.3s ease',
         }}
       >
         Enter PolicyEngine
+      </motion.a>
+
+      <motion.a
+        href={CHAT_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        whileHover={{ scale: 1.03 }}
+        whileTap={{ scale: 0.98 }}
+        style={{
+          ...buttonBase,
+          background: colors.secondary[800],
+          color: colors.white,
+          boxShadow: `0 2px 12px ${colors.shadow.medium}`,
+        }}
+      >
+        Try the AI chatbot
       </motion.a>
     </motion.div>
   );

--- a/app/src/components/shared/FeaturedResearchBanner.tsx
+++ b/app/src/components/shared/FeaturedResearchBanner.tsx
@@ -29,24 +29,24 @@ export default function FeaturedResearchBanner() {
 
   const cards = [
     {
-      href: '/uk/spring-statement-2026',
-      title: 'Spring Statement 2026 analysis',
-      desc: 'New OBR forecast and its effects on UK living standards',
+      href: '/uk/uk-cliff-watch',
+      title: 'UK CliffWatch',
+      desc: 'Where benefit withdrawal and taxes create cliffs and high marginal rates as earnings rise',
     },
     {
-      href: '/uk/research/uk-two-child-limit-reintroduction',
-      title: 'Two-child limit reintroduction',
-      desc: 'Budgetary, distributional, poverty, and inequality impacts across the UK',
+      href: '/uk/cancelling-fuel-duty-rise',
+      title: 'Fuel duty rise cancellation',
+      desc: 'Fiscal cost and household impact of cancelling the Autumn Budget 2025 fuel-duty rise',
     },
     {
-      href: '/uk/uk-salary-sacrifice-tool',
-      title: 'Salary sacrifice cap analysis tool',
-      desc: 'Revenue and distributional impacts of capping pension salary sacrifice',
+      href: '/uk/uc-rebalancing',
+      title: 'Universal Credit rebalancing',
+      desc: 'Household and fiscal impact of the Universal Credit Act 2025 rebalancing package',
     },
     {
-      href: '/uk/uk-student-loan-calculator',
-      title: 'Student loan deductions calculator',
-      desc: 'Repayments, marginal tax rates, and lifetime costs for UK graduates',
+      href: '/uk/energy-price-shock',
+      title: 'Energy price shock',
+      desc: 'Distributional impact of energy price shocks, with five modelled policy responses',
     },
   ];
 


### PR DESCRIPTION
Two homepage updates (UK).

## 1. Hero — second CTA button
Adds a **"Try the AI chatbot"** button next to **"Enter PolicyEngine"**, in a distinct navy colour (`secondary[800]`) so the two read as separate actions. Links to the PolicyEngine UK Chat (`https://policyengine-uk-chat.vercel.app/`), opens in a new tab.

## 2. FeaturedResearchBanner — refresh
Replaces the four UK cards with the latest featured tools, led by **UK CliffWatch**:
1. UK CliffWatch → `/uk/uk-cliff-watch`
2. Fuel duty rise cancellation → `/uk/cancelling-fuel-duty-rise`
3. Universal Credit rebalancing → `/uk/uc-rebalancing`
4. Energy price shock → `/uk/energy-price-shock`

**Note:** the CliffWatch link (`/uk/uk-cliff-watch`) resolves once PolicyEngine/policyengine-app-v2#1071 (the apps.json entry) is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)