### PR TITLE
[codex] Hide US place geography selectors

### DIFF
--- a/app/src/pages/reportBuilder/modals/PopulationBrowseModal.tsx
+++ b/app/src/pages/reportBuilder/modals/PopulationBrowseModal.tsx
@@ -30,7 +30,6 @@ import {
   getUKCountries,
   getUKLocalAuthorities,
   getUSCongressionalDistricts,
-  getUSPlaces,
   getUSStates,
   RegionOption,
 } from '@/utils/regionStrategies';
@@ -97,7 +96,6 @@ export function PopulationBrowseModal({
     }
     const usStates = getUSStates(regions);
     const usDistricts = getUSCongressionalDistricts(regions);
-    const usPlaces = getUSPlaces(regions);
     return [
       {
         id: 'states' as const,
@@ -111,12 +109,17 @@ export function PopulationBrowseModal({
         count: usDistricts.length,
         regions: usDistricts,
       },
+      // Populace does not yet support place-level simulations. Re-enable this
+      // before launching the simulation API on policyengine.py 4.18.6+ once
+      // place computation is supported.
+      /*
       {
         id: 'places' as const,
         label: 'Cities',
         count: usPlaces.length,
         regions: usPlaces,
       },
+      */
     ];
   }, [countryId, regions]);
 

--- a/app/src/pathways/report/components/geographicOptions/USGeographicOptions.tsx
+++ b/app/src/pathways/report/components/geographicOptions/USGeographicOptions.tsx
@@ -2,7 +2,6 @@ import { Label, RadioGroup, RadioGroupItem } from '@/components/ui';
 import { USScopeType } from '@/types/regionTypes';
 import { RegionOption, US_REGION_TYPES } from '@/utils/regionStrategies';
 import USDistrictSelector from './USDistrictSelector';
-import USPlaceSelector from './USPlaceSelector';
 import USStateSelector from './USStateSelector';
 
 interface USGeographicOptionsProps {
@@ -70,7 +69,9 @@ export default function USGeographicOptions({
         )}
       </div>
 
-      {/* Place (city) option */}
+      {/* Populace does not yet support place-level simulations. Re-enable this
+      before launching the simulation API on policyengine.py 4.18.6+ once place
+      computation is supported.
       <div>
         <div className="tw:flex tw:items-center tw:gap-2">
           <RadioGroupItem value={US_REGION_TYPES.PLACE} id="scope-place" />
@@ -82,6 +83,7 @@ export default function USGeographicOptions({
           </div>
         )}
       </div>
+      */}
 
       {/* Household option */}
       <div className="tw:flex tw:items-center tw:gap-2">

--- a/app/src/tests/unit/pathways/report/components/geographicOptions/USGeographicOptions.test.tsx
+++ b/app/src/tests/unit/pathways/report/components/geographicOptions/USGeographicOptions.test.tsx
@@ -24,7 +24,7 @@ describe('USGeographicOptions', () => {
     } as ReturnType<typeof useRegions>);
   });
 
