### PR TITLE
Hide congressional district selection in the report builder

### DIFF
--- a/app/src/pages/reportBuilder/modals/PopulationBrowseModal.tsx
+++ b/app/src/pages/reportBuilder/modals/PopulationBrowseModal.tsx
@@ -29,7 +29,6 @@ import {
   getUKConstituencies,
   getUKCountries,
   getUKLocalAuthorities,
-  getUSCongressionalDistricts,
   getUSStates,
   RegionOption,
 } from '@/utils/regionStrategies';
@@ -95,7 +94,6 @@ export function PopulationBrowseModal({
       ];
     }
     const usStates = getUSStates(regions);
-    const usDistricts = getUSCongressionalDistricts(regions);
     return [
       {
         id: 'states' as const,
@@ -103,12 +101,18 @@ export function PopulationBrowseModal({
         count: usStates.length,
         regions: usStates,
       },
+      // Congressional district selection is disabled for now. Previously created
+      // district-based reports remain viewable; this only hides the option when
+      // creating a new report. Re-enable by restoring the import, the
+      // getUSCongressionalDistricts() call, and this entry.
+      /*
       {
         id: 'districts' as const,
         label: 'Congressional districts',
         count: usDistricts.length,
         regions: usDistricts,
       },
+      */
       // Populace does not yet support place-level simulations. Re-enable this
       // before launching the simulation API on policyengine.py 4.18.6+ once
       // place computation is supported.

--- a/app/src/pages/reportBuilder/modals/PopulationBrowseModal.tsx
+++ b/app/src/pages/reportBuilder/modals/PopulationBrowseModal.tsx
@@ -351,10 +351,9 @@ export function PopulationBrowseModal({
       );
     }
 
-    const allDistricts =
-      countryId === 'us'
-        ? geographyCategories.find((c) => c.id === 'districts')?.regions
-        : undefined;
+    // Congressional district selection is disabled, so there is no district
+    // drill-down data to pass to the browse content.
+    const allDistricts = undefined;
 
     return (
       <PopulationBrowseContent

--- a/app/src/pathways/report/components/geographicOptions/USGeographicOptions.tsx
+++ b/app/src/pathways/report/components/geographicOptions/USGeographicOptions.tsx
@@ -1,7 +1,6 @@
 import { Label, RadioGroup, RadioGroupItem } from '@/components/ui';
 import { USScopeType } from '@/types/regionTypes';
 import { RegionOption, US_REGION_TYPES } from '@/utils/regionStrategies';
-import USDistrictSelector from './USDistrictSelector';
 import USStateSelector from './USStateSelector';
 
 interface USGeographicOptionsProps {
@@ -17,7 +16,6 @@ export default function USGeographicOptions({
   scope,
   selectedRegion,
   stateOptions,
-  districtOptions,
   onScopeChange,
   onRegionChange,
 }: USGeographicOptionsProps) {
@@ -52,7 +50,10 @@ export default function USGeographicOptions({
         )}
       </div>
 
-      {/* Congressional District option */}
+      {/* Congressional district selection is disabled for now. Previously
+      created district-based reports remain viewable; this only hides the option
+      when creating a new report. Re-enable by restoring the USDistrictSelector
+      import, the districtOptions prop, and this block.
       <div>
         <div className="tw:flex tw:items-center tw:gap-2">
           <RadioGroupItem value={US_REGION_TYPES.CONGRESSIONAL_DISTRICT} id="scope-district" />
@@ -68,6 +69,7 @@ export default function USGeographicOptions({
           </div>
         )}
       </div>
+      */}
 
       {/* Populace does not yet support place-level simulations. Re-enable this
       before launching the simulation API on policyengine.py 4.18.6+ once place

--- a/app/src/tests/unit/pathways/report/components/geographicOptions/USGeographicOptions.test.tsx
+++ b/app/src/tests/unit/pathways/report/components/geographicOptions/USGeographicOptions.test.tsx
@@ -46,7 +46,9 @@ describe('USGeographicOptions', () => {
     expect(
       screen.getByLabelText('All households in a state or federal district')
     ).toBeInTheDocument();
-    expect(screen.getByLabelText('All households in a congressional district')).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('All households in a congressional district')
+    ).not.toBeInTheDocument();
     expect(screen.queryByLabelText('All households in a city')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Custom household')).toBeInTheDocument();
   });
@@ -117,7 +119,7 @@ describe('USGeographicOptions', () => {
     expect(screen.queryByText('Select state')).not.toBeInTheDocument();
   });
 
-  test('given congressional_district scope then shows district selector', () => {
+  test('given congressional_district scope then does not show district selector (hidden)', () => {
     // Given
     const onScopeChange = vi.fn();
     const onRegionChange = vi.fn();
@@ -134,8 +136,8 @@ describe('USGeographicOptions', () => {
       />
     );
 
-    // Then - text is now sentence case
-    expect(screen.getByText('Select congressional district')).toBeInTheDocument();
+    // Then - the congressional district option is temporarily hidden
+    expect(screen.queryByText('Select congressional district')).not.toBeInTheDocument();
   });
 
   test('given user clicks state option then calls onScopeChange and clears region', async () => {
@@ -162,9 +164,8 @@ describe('USGeographicOptions', () => {
     expect(onScopeChange).toHaveBeenCalledWith(US_REGION_TYPES.STATE);
   });
 
-  test('given user clicks congressional district option then calls onScopeChange and clears region', async () => {
+  test('given component then does not render congressional district option (hidden)', () => {
     // Given
-    const user = userEvent.setup();
     const onScopeChange = vi.fn();
     const onRegionChange = vi.fn();
     render(
@@ -178,12 +179,10 @@ describe('USGeographicOptions', () => {
       />
     );
 
-    // When
-    await user.click(screen.getByLabelText('All households in a congressional district'));
-
-    // Then
-    expect(onRegionChange).toHaveBeenCalledWith('');
-    expect(onScopeChange).toHaveBeenCalledWith(US_REGION_TYPES.CONGRESSIONAL_DISTRICT);
+    // Then - the congressional district option is temporarily hidden
+    expect(
+      screen.queryByLabelText('All households in a congressional district')
+    ).not.toBeInTheDocument();
   });
 
   test('given user clicks household option then calls onScopeChange with household', async () => {

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -7,3 +7,4 @@
     changed:
       - Proxy UK Python package docs at /uk/python and UK API docs at /uk/api so the country-parameterized "Python" and "API" nav links work on UK pages
       - Align the calculator app header (e.g. /us/reports) with the main website header — hover-open dropdowns, per-item underline, Model dropdown with sub-items, Python link, and Events under About
+      - Hide the congressional district option when choosing a geography for a new report; previously created district-based reports remain viewable


### PR DESCRIPTION
Fixes #1082

## What

Hides the congressional district option when choosing a geography for a **new** report, in both entry points:

- `USGeographicOptions.tsx` — the radio option "All households in a congressional district"
- `PopulationBrowseModal.tsx` — the "Congressional districts" browse category

## Preserving existing reports

This only touches the report **creation** flow. Previously created congressional district-based reports are unaffected — they still load and render normally (the report-output path is separate and untouched here).

## Approach

Mirrors the pattern from #1075 (hide US place selector): the blocks are commented out with a re-enable note rather than deleted, so restoring the option is a one-step revert.

Companion PR (separate): disable the congressional district impact map in US report outputs.
