### PR TITLE
Use Populace region scoping in reproduction code

### DIFF
--- a/app/src/tests/unit/utils/reproducibilityCode.test.ts
+++ b/app/src/tests/unit/utils/reproducibilityCode.test.ts
@@ -437,7 +437,7 @@ describe('reproducibilityCode', () => {
         expect(code).toContain('Microsimulation(reform=reform');
       });
 
-      test('given US state region then uses state-specific dataset', () => {
+      test('given default US state region then uses Populace region scoping', () => {
         // When
         const lines = getReproducibilityCodeBlock(
           'policy',
@@ -450,10 +450,15 @@ describe('reproducibilityCode', () => {
         const code = lines.join('\n');
 
         // Then
-        expect(code).toContain('states/CA.h5');
+        expect(code).toContain('import policyengine as pe');
+        expect(code).toContain('from policyengine.core import Simulation');
+        expect(code).toContain('datasets = pe.us.ensure_datasets');
+        expect(code).toContain('region = pe.us.model.region_registry.get("state/ca")');
+        expect(code).toContain('scoping_strategy=region.scoping_strategy');
+        expect(code).not.toContain('states/CA.h5');
       });
 
-      test('given congressional district region then uses district-specific dataset', () => {
+      test('given default congressional district region then uses Populace region scoping', () => {
         // When
         const lines = getReproducibilityCodeBlock(
           'policy',
@@ -466,7 +471,53 @@ describe('reproducibilityCode', () => {
         const code = lines.join('\n');
 
         // Then
-        expect(code).toContain('districts/CA-01.h5');
+        expect(code).toContain('import policyengine as pe');
+        expect(code).toContain('from policyengine.core import Simulation');
+        expect(code).toContain(
+          'region = pe.us.model.region_registry.get("congressional_district/CA-01")'
+        );
+        expect(code).toContain('scoping_strategy=region.scoping_strategy');
+        expect(code).not.toContain('districts/CA-01.h5');
+      });
+
+      test('given default US state region with reform then passes policy dict to scoped simulation', () => {
+        // When
+        const lines = getReproducibilityCodeBlock(
+          'policy',
+          TEST_COUNTRIES.US,
+          REFORM_ONLY_POLICY,
+          TEST_REGIONS.CA_STATE,
+          TEST_YEARS.DEFAULT,
+          null
+        );
+        const code = lines.join('\n');
+
+        // Then
+        expect(code).toContain('reform_policy = {');
+        expect(code).toContain('policy=reform_policy');
+        expect(code).not.toContain('from policyengine_core.reforms import Reform');
+        expect(code).not.toContain('reform = Reform.from_dict(');
+      });
+
+      test('given resolved Populace default dataset for state region then still uses region scoping', () => {
+        // When
+        const lines = getReproducibilityCodeBlock(
+          'policy',
+          TEST_COUNTRIES.US,
+          EMPTY_POLICY,
+          TEST_REGIONS.CA_STATE,
+          TEST_YEARS.DEFAULT,
+          'hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-sparse-l0-refit',
+          null,
+          false,
+          false
+        );
+        const code = lines.join('\n');
+
+        // Then
+        expect(code).toContain('region = pe.us.model.region_registry.get("state/ca")');
+        expect(code).toContain('scoping_strategy=region.scoping_strategy');
+        expect(code).not.toContain('dataset="hf://policyengine/populace-us');
       });
 
       test('given pinned state dataset url then uses it verbatim instead of floating state path', () => {

--- a/app/src/utils/reproducibilityCode.ts
+++ b/app/src/utils/reproducibilityCode.ts
@@ -70,6 +70,23 @@ function getSubnationalDatasetUrl(region: string): string | null {
   return null;
 }
 
+function isDefaultUsScopedRegion(
+  countryId: string,
+  region: string,
+  dataset: string | null,
+  isDefaultDataset: boolean
+): boolean {
+  const isResolvedPopulaceDefault =
+    countryId === 'us' &&
+    typeof dataset === 'string' &&
+    dataset.includes('policyengine/populace-us');
+  return (
+    countryId === 'us' &&
+    (region.startsWith('state/') || region.startsWith('congressional_district/')) &&
+    (!dataset || isDefaultDataset || isResolvedPopulaceDefault)
+  );
+}
+
 /**
  * For place/ regions, get the parent state's dataset URL.
  * "place/NJ-57000" → states/NJ.h5
@@ -136,11 +153,15 @@ function getHeaderCode(
   countryId: string,
   policy: { baseline: { data: any }; reform: { data: any } },
   region: string,
+  dataset: string | null,
+  isDefaultDataset: boolean,
   policyengineVersion: string | null
 ): string[] {
   const lines: string[] = [];
   const packageName = countryId === 'uk' ? 'policyengine_uk' : 'policyengine_us';
   const policyengineExtra = countryId === 'uk' ? 'uk' : 'us';
+  const usesScopedRegion =
+    type === 'policy' && isDefaultUsScopedRegion(countryId, region, dataset, isDefaultDataset);
 
   if (policyengineVersion) {
     lines.push(`%pip install "policyengine[${policyengineExtra}]==${policyengineVersion}"`, '');
@@ -149,12 +170,18 @@ function getHeaderCode(
   // Add lines depending upon type of block
   if (type === 'household') {
     lines.push(`from ${packageName} import Simulation`);
+  } else if (usesScopedRegion) {
+    lines.push('import policyengine as pe');
+    lines.push('from policyengine.core import Simulation');
   } else {
     lines.push(`from ${packageName} import Microsimulation`);
   }
 
   // If either baseline or reform is custom, add the following Python imports
-  if (Object.keys(policy.reform.data).length > 0 || Object.keys(policy.baseline.data).length > 0) {
+  if (
+    !usesScopedRegion &&
+    (Object.keys(policy.reform.data).length > 0 || Object.keys(policy.baseline.data).length > 0)
+  ) {
     lines.push('from policyengine_core.reforms import Reform');
   }
 
@@ -202,6 +229,17 @@ function getReformCode(policy: PolicyData, countryId: string): string[] {
   const lines = [''].concat(jsonStr.split('\n'));
   lines[1] = `reform = Reform.from_dict(${lines[1]}`;
   lines[lines.length - 1] = `${lines[lines.length - 1]}, country_id="${countryId}")`;
+  return lines;
+}
+
+function getPolicyDictCode(policyData: Record<string, any>, variableName: string): string[] {
+  if (Object.keys(policyData).length === 0) {
+    return [];
+  }
+  let jsonStr = JSON.stringify(policyData, null, 2);
+  jsonStr = sanitizeStringToPython(jsonStr);
+  const lines = [''].concat(jsonStr.split('\n'));
+  lines[1] = `${variableName} = ${lines[1]}`;
   return lines;
 }
 
@@ -282,6 +320,10 @@ function getImplementationCode(
   const resolvedDatasetUrl =
     dataset && !isDefaultDataset ? getDatasetUrl(countryId, dataset, year) : null;
 
+  if (isDefaultUsScopedRegion(countryId, region, dataset, isDefaultDataset)) {
+    return getScopedUsRegionImplementationCode(region, year, hasBaseline, hasReform);
+  }
+
   // Place regions use state dataset + place_fips filtering
   if (countryId === 'us' && region.startsWith('place/')) {
     return getPlaceImplementationCode(region, year, hasBaseline, hasReform, resolvedDatasetUrl);
@@ -315,6 +357,42 @@ function getImplementationCode(
     `reformed_income = reformed.calculate("household_net_income", period=${year})`,
     'difference_income = reformed_income - baseline_income',
   ];
+}
+
+function getScopedUsRegionImplementationCode(
+  region: string,
+  year: number,
+  hasBaseline: boolean,
+  hasReform: boolean
+): string[] {
+  const baselinePolicyArg = hasBaseline ? '    policy=baseline_policy,' : '';
+  const reformPolicyArg = hasReform ? '    policy=reform_policy,' : '';
+
+  return [
+    '',
+    '',
+    `datasets = pe.us.ensure_datasets(years=[${year}])`,
+    'dataset = next(iter(datasets.values()))',
+    `region = pe.us.model.region_registry.get("${region}")`,
+    '',
+    'baseline = Simulation(',
+    '    dataset=dataset,',
+    '    tax_benefit_model_version=pe.us.model,',
+    baselinePolicyArg,
+    '    scoping_strategy=region.scoping_strategy,',
+    ')',
+    'reformed = Simulation(',
+    '    dataset=dataset,',
+    '    tax_benefit_model_version=pe.us.model,',
+    reformPolicyArg,
+    '    scoping_strategy=region.scoping_strategy,',
+    ')',
+    'baseline.ensure()',
+    'reformed.ensure()',
+    'baseline_income = baseline.output_dataset.data.household["household_net_income"]',
+    'reformed_income = reformed.output_dataset.data.household["household_net_income"]',
+    'difference_income = reformed_income - baseline_income',
+  ].filter((line) => line !== '');
 }
 
 /**
@@ -374,10 +452,24 @@ export function getReproducibilityCodeBlock(
   isDefaultDataset: boolean = true,
   policyengineVersion: string | null = null
 ): string[] {
+  const usesScopedRegion =
+    type === 'policy' && isDefaultUsScopedRegion(countryId, region, dataset, isDefaultDataset);
   return [
-    ...getHeaderCode(type, countryId, policy, region, policyengineVersion),
-    ...getBaselineCode(policy, countryId),
-    ...getReformCode(policy, countryId),
+    ...getHeaderCode(
+      type,
+      countryId,
+      policy,
+      region,
+      dataset,
+      isDefaultDataset,
+      policyengineVersion
+    ),
+    ...(usesScopedRegion
+      ? getPolicyDictCode(policy.baseline.data, 'baseline_policy')
+      : getBaselineCode(policy, countryId)),
+    ...(usesScopedRegion
+      ? getPolicyDictCode(policy.reform.data, 'reform_policy')
+      : getReformCode(policy, countryId)),
     ...getSituationCode(type, policy, countryId, year, household, earningVariation),
     ...getImplementationCode(type, region, countryId, year, policy, dataset, isDefaultDataset),
   ];


### PR DESCRIPTION
## Summary
- Generate policyengine.py region-scoped reproducibility code for default US state and congressional district runs.
- Stop default state/CD reproduction snippets from pointing to legacy policyengine-us-data split H5 files.
- Preserve explicit pinned dataset URLs for old saved reports that already include a resolved split H5.

## Context
Populace PR #228 is merged and changes the US fiscal release builder so the default `populace_us_2024.h5` is the sparse L0+refit artifact while state/CD analysis should filter the certified national Populace file by region. The calibration evidence is in https://github.com/PolicyEngine/populace/pull/228#issuecomment-4851128150, including the full 32,633-target surface and CD-specific loss comparisons.

## Verification
- `./node_modules/.bin/prettier --write app/src/utils/reproducibilityCode.ts app/src/tests/unit/utils/reproducibilityCode.test.ts`
- `bun run --cwd app vitest src/tests/unit/utils/reproducibilityCode.test.ts`
- `git diff --check`
- `bun run --cwd app typecheck`
- `bun run --cwd app build`
