### PR TITLE
Disable congressional district impact map in US report outputs

### DIFF
--- a/app/src/pages/report-output/MigrationSubPage.tsx
+++ b/app/src/pages/report-output/MigrationSubPage.tsx
@@ -9,7 +9,6 @@ import {
   Stack,
   Text,
 } from '@/components/ui';
-import { CongressionalDistrictDataProvider } from '@/contexts/CongressionalDistrictDataContext';
 import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import type { Geography } from '@/types/ingredients/Geography';
@@ -99,8 +98,9 @@ const DISTRIBUTIONAL_MODE_OPTIONS = [
 
 export default function MigrationSubPage({
   output,
-  report,
-  simulations,
+  // `report` and `simulations` are currently unused because the congressional
+  // district impact map (which needed them) is disabled below; kept on the
+  // props interface so re-enabling that map doesn't change this component's API.
   geographies,
 }: MigrationSubPageProps) {
   const countryId = useCurrentCountry();
@@ -110,13 +110,12 @@ export default function MigrationSubPage({
   const hasLocalLevelGeography = geographies?.some((g) => isUKLocalLevelGeography(g));
   const showUKGeographySections = countryId === 'uk' && !hasLocalLevelGeography;
 
-  // Congressional district provider props
-  const reformPolicyId = simulations?.[1]?.policyId;
-  const baselinePolicyId = simulations?.[0]?.policyId;
-  const year = report?.year;
-  const region = simulations?.[0]?.populationId;
-  const canShowCongressional =
-    countryId === 'us' && !!reformPolicyId && !!baselinePolicyId && !!year;
+  // Congressional district impact map is disabled for now. It rendered on every
+  // US report (recomputed live via CongressionalDistrictDataProvider); existing
+  // reports remain fully viewable without it. To re-enable, restore the provider
+  // wrapper in the return and the CongressionalDistrictDataProvider import, and
+  // derive this from countryId === 'us' && reform && baseline && year.
+  const canShowCongressional = false;
 
   const stackChildren = (
     <>
@@ -165,20 +164,5 @@ export default function MigrationSubPage({
     </>
   );
 
-  return (
-    <Stack gap="xl">
-      {canShowCongressional ? (
-        <CongressionalDistrictDataProvider
-          reformPolicyId={reformPolicyId}
-          baselinePolicyId={baselinePolicyId}
-          year={year}
-          region={region}
-        >
-          {stackChildren}
-        </CongressionalDistrictDataProvider>
-      ) : (
-        stackChildren
-      )}
-    </Stack>
-  );
+  return <Stack gap="xl">{stackChildren}</Stack>;
 }

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -7,3 +7,4 @@
     changed:
       - Proxy UK Python package docs at /uk/python and UK API docs at /uk/api so the country-parameterized "Python" and "API" nav links work on UK pages
       - Align the calculator app header (e.g. /us/reports) with the main website header — hover-open dropdowns, per-item underline, Model dropdown with sub-items, Python link, and Events under About
+      - Hide the congressional district impact map from US report outputs; previously created reports remain viewable


### PR DESCRIPTION
Fixes #1083

## What

Disables the congressional district impact map in US report outputs.

`MigrationSubPage.tsx` rendered a `CongressionalDistrictCard` (a live-fetched by-district choropleth) on **every** US report via `CongressionalDistrictDataProvider`. This gates it off (`canShowCongressional = false`) and drops the provider, so the map — and its live data fetch — no longer appear.

## Preserving existing reports

The map was recomputed live on view and never stored in a report, so nothing is lost from saved reports: previously created reports still open and render every other output — fully viewable, just without the map.

## Notes

- `SocietyWideOverview` is unchanged; it still accepts `showCongressionalCard` (now passed `false`), so re-enabling is a one-line flip plus restoring the provider wrapper (documented inline).
- The non-navigable comparative-analysis district views (`AbsoluteChangeByDistrict` / `RelativeChangeByDistrict`) are not reachable from the UI (empty nav tree) and are left untouched here — happy to remove those too if you'd prefer.

Companion PR (separate): hide the congressional district option in the report-builder selector.