-  test('given component then renders all scope options', () => {
+  test('given component then renders available scope options', () => {
     // Given
     const onScopeChange = vi.fn();
     const onRegionChange = vi.fn();
@@ -47,7 +47,7 @@ describe('USGeographicOptions', () => {
       screen.getByLabelText('All households in a state or federal district')
     ).toBeInTheDocument();
     expect(screen.getByLabelText('All households in a congressional district')).toBeInTheDocument();
-    expect(screen.getByLabelText('All households in a city')).toBeInTheDocument();
+    expect(screen.queryByLabelText('All households in a city')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Custom household')).toBeInTheDocument();
   });
 
@@ -230,9 +230,8 @@ describe('USGeographicOptions', () => {
     expect(screen.queryByText('Select state')).not.toBeInTheDocument();
   });
 
-  // Place (city) tests
-  describe('place (city) option', () => {
-    test('given component then renders city option with correct label', () => {
+  describe('temporarily hidden place (city) option', () => {
+    test('given component then does not render city option', () => {
       // Given
       const onScopeChange = vi.fn();
       const onRegionChange = vi.fn();
@@ -250,10 +249,10 @@ describe('USGeographicOptions', () => {
       );
 
       // Then
-      expect(screen.getByLabelText('All households in a city')).toBeInTheDocument();
+      expect(screen.queryByLabelText('All households in a city')).not.toBeInTheDocument();
     });
 
-    test('given place scope then place radio is checked', () => {
+    test('given stale place scope then does not show place selector', () => {
       // Given
       const onScopeChange = vi.fn();
       const onRegionChange = vi.fn();
@@ -271,97 +270,8 @@ describe('USGeographicOptions', () => {
       );
 
       // Then
-      expect(screen.getByLabelText('All households in a city')).toBeChecked();
-    });
-
-    test('given place scope then shows place selector', () => {
-      // Given
-      const onScopeChange = vi.fn();
-      const onRegionChange = vi.fn();
-
-      // When
-      render(
-        <USGeographicOptions
-          scope={US_REGION_TYPES.PLACE}
-          selectedRegion=""
-          stateOptions={mockUSStateOptions}
-          districtOptions={mockUSDistrictOptions}
-          onScopeChange={onScopeChange}
-          onRegionChange={onRegionChange}
-        />
-      );
-
-      // Then
-      expect(screen.getByText('Select city')).toBeInTheDocument();
-    });
-
-    test('given national scope then does not show place selector', () => {
-      // Given
-      const onScopeChange = vi.fn();
-      const onRegionChange = vi.fn();
-
-      // When
-      render(
-        <USGeographicOptions
-          scope={US_REGION_TYPES.NATIONAL}
-          selectedRegion=""
-          stateOptions={mockUSStateOptions}
-          districtOptions={mockUSDistrictOptions}
-          onScopeChange={onScopeChange}
-          onRegionChange={onRegionChange}
-        />
-      );
-
-      // Then
+      expect(screen.queryByLabelText('All households in a city')).not.toBeInTheDocument();
       expect(screen.queryByText('Select city')).not.toBeInTheDocument();
-    });
-
-    test('given user clicks place option then calls onScopeChange with place', async () => {
-      // Given
-      const user = userEvent.setup();
-      const onScopeChange = vi.fn();
-      const onRegionChange = vi.fn();
-      render(
-        <USGeographicOptions
-          scope={US_REGION_TYPES.NATIONAL}
-          selectedRegion=""
-          stateOptions={mockUSStateOptions}
-          districtOptions={mockUSDistrictOptions}
-          onScopeChange={onScopeChange}
-          onRegionChange={onRegionChange}
-        />
-      );
-
-      // When
-      await user.click(screen.getByLabelText('All households in a city'));
-
-      // Then
-      expect(onRegionChange).toHaveBeenCalledWith('');
-      expect(onScopeChange).toHaveBeenCalledWith(US_REGION_TYPES.PLACE);
-    });
-
-    test('given user switches from state to place then clears selected region', async () => {
-      // Given
-      const user = userEvent.setup();
-      const onScopeChange = vi.fn();
-      const onRegionChange = vi.fn();
-      render(
-        <USGeographicOptions
-          scope={US_REGION_TYPES.STATE}
-          selectedRegion="state/ca"
-          stateOptions={mockUSStateOptions}
-          districtOptions={mockUSDistrictOptions}
-          onScopeChange={onScopeChange}
-          onRegionChange={onRegionChange}
-        />
-      );
-
-      // When
-      await user.click(screen.getByLabelText('All households in a city'));
-
-      // Then
-      expect(onRegionChange).toHaveBeenCalledWith('');
-      expect(onScopeChange).toHaveBeenCalledWith(US_REGION_TYPES.PLACE);
     });
   });
 });


### PR DESCRIPTION
Fixes #1076

## Summary
- Hide the US place/city selector from the report population scope flow.
- Hide the Cities category from the ReportBuilder population browse modal.
- Leave existing place display and legacy compatibility paths intact.

## Why
Populace-backed US datasets do not yet support place-level computation. This needs to land before launching the simulation API on policyengine.py 4.18.6+ so users cannot newly select place geographies that the new simulation runtime cannot calculate.

Existing reports or saved populations that already point at place geographies may still attempt to calculate and fail; this PR only removes the user-facing selectors for new selections.

## Validation
- npm -w app exec prettier -- --write src/pathways/report/components/geographicOptions/USGeographicOptions.tsx src/pages/reportBuilder/modals/PopulationBrowseModal.tsx
- npm -w app run typecheck
- npm -w app exec eslint -- src/pathways/report/components/geographicOptions/USGeographicOptions.tsx src/pages/reportBuilder/modals/PopulationBrowseModal.tsx