### PR TITLE
Add policyengine.org/tutorial (proxy to tutorial site)

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -32,11 +32,6 @@
       "source": "/:countryId/blog",
       "destination": "/:countryId/research",
       "permanent": true
-    },
-    {
-      "source": "/tutorial",
-      "destination": "/tutorial/",
-      "permanent": false
     }
   ],
   "rewrites": [
@@ -121,8 +116,12 @@
       "destination": "https://policyengine-slides.vercel.app/slides/:path*"
     },
     {
+      "source": "/tutorial",
+      "destination": "https://policyengine-tutorial.vercel.app/tutorial"
+    },
+    {
       "source": "/tutorial/:path*",
-      "destination": "https://policyengine-tutorial.vercel.app/:path*"
+      "destination": "https://policyengine-tutorial.vercel.app/tutorial/:path*"
     },
     {
       "source": "/plugin-blog",

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,8 +1,22 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "images": {
-    "sizes": [128, 256, 384, 512, 640, 750, 828, 1080, 1200, 1920],
-    "formats": ["image/avif", "image/webp"],
+    "sizes": [
+      128,
+      256,
+      384,
+      512,
+      640,
+      750,
+      828,
+      1080,
+      1200,
+      1920
+    ],
+    "formats": [
+      "image/avif",
+      "image/webp"
+    ],
     "minimumCacheTTL": 86400
   },
   "installCommand": "cd .. && bun install --frozen-lockfile",
@@ -18,6 +32,11 @@
       "source": "/:countryId/blog",
       "destination": "/:countryId/research",
       "permanent": true
+    },
+    {
+      "source": "/tutorial",
+      "destination": "/tutorial/",
+      "permanent": false
     }
   ],
   "rewrites": [
@@ -100,6 +119,10 @@
     {
       "source": "/slides/:path*",
       "destination": "https://policyengine-slides.vercel.app/slides/:path*"
+    },
+    {
+      "source": "/tutorial/:path*",
+      "destination": "https://policyengine-tutorial.vercel.app/:path*"
     },
     {
       "source": "/plugin-blog",


### PR DESCRIPTION
## What

Serve the PolicyEngine tutorials hub at **policyengine.org/tutorial** by proxying to the `policyengine-tutorial` Vercel project (repo: [PolicyEngine/tutorial](https://github.com/PolicyEngine/tutorial)).

This mirrors the existing external-proxy rewrites in this file (e.g. `/slides`, `/plugin-blog`, `/us/taxsim`).

## Why

The IMA World Congress 2026 PolicyEngine tutorial (Fri 3 Jul) needs a stable, branded URL to share with participants. A subdomain (`tutorial.policyengine.org`) was set up on Vercel but its DNS record can't be added right now, so a path on the apex avoids the DNS dependency entirely.

## Changes (`website/vercel.json`)

- **Redirect** `/tutorial` → `/tutorial/` so the proxied page's relative asset paths resolve correctly.
- **Rewrite** `/tutorial/:path*` → `https://policyengine-tutorial.vercel.app/:path*`.

No app code touched; config only. After merge, https://policyengine.org/tutorial serves the tutorial landing page (and "Open in Colab" links out to the notebook).
