### PR TITLE
Add /uk/uk-cliff-watch app-zone route

### DIFF
--- a/website/src/data/appZoneRoutes.ts
+++ b/website/src/data/appZoneRoutes.ts
@@ -32,6 +32,11 @@ export const appZoneRoutes: AppZoneRoute[] = [
       "https://scotland-income-tax-reform.vercel.app/uk/scotland-income-tax-reform",
   },
   {
+    source: "/uk/uk-cliff-watch",
+    destination:
+      "https://uk-cliff-watch.vercel.app/uk/uk-cliff-watch",
+  },
+  {
     source: "/us/pe84",
     destination: "https://april-fools-2026-two.vercel.app/us/pe84/calculator",
     deepDestination: "https://april-fools-2026-two.vercel.app/us/pe84/:path*",


### PR DESCRIPTION
## Why

`policyengine.org/uk/uk-cliff-watch` returns **Page not found**.

The UK CliffWatch tool is registered in `apps.json` (slug `uk-cliff-watch`, shown in the research/apps listing), but interactive apps are actually *served* on policyengine.org via the `appZoneRewrites` in `website/next.config.ts` — the website Next.js app has no catch-all app-slug route and does not iframe from `apps.json`. `uk-cliff-watch` was missing from `appZoneRoutes`, so the request fell through to the website app's `not-found` page.

## What

Add the app-zone entry, following the same matching-basePath convention as the other entries (e.g. `scotland-income-tax-reform`):

```ts
{
  source: "/uk/uk-cliff-watch",
  destination: "https://uk-cliff-watch.vercel.app/uk/uk-cliff-watch",
}
```

`withDeepRoute` also generates `/uk/uk-cliff-watch/:path*` → `.../uk/uk-cliff-watch/:path*`, which proxies the app's `/_next` assets.

## ⚠️ Requires a coordinated deploy change in `uk-cliff-watch`

This route proxies to `https://uk-cliff-watch.vercel.app/uk/uk-cliff-watch`, but the deployment **currently serves at root** — its `vercel.json` forces `NEXT_PUBLIC_BASE_PATH: ""`, so it emits `/_next/...` at the root and `…/uk/uk-cliff-watch` 404s. For this rewrite to render (assets included), the `uk-cliff-watch` repo must build under `basePath: /uk/uk-cliff-watch`:

- remove the `NEXT_PUBLIC_BASE_PATH: ""` override in its `vercel.json`, and
- set the `next.config.mjs` production default basePath to `/uk/uk-cliff-watch` (currently `/uk/cliff-watch`).

Until that ships, `/uk/uk-cliff-watch` will proxy to a 404 rather than the site 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)