### PR TITLE
Use automatic congressional district report output

### DIFF
--- a/app/src/api/societyWideCalculation.ts
+++ b/app/src/api/societyWideCalculation.ts
@@ -13,7 +13,7 @@ export interface PolicyEngineBundle {
 
 // NOTE: Need to add other params at later point
 export interface SocietyWideCalculationParams {
-  region: string; // Must include a region; "us" for US nationwide, two-letter state code for US states
+  region: string; // "us" for US nationwide, "state/ca" for US states, or another API v1 region code
   time_period: string; // Four-digit year
   dataset?: string; // Optional dataset parameter; defaults to API's default dataset
 }

--- a/app/src/contexts/congressional-district/CongressionalDistrictDataContext.tsx
+++ b/app/src/contexts/congressional-district/CongressionalDistrictDataContext.tsx
@@ -1,20 +1,10 @@
 /**
  * Congressional District Data Context
  *
- * Provides centralized management of congressional district data fetching.
- * For national reports: Fetches data from all 51 states in parallel on-demand.
- * For state-level reports: Fetches only that state's data automatically on mount.
+ * Provides congressional district label lookup and an optional manual fetch path.
  */
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useReducer,
-  useRef,
-} from 'react';
+import { createContext, useCallback, useContext, useMemo, useReducer, useRef } from 'react';
 import {
   buildDistrictLabelLookup,
   normalizeDistrictId,
@@ -47,12 +37,12 @@ const CongressionalDistrictDataContext =
   createContext<CongressionalDistrictDataContextValue | null>(null);
 
 /**
- * Provider that manages congressional district data fetching.
+ * Provider that manages congressional district label metadata.
  *
- * For national reports: Fetches data from all 51 states in parallel on-demand.
- * For state-level reports: Fetches only that state's data automatically on mount.
+ * For current report output, district data is expected to be included in the
+ * report payload for US national and state-level reports.
  *
- * Stores the raw district data which can be used by multiple visualization components.
+ * Stores manual-fetch district data only when startFetch is explicitly invoked.
  */
 export function CongressionalDistrictDataProvider({
   children,
@@ -182,13 +172,6 @@ export function CongressionalDistrictDataProvider({
       pollState(stateCode, abortController.signal);
     });
   }, [state.hasStarted, stateCodes, pollState]);
-
-  // Auto-start fetching for state-level reports
-  useEffect(() => {
-    if (isStateLevelReport && !state.hasStarted && stateCodes.length > 0) {
-      startFetch();
-    }
-  }, [isStateLevelReport, state.hasStarted, stateCodes.length, startFetch]);
 
   // Compute derived values
   const { completedCount, loadingCount, errorCount, isLoading, isComplete } =

--- a/app/src/contexts/congressional-district/index.ts
+++ b/app/src/contexts/congressional-district/index.ts
@@ -1,8 +1,7 @@
 /**
  * Congressional District Data Context
  *
- * Provides centralized management of congressional district data fetching
- * for both national and state-level reports.
+ * Provides congressional district label lookup and an optional manual fetch path.
  */
 
 export {

--- a/app/src/libs/calculations/economy/SocietyWideCalcStrategy.ts
+++ b/app/src/libs/calculations/economy/SocietyWideCalcStrategy.ts
@@ -21,7 +21,7 @@ export class SocietyWideCalcStrategy implements CalcExecutionStrategy {
     try {
       // Pass the region value AS-IS to the API (NO prefix stripping)
       // For UK: includes prefix like "constituency/Sheffield Central" or "country/england"
-      // For US: just state code like "ca" or "ny"
+      // For US: includes prefix like "state/ca" for state-level reports
       // For National: just country code like "uk" or "us"
       const apiRegion = params.region || params.countryId;
 

--- a/app/src/pages/report-output/ComparativeAnalysisPage.tsx
+++ b/app/src/pages/report-output/ComparativeAnalysisPage.tsx
@@ -22,9 +22,9 @@ import PovertyImpactByRaceSubPage from './poverty-impact/PovertyImpactByRaceSubP
 interface Props {
   output: SocietyWideOutput;
   view?: string;
-  /** Reform policy ID for state-by-state congressional district fetching */
+  /** Reform policy ID retained for optional manual district data fetches */
   reformPolicyId?: string;
-  /** Baseline policy ID for state-by-state congressional district fetching */
+  /** Baseline policy ID retained for optional manual district data fetches */
   baselinePolicyId?: string;
   /** Year for calculations */
   year?: string;
@@ -63,8 +63,8 @@ const VIEW_MAP: Record<string, ComponentType<ViewComponentProps>> = {
  * Sub-router for Comparative Analysis tab - maps :view URL parameter to specific chart components.
  * Acts as a mini-router to keep SocietyWideReportOutput clean as we add 20+ analysis charts.
  *
- * Wraps content with CongressionalDistrictDataProvider so district data is shared
- * between absolute and relative congressional district views.
+ * Wraps content with CongressionalDistrictDataProvider so district label metadata
+ * is shared between congressional district views.
  */
 export function ComparativeAnalysisPage({
   output,
@@ -83,8 +83,8 @@ export function ComparativeAnalysisPage({
   // Render content
   const content = ViewComponent ? <ViewComponent output={output} /> : <NotFoundSubPage />;
 
-  // Wrap with CongressionalDistrictDataProvider if we have the required props
-  // This ensures district data is shared between absolute and relative views
+  // Wrap with CongressionalDistrictDataProvider if we have the required props.
+  // This ensures label metadata is shared between absolute and relative district views.
   if (reformPolicyId && baselinePolicyId && year) {
     return (
       <CongressionalDistrictDataProvider

--- a/app/src/pages/report-output/MigrationSubPage.tsx
+++ b/app/src/pages/report-output/MigrationSubPage.tsx
@@ -97,6 +97,31 @@ const DISTRIBUTIONAL_MODE_OPTIONS = [
   { label: 'Intra-decile impacts', value: 'intra-decile' as DistributionalMode },
 ];
 
+export function canShowCongressionalDistrictImpactCard({
+  countryId,
+  reformPolicyId,
+  baselinePolicyId,
+  year,
+  region,
+}: {
+  countryId: string;
+  reformPolicyId?: string | null;
+  baselinePolicyId?: string | null;
+  year?: string | null;
+  region?: string | null;
+}): boolean {
+  if (countryId !== 'us' || !reformPolicyId || !baselinePolicyId || !year) {
+    return false;
+  }
+
+  if (!region) {
+    return true;
+  }
+
+  const normalizedRegion = region.toLowerCase();
+  return normalizedRegion === 'us' || normalizedRegion.startsWith('state/');
+}
+
 export default function MigrationSubPage({
   output,
   report,
@@ -115,8 +140,13 @@ export default function MigrationSubPage({
   const baselinePolicyId = simulations?.[0]?.policyId;
   const year = report?.year;
   const region = simulations?.[0]?.populationId;
-  const canShowCongressional =
-    countryId === 'us' && !!reformPolicyId && !!baselinePolicyId && !!year;
+  const canShowCongressional = canShowCongressionalDistrictImpactCard({
+    countryId,
+    reformPolicyId,
+    baselinePolicyId,
+    year,
+    region,
+  });
 
   const stackChildren = (
     <>
@@ -169,9 +199,9 @@ export default function MigrationSubPage({
     <Stack gap="xl">
       {canShowCongressional ? (
         <CongressionalDistrictDataProvider
-          reformPolicyId={reformPolicyId}
-          baselinePolicyId={baselinePolicyId}
-          year={year}
+          reformPolicyId={reformPolicyId ?? ''}
+          baselinePolicyId={baselinePolicyId ?? ''}
+          year={year ?? ''}
           region={region}
         >
           {stackChildren}

--- a/app/src/pages/report-output/SocietyWideOverview.tsx
+++ b/app/src/pages/report-output/SocietyWideOverview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   IconChartBar,
   IconCoin,
@@ -13,7 +13,7 @@ import { normalizeDistrictId } from '@/adapters/congressional-district/congressi
 import { SocietyWideReportOutput } from '@/api/societyWideCalculation';
 import DashboardCard from '@/components/report/DashboardCard';
 import MetricCard from '@/components/report/MetricCard';
-import { Group, Progress, SegmentedControl, Stack, Text } from '@/components/ui';
+import { Group, SegmentedControl, Stack, Text } from '@/components/ui';
 import { MapTypeToggle } from '@/components/visualization/choropleth/MapTypeToggle';
 import type { MapVisualizationType } from '@/components/visualization/choropleth/types';
 import { USDistrictChoroplethMap } from '@/components/visualization/USDistrictChoroplethMap';
@@ -441,8 +441,7 @@ function DistrictListColumn({
 
 /**
  * Congressional district card content — must be rendered inside a
- * CongressionalDistrictDataProvider. Starts fetching once the report
- * output is available and no pre-computed district data exists.
+ * CongressionalDistrictDataProvider for district labels and focus metadata.
  */
 function CongressionalDistrictCard({
   output,
@@ -459,17 +458,7 @@ function CongressionalDistrictCard({
   header: React.ReactNode;
   onToggleMode: () => void;
 }) {
-  const {
-    stateResponses,
-    completedCount,
-    totalStates,
-    hasStarted,
-    isLoading,
-    labelLookup,
-    stateCode,
-    startFetch,
-    erroredStates,
-  } = useCongressionalDistrictData();
+  const { labelLookup, stateCode } = useCongressionalDistrictData();
   const [congressionalMode, setCongressionalMode] = useState<CongressionalMode>('absolute');
   const [mapVisualizationType, setMapVisualizationType] =
     useState<MapVisualizationType>('geographic');
@@ -499,76 +488,28 @@ function CongressionalDistrictCard({
         : null,
     [labelLookup, savedDistricts, stateCode]
   );
-  const hasSavedChangeData = savedDistrictAvailability?.hasCompleteCoverage ?? false;
-  const hasSavedWinnerData = savedDistrictAvailability?.hasCompleteWinnerData ?? false;
-  const hasSavedLoserData = savedDistrictAvailability?.hasCompleteLoserData ?? false;
-  const hasSavedOutcomeData = hasSavedWinnerData && hasSavedLoserData;
-  const hasSavedActiveOutcomeData =
-    outcomeMetric === 'winner' ? hasSavedWinnerData : hasSavedLoserData;
-  const needsSavedPayloadRefresh = !savedDistricts || !hasSavedChangeData || !hasSavedOutcomeData;
-
-  // Auto-start fetch when the saved payload is missing districts or missing
-  // either outcome metric, but still let the active mode use any complete
-  // metric-specific saved data that is already available.
-  useEffect(() => {
-    if (needsSavedPayloadRefresh && !hasStarted) {
-      startFetch();
-    }
-  }, [hasStarted, needsSavedPayloadRefresh, startFetch]);
-
-  // Build map data from context (progressive fill as states complete)
-  const changeContextMapData = useMemo(() => {
-    if (stateResponses.size === 0) {
+  const changeMapData = useMemo(() => {
+    if (!savedDistricts) {
       return [];
     }
-    const points: Array<{ geoId: string; label: string; value: number }> = [];
-    stateResponses.forEach((stateData) => {
-      stateData.districts.forEach((district) => {
-        points.push({
-          geoId: district.district,
-          label: labelLookup.get(district.district) ?? `District ${district.district}`,
-          value:
-            changeMetric === 'absolute'
-              ? district.average_household_income_change
-              : district.relative_household_income_change,
-        });
-      });
-    });
-    return points;
-  }, [changeMetric, labelLookup, stateResponses]);
 
-  // Use pre-computed data if available, otherwise progressive context data
-  const changeMapData = useMemo(() => {
-    if (savedDistricts && hasSavedChangeData) {
-      return savedDistricts.map((item) => ({
-        geoId: item.district,
-        label: labelLookup.get(item.district) ?? `District ${item.district}`,
-        value:
-          changeMetric === 'absolute'
-            ? item.average_household_income_change
-            : item.relative_household_income_change,
-      }));
-    }
-    return changeContextMapData;
-  }, [changeContextMapData, changeMetric, hasSavedChangeData, labelLookup, savedDistricts]);
+    return savedDistricts.map((item) => ({
+      geoId: item.district,
+      label: labelLookup.get(item.district) ?? `District ${item.district}`,
+      value:
+        changeMetric === 'absolute'
+          ? item.average_household_income_change
+          : item.relative_household_income_change,
+    }));
+  }, [changeMetric, labelLookup, savedDistricts]);
 
   const payloadOutcomeData = useMemo(() => {
-    if (savedDistricts && hasSavedActiveOutcomeData) {
-      return buildOutcomeMapData(savedDistricts, outcomeMetric, labelLookup);
-    }
-
-    if (stateResponses.size === 0) {
+    if (!savedDistricts) {
       return { points: [], missingCount: 0 };
     }
 
-    const districts: DistrictOutcomePayload[] = [];
-    stateResponses.forEach((stateData) => {
-      stateData.districts.forEach((district) => {
-        districts.push(district);
-      });
-    });
-    return buildOutcomeMapData(districts, outcomeMetric, labelLookup);
-  }, [hasSavedActiveOutcomeData, labelLookup, outcomeMetric, savedDistricts, stateResponses]);
+    return buildOutcomeMapData(savedDistricts, outcomeMetric, labelLookup);
+  }, [labelLookup, outcomeMetric, savedDistricts]);
 
   const mapData = isOutcomeMode ? payloadOutcomeData.points : changeMapData;
   const outcomeDisplayData = payloadOutcomeData.points;
@@ -629,7 +570,7 @@ function CongressionalDistrictCard({
           value: district.value,
         });
       }
-    } else if (savedDistricts && hasSavedChangeData) {
+    } else if (savedDistricts) {
       for (const d of savedDistricts) {
         all.push({
           id: d.district,
@@ -640,31 +581,10 @@ function CongressionalDistrictCard({
               : d.relative_household_income_change,
         });
       }
-    } else {
-      stateResponses.forEach((stateData) => {
-        for (const d of stateData.districts) {
-          all.push({
-            id: d.district,
-            label: toShortLabel(d.district),
-            value:
-              changeMetric === 'absolute'
-                ? d.average_household_income_change
-                : d.relative_household_income_change,
-          });
-        }
-      });
     }
     all.sort((a, b) => b.value - a.value);
     return all;
-  }, [
-    changeMetric,
-    hasSavedChangeData,
-    isOutcomeMode,
-    labelLookup,
-    outcomeDisplayData,
-    savedDistricts,
-    stateResponses,
-  ]);
+  }, [changeMetric, isOutcomeMode, labelLookup, outcomeDisplayData, savedDistricts]);
 
   const top5 = sortedDistricts.slice(0, 5);
   const bottom5 = sortedDistricts.slice(-5).reverse();
@@ -703,9 +623,7 @@ function CongressionalDistrictCard({
     [congressionalMode]
   );
 
-  // Detect errored districts from either source:
-  // 1. Saved report output: districts in labelLookup but missing from savedDistricts
-  // 2. Refreshed state payloads: districts belonging to states in erroredStates
+  // Detect districts that are expected from metadata but missing from the saved report output.
   const savedErrorSummary = useMemo(() => {
     if (!savedDistricts) {
       return { errorDistrictCount: 0, errorStateAbbrs: [] as string[] };
@@ -726,47 +644,9 @@ function CongressionalDistrictCard({
     return { errorDistrictCount: count, errorStateAbbrs: Array.from(missingStates) };
   }, [labelLookup, savedDistrictAvailability, savedDistricts, stateCode]);
 
-  const fetchedErrorSummary = useMemo(() => {
-    const abbrs = Array.from(erroredStates).map((code) =>
-      code.replace(/^state\//, '').toUpperCase()
-    );
-    if (abbrs.length === 0) {
-      return { errorDistrictCount: 0, errorStateAbbrs: abbrs };
-    }
-    const errorSet = new Set(abbrs);
-    let count = 0;
-    labelLookup.forEach((_label, districtId) => {
-      if (errorSet.has(districtId.split('-')[0])) {
-        count++;
-      }
-    });
-    return { errorDistrictCount: count, errorStateAbbrs: abbrs };
-  }, [erroredStates, labelLookup]);
-
-  const activeErrorSummary = useMemo(() => {
-    if (isOutcomeMode) {
-      return hasSavedActiveOutcomeData ? savedErrorSummary : fetchedErrorSummary;
-    }
-
-    return hasSavedChangeData ? savedErrorSummary : fetchedErrorSummary;
-  }, [
-    fetchedErrorSummary,
-    hasSavedActiveOutcomeData,
-    hasSavedChangeData,
-    isOutcomeMode,
-    savedErrorSummary,
-  ]);
-
-  const changeDataReady = Boolean(hasSavedChangeData || (!isLoading && hasStarted));
-  const outcomeDataReady = Boolean(hasSavedActiveOutcomeData || (!isLoading && hasStarted));
-  const dataReady = isOutcomeMode ? outcomeDataReady : changeDataReady;
-  const progressCount = completedCount;
-  const totalCount = totalStates;
-  const progressLabel = 'states';
-  const progressPercent = totalCount > 0 ? Math.round((progressCount / totalCount) * 100) : 0;
   const visibleErrorCount =
-    activeErrorSummary.errorDistrictCount + (isOutcomeMode ? payloadOutcomeData.missingCount : 0);
-  const mapErrorStates = activeErrorSummary.errorStateAbbrs;
+    savedErrorSummary.errorDistrictCount + (isOutcomeMode ? payloadOutcomeData.missingCount : 0);
+  const mapErrorStates = savedErrorSummary.errorStateAbbrs;
 
   return (
     <DashboardCard
@@ -779,21 +659,7 @@ function CongressionalDistrictCard({
       expandedRows={3}
       shrunkenHeader={header}
       shrunkenBody={
-        !dataReady ? (
-          <Stack gap="sm">
-            <Text size="sm" c={colors.text.secondary}>
-              Loading ({progressCount} of {totalCount} {progressLabel})...
-            </Text>
-            <Progress value={progressPercent} />
-            {visibleErrorCount > 0 && (
-              <MetricCard
-                label="Districts with errors"
-                value={visibleErrorCount.toString()}
-                trend="error"
-              />
-            )}
-          </Stack>
-        ) : mapData.length === 0 ? (
+        mapData.length === 0 ? (
           <Stack gap="sm" align="center" justify="center" style={{ height: '100%' }}>
             <Text size="sm" c={colors.text.secondary}>
               No congressional district data available
@@ -914,11 +780,9 @@ function CongressionalDistrictCard({
           ) : (
             <Stack align="center" justify="center" style={{ height: CONGRESSIONAL_MAP_H }}>
               <Text c={colors.text.secondary}>
-                {!dataReady
-                  ? 'Loading congressional district data...'
-                  : isOutcomeMode
-                    ? 'No congressional district outcome data available'
-                    : 'No congressional district data available'}
+                {isOutcomeMode
+                  ? 'No congressional district outcome data available'
+                  : 'No congressional district data available'}
               </Text>
             </Stack>
           )}

--- a/app/src/pages/report-output/congressional-district/AbsoluteChangeByDistrict.tsx
+++ b/app/src/pages/report-output/congressional-district/AbsoluteChangeByDistrict.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { normalizeDistrictId } from '@/adapters/congressional-district/congressionalDistrictDataAdapter';
 import type { SocietyWideReportOutput } from '@/api/societyWideCalculation';
 import { MapDownloadMenu } from '@/components/MapDownloadMenu';
-import { Group, Progress, Stack, Text, Title } from '@/components/ui';
+import { Group, Stack, Text, Title } from '@/components/ui';
 import {
   MapTypeToggle,
   USDistrictChoroplethMap,
@@ -23,27 +23,16 @@ interface AbsoluteChangeByDistrictProps {
  * Displays a geographic choropleth map showing the absolute household income change
  * for each US congressional district in currency terms.
  *
- * Uses shared CongressionalDistrictDataContext for data fetching so that
- * switching between absolute and relative views doesn't trigger re-fetching.
+ * Uses district data included in the report output.
  */
 export function AbsoluteChangeByDistrict({ output }: AbsoluteChangeByDistrictProps) {
   // Map visualization type state (default to geographic)
   const [mapType, setMapType] = useState<MapVisualizationType>('geographic');
   const mapRef = useRef<HTMLDivElement>(null);
 
-  // Get shared district data from context
-  const {
-    stateResponses,
-    completedCount,
-    totalStates,
-    isLoading,
-    hasStarted,
-    labelLookup,
-    stateCode,
-    startFetch,
-  } = useCongressionalDistrictData();
+  const { labelLookup, stateCode } = useCongressionalDistrictData();
 
-  // Check if output already has district data (from nationwide calculation)
+  // Check if output has district data from the report calculation.
   const existingMapData = useMemo(() => {
     if (!('congressional_district_impact' in output)) {
       return [];
@@ -62,39 +51,9 @@ export function AbsoluteChangeByDistrict({ output }: AbsoluteChangeByDistrictPro
     });
   }, [output, labelLookup]);
 
-  // Transform context data to choropleth format (absolute change)
-  const contextMapData = useMemo(() => {
-    if (stateResponses.size === 0) {
-      return [];
-    }
-    const points: Array<{ geoId: string; label: string; value: number }> = [];
-    stateResponses.forEach((stateData) => {
-      stateData.districts.forEach((district) => {
-        points.push({
-          geoId: district.district,
-          label: labelLookup.get(district.district) ?? `District ${district.district}`,
-          value: district.average_household_income_change,
-        });
-      });
-    });
-    return points;
-  }, [stateResponses, labelLookup]);
+  const mapData = existingMapData;
 
-  // Use existing data if available, otherwise use context data
-  const mapData = existingMapData.length > 0 ? existingMapData : contextMapData;
-
-  // Auto-start fetch when component mounts if no existing data
-  useEffect(() => {
-    if (existingMapData.length === 0 && !hasStarted) {
-      startFetch();
-    }
-  }, [existingMapData.length, hasStarted, startFetch]);
-
-  // Calculate progress percentage
-  const progressPercent = totalStates > 0 ? Math.round((completedCount / totalStates) * 100) : 0;
-
-  // No data and not loading
-  if (!mapData.length && !isLoading && !hasStarted) {
+  if (!mapData.length) {
     return (
       <Stack align="center" justify="center" style={{ height: 400 }}>
         <Text c="dimmed">No congressional district data available</Text>
@@ -116,10 +75,6 @@ export function AbsoluteChangeByDistrict({ output }: AbsoluteChangeByDistrictPro
         </Group>
       </Group>
 
-      {/* Show progress while loading */}
-      {isLoading && <Progress value={progressPercent} />}
-
-      {/* Show map if we have any data */}
       {mapData.length > 0 && (
         <USDistrictChoroplethMap
           data={mapData}

--- a/app/src/pages/report-output/congressional-district/RelativeChangeByDistrict.tsx
+++ b/app/src/pages/report-output/congressional-district/RelativeChangeByDistrict.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { normalizeDistrictId } from '@/adapters/congressional-district/congressionalDistrictDataAdapter';
 import type { SocietyWideReportOutput } from '@/api/societyWideCalculation';
 import { MapDownloadMenu } from '@/components/MapDownloadMenu';
-import { Group, Progress, Stack, Text, Title } from '@/components/ui';
+import { Group, Stack, Text, Title } from '@/components/ui';
 import {
   MapTypeToggle,
   USDistrictChoroplethMap,
@@ -23,27 +23,16 @@ interface RelativeChangeByDistrictProps {
  * Displays a geographic choropleth map showing the relative (percentage) household
  * income change for each US congressional district.
  *
- * Uses shared CongressionalDistrictDataContext for data fetching so that
- * switching between absolute and relative views doesn't trigger re-fetching.
+ * Uses district data included in the report output.
  */
 export function RelativeChangeByDistrict({ output }: RelativeChangeByDistrictProps) {
   // Map visualization type state (default to geographic)
   const [mapType, setMapType] = useState<MapVisualizationType>('geographic');
   const mapRef = useRef<HTMLDivElement>(null);
 
-  // Get shared district data from context
-  const {
-    stateResponses,
-    completedCount,
-    totalStates,
-    isLoading,
-    hasStarted,
-    labelLookup,
-    stateCode,
-    startFetch,
-  } = useCongressionalDistrictData();
+  const { labelLookup, stateCode } = useCongressionalDistrictData();
 
-  // Check if output already has district data (from nationwide calculation)
+  // Check if output has district data from the report calculation.
   const existingMapData = useMemo(() => {
     if (!('congressional_district_impact' in output)) {
       return [];
@@ -62,39 +51,9 @@ export function RelativeChangeByDistrict({ output }: RelativeChangeByDistrictPro
     });
   }, [output, labelLookup]);
 
-  // Transform context data to choropleth format (relative change)
-  const contextMapData = useMemo(() => {
-    if (stateResponses.size === 0) {
-      return [];
-    }
-    const points: Array<{ geoId: string; label: string; value: number }> = [];
-    stateResponses.forEach((stateData) => {
-      stateData.districts.forEach((district) => {
-        points.push({
-          geoId: district.district,
-          label: labelLookup.get(district.district) ?? `District ${district.district}`,
-          value: district.relative_household_income_change,
-        });
-      });
-    });
-    return points;
-  }, [stateResponses, labelLookup]);
+  const mapData = existingMapData;
 
-  // Use existing data if available, otherwise use context data
-  const mapData = existingMapData.length > 0 ? existingMapData : contextMapData;
-
-  // Auto-start fetch when component mounts if no existing data
-  useEffect(() => {
-    if (existingMapData.length === 0 && !hasStarted) {
-      startFetch();
-    }
-  }, [existingMapData.length, hasStarted, startFetch]);
-
-  // Calculate progress percentage
-  const progressPercent = totalStates > 0 ? Math.round((completedCount / totalStates) * 100) : 0;
-
-  // No data and not loading
-  if (!mapData.length && !isLoading && !hasStarted) {
+  if (!mapData.length) {
     return (
       <Stack align="center" justify="center" style={{ height: 400 }}>
         <Text c="dimmed">No congressional district data available</Text>
@@ -116,10 +75,6 @@ export function RelativeChangeByDistrict({ output }: RelativeChangeByDistrictPro
         </Group>
       </Group>
 
-      {/* Show progress while loading */}
-      {isLoading && <Progress value={progressPercent} />}
-
-      {/* Show map if we have any data */}
       {mapData.length > 0 && (
         <USDistrictChoroplethMap
           data={mapData}

--- a/app/src/tests/fixtures/pages/congressional-district/congressionalDistrictComponentMocks.ts
+++ b/app/src/tests/fixtures/pages/congressional-district/congressionalDistrictComponentMocks.ts
@@ -61,6 +61,7 @@ export const MOCK_US_REPORT_OUTPUT: ReportOutputSocietyWideUS = {
         winner_percentage: 0.58,
         loser_percentage: 0.27,
         no_change_percentage: 0.15,
+        population: 710000,
       },
       {
         district: 'AL-02',
@@ -69,6 +70,7 @@ export const MOCK_US_REPORT_OUTPUT: ReportOutputSocietyWideUS = {
         winner_percentage: 0.34,
         loser_percentage: 0.49,
         no_change_percentage: 0.17,
+        population: 705000,
       },
       {
         district: 'CA-52',
@@ -77,6 +79,7 @@ export const MOCK_US_REPORT_OUTPUT: ReportOutputSocietyWideUS = {
         winner_percentage: 0.71,
         loser_percentage: 0.18,
         no_change_percentage: 0.11,
+        population: 760000,
       },
       {
         district: 'NY-14',
@@ -85,6 +88,7 @@ export const MOCK_US_REPORT_OUTPUT: ReportOutputSocietyWideUS = {
         winner_percentage: 0.29,
         loser_percentage: 0.56,
         no_change_percentage: 0.15,
+        population: 720000,
       },
       {
         district: 'TX-35',
@@ -93,6 +97,7 @@ export const MOCK_US_REPORT_OUTPUT: ReportOutputSocietyWideUS = {
         winner_percentage: 0.12,
         loser_percentage: 0.13,
         no_change_percentage: 0.75,
+        population: 735000,
       },
     ],
   },

--- a/app/src/tests/unit/api/societyWideCalculation.test.ts
+++ b/app/src/tests/unit/api/societyWideCalculation.test.ts
@@ -306,6 +306,30 @@ describe('societyWide API', () => {
       );
     });
 
+    test('given US state-level params then omits deprecated district breakdown query', async () => {
+      // Given
+      const countryId = TEST_COUNTRIES.US;
+      const reformPolicyId = TEST_POLICY_IDS.REFORM;
+      const baselinePolicyId = TEST_POLICY_IDS.BASELINE;
+      const params = { region: 'state/ca', time_period: CURRENT_YEAR };
+      const mockResponse = mockSuccessResponse(mockCompletedResponse);
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      // When
+      await fetchSocietyWideCalculation(countryId, reformPolicyId, baselinePolicyId, params);
+
+      // Then
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BASE_URL}/${countryId}/economy/${reformPolicyId}/over/${baselinePolicyId}?region=state%2Fca&time_period=${CURRENT_YEAR}`,
+        expect.objectContaining({
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+      expect((global.fetch as any).mock.calls[0][0]).not.toContain('include_district_breakdowns');
+    });
+
     test('given explicit dataset parameter then includes it in URL', async () => {
       // Given
       const countryId = TEST_COUNTRIES.US;

--- a/app/src/tests/unit/contexts/congressional-district/CongressionalDistrictDataContext.test.tsx
+++ b/app/src/tests/unit/contexts/congressional-district/CongressionalDistrictDataContext.test.tsx
@@ -128,12 +128,7 @@ describe('CongressionalDistrictDataContext', () => {
     });
 
     test('given state-level report then isStateLevelReport is true', () => {
-      // Given - mock API to prevent auto-fetch from failing
-      vi.mocked(societyWideApi.fetchSocietyWideCalculation).mockResolvedValue({
-        status: 'ok',
-        result: { congressional_district_impact: { districts: [] } } as any,
-      });
-
+      // Given
       const store = createMockStore(MOCK_REGIONS);
       const wrapper = createWrapper(store, {
         reformPolicyId: '123',
@@ -148,6 +143,7 @@ describe('CongressionalDistrictDataContext', () => {
       // Then
       expect(result.current.isStateLevelReport).toBe(true);
       expect(result.current.stateCode).toBe('ca');
+      expect(societyWideApi.fetchSocietyWideCalculation).not.toHaveBeenCalled();
     });
   });
 
@@ -220,8 +216,8 @@ describe('CongressionalDistrictDataContext', () => {
     });
   });
 
-  describe('state-level auto-fetch', () => {
-    test('given state-level report then auto-starts fetching', async () => {
+  describe('state-level reports', () => {
+    test('given state-level report then does not auto-start fetching', () => {
       // Given
       const mockFetch = vi.mocked(societyWideApi.fetchSocietyWideCalculation);
       mockFetch.mockResolvedValue({
@@ -244,10 +240,9 @@ describe('CongressionalDistrictDataContext', () => {
       // When
       const { result } = renderHook(() => useCongressionalDistrictData(), { wrapper });
 
-      // Then - should auto-start for state-level reports
-      await waitFor(() => {
-        expect(result.current.hasStarted).toBe(true);
-      });
+      // Then
+      expect(result.current.hasStarted).toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 
@@ -274,6 +269,9 @@ describe('CongressionalDistrictDataContext', () => {
 
       // When
       const { result } = renderHook(() => useCongressionalDistrictData(), { wrapper });
+      act(() => {
+        result.current.startFetch();
+      });
 
       // Then
       await waitFor(() => {
@@ -304,6 +302,9 @@ describe('CongressionalDistrictDataContext', () => {
 
       // When
       const { result } = renderHook(() => useCongressionalDistrictData(), { wrapper });
+      act(() => {
+        result.current.startFetch();
+      });
 
       // Then
       await waitFor(() => {
@@ -332,6 +333,9 @@ describe('CongressionalDistrictDataContext', () => {
 
       // When
       const { result } = renderHook(() => useCongressionalDistrictData(), { wrapper });
+      act(() => {
+        result.current.startFetch();
+      });
 
       // Then
       await waitFor(() => {
@@ -366,6 +370,9 @@ describe('CongressionalDistrictDataContext', () => {
 
       // When
       const { result } = renderHook(() => useCongressionalDistrictData(), { wrapper });
+      act(() => {
+        result.current.startFetch();
+      });
 
       // Then
       await waitFor(() => {

--- a/app/src/tests/unit/pages/report-output/MigrationSubPage.test.tsx
+++ b/app/src/tests/unit/pages/report-output/MigrationSubPage.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import MigrationSubPage, {
+  canShowCongressionalDistrictImpactCard,
+} from '@/pages/report-output/MigrationSubPage';
+import { createMockSocietyWideOutput } from '@/tests/fixtures/pages/reportOutputMocks';
+import type { Report } from '@/types/ingredients/Report';
+import type { Simulation } from '@/types/ingredients/Simulation';
+
+const { mockUseCurrentCountry } = vi.hoisted(() => ({
+  mockUseCurrentCountry: vi.fn(),
+}));
+
+vi.mock('@/hooks/useCurrentCountry', () => ({
+  useCurrentCountry: mockUseCurrentCountry,
+}));
+
+vi.mock('@/contexts/CongressionalDistrictDataContext', () => ({
+  CongressionalDistrictDataProvider: vi.fn(({ children }) => (
+    <div data-testid="congressional-provider">{children}</div>
+  )),
+}));
+
+vi.mock('@/pages/report-output/SocietyWideOverview', () => ({
+  default: vi.fn(({ showCongressionalCard }: { showCongressionalCard?: boolean }) => (
+    <div
+      data-testid="society-wide-overview"
+      data-show-congressional={String(!!showCongressionalCard)}
+    />
+  )),
+}));
+
+vi.mock('@/pages/report-output/budgetary-impact/BudgetaryImpactByProgramSubPage', () => ({
+  default: vi.fn(() => <div data-testid="budgetary-impact-by-program" />),
+}));
+
+vi.mock('@/pages/report-output/ConstituencySubPage', () => ({
+  ConstituencySubPage: vi.fn(() => <div data-testid="constituency-impact" />),
+}));
+
+vi.mock('@/pages/report-output/LocalAuthoritySubPage', () => ({
+  LocalAuthoritySubPage: vi.fn(() => <div data-testid="local-authority-impact" />),
+}));
+
+vi.mock(
+  '@/pages/report-output/distributional-impact/DistributionalImpactWealthAverageSubPage',
+  () => ({
+    default: vi.fn(() => <div data-testid="wealth-average" />),
+  })
+);
+
+vi.mock(
+  '@/pages/report-output/distributional-impact/DistributionalImpactWealthRelativeSubPage',
+  () => ({
+    default: vi.fn(() => <div data-testid="wealth-relative" />),
+  })
+);
+
+vi.mock('@/pages/report-output/distributional-impact/WinnersLosersWealthDecileSubPage', () => ({
+  default: vi.fn(() => <div data-testid="wealth-winners-losers" />),
+}));
+
+const report: Report = {
+  id: 'report-1',
+  countryId: 'us',
+  year: '2026',
+  apiVersion: '1.0.0',
+  simulationIds: ['baseline', 'reform'],
+  status: 'complete',
+  outputType: 'economy',
+  output: null,
+};
+
+function simulationsForRegion(region: string): Simulation[] {
+  return [
+    {
+      id: 'baseline',
+      countryId: 'us',
+      label: 'Baseline',
+      policyId: 'baseline-policy',
+      populationId: region,
+      populationType: 'geography',
+      isCreated: true,
+      status: 'complete',
+    },
+    {
+      id: 'reform',
+      countryId: 'us',
+      label: 'Reform',
+      policyId: 'reform-policy',
+      populationId: region,
+      populationType: 'geography',
+      isCreated: true,
+      status: 'complete',
+    },
+  ];
+}
+
+function renderMigrationSubPage(region: string) {
+  mockUseCurrentCountry.mockReturnValue('us');
+  render(
+    <MigrationSubPage
+      output={createMockSocietyWideOutput() as any}
+      report={report}
+      simulations={simulationsForRegion(region)}
+    />
+  );
+}
+
+describe('canShowCongressionalDistrictImpactCard', () => {
+  test.each([
+    ['us', true],
+    ['state/ca', true],
+    ['STATE/UT', true],
+    ['place/CA-44000', false],
+    ['congressional_district/CA-12', false],
+  ])('given US region %s then returns %s', (region, expected) => {
+    expect(
+      canShowCongressionalDistrictImpactCard({
+        countryId: 'us',
+        reformPolicyId: 'reform-policy',
+        baselinePolicyId: 'baseline-policy',
+        year: '2026',
+        region,
+      })
+    ).toBe(expected);
+  });
+
+  test('given non-US country then returns false', () => {
+    expect(
+      canShowCongressionalDistrictImpactCard({
+        countryId: 'uk',
+        reformPolicyId: 'reform-policy',
+        baselinePolicyId: 'baseline-policy',
+        year: '2026',
+        region: 'uk',
+      })
+    ).toBe(false);
+  });
+});
+
+describe('MigrationSubPage congressional district card gating', () => {
+  test.each(['us', 'state/ca'])(
+    'given %s report then shows congressional district card',
+    (region) => {
+      renderMigrationSubPage(region);
+
+      expect(screen.getByTestId('congressional-provider')).toBeInTheDocument();
+      expect(screen.getByTestId('society-wide-overview')).toHaveAttribute(
+        'data-show-congressional',
+        'true'
+      );
+    }
+  );
+
+  test.each(['place/CA-44000', 'congressional_district/CA-12'])(
+    'given %s report then hides congressional district card',
+    (region) => {
+      renderMigrationSubPage(region);
+
+      expect(screen.queryByTestId('congressional-provider')).not.toBeInTheDocument();
+      expect(screen.getByTestId('society-wide-overview')).toHaveAttribute(
+        'data-show-congressional',
+        'false'
+      );
+    }
+  );
+});

--- a/app/src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
@@ -368,7 +368,7 @@ describe('SocietyWideOverview', () => {
     ).toBe(false);
   });
 
-  test('saved districts without outcome shares trigger a same-payload refresh', () => {
+  test('saved districts without outcome shares do not trigger a refresh', () => {
     const startFetch = vi.fn();
     mockUseCongressionalDistrictData.mockReturnValue(
       createCongressionalDistrictContextMock({ startFetch })
@@ -388,7 +388,7 @@ describe('SocietyWideOverview', () => {
 
     render(<SocietyWideOverview output={output as any} showCongressionalCard />);
 
-    expect(startFetch).toHaveBeenCalledTimes(1);
+    expect(startFetch).not.toHaveBeenCalled();
   });
 
   test('saved districts with outcome shares do not trigger a refresh', () => {
@@ -416,7 +416,7 @@ describe('SocietyWideOverview', () => {
     expect(startFetch).not.toHaveBeenCalled();
   });
 
-  test('saved districts with complete winner shares but missing loser shares still trigger a refresh', () => {
+  test('saved districts with complete winner shares but missing loser shares do not trigger a refresh', () => {
     const startFetch = vi.fn();
     mockUseCongressionalDistrictData.mockReturnValue(
       createCongressionalDistrictContextMock({
@@ -449,10 +449,10 @@ describe('SocietyWideOverview', () => {
 
     render(<SocietyWideOverview output={output as any} showCongressionalCard />);
 
-    expect(startFetch).toHaveBeenCalledTimes(1);
+    expect(startFetch).not.toHaveBeenCalled();
   });
 
-  test('truncated saved districts trigger a same-payload refresh', () => {
+  test('truncated saved districts do not trigger a refresh', () => {
     const startFetch = vi.fn();
     mockUseCongressionalDistrictData.mockReturnValue(
       createCongressionalDistrictContextMock({
@@ -480,6 +480,6 @@ describe('SocietyWideOverview', () => {
 
     render(<SocietyWideOverview output={output as any} showCongressionalCard />);
 
-    expect(startFetch).toHaveBeenCalledTimes(1);
+    expect(startFetch).not.toHaveBeenCalled();
   });
 });

--- a/app/src/tests/unit/pages/report-output/congressional-district/AbsoluteChangeByDistrict.test.tsx
+++ b/app/src/tests/unit/pages/report-output/congressional-district/AbsoluteChangeByDistrict.test.tsx
@@ -42,18 +42,18 @@ describe('AbsoluteChangeByDistrict', () => {
     ).toBeInTheDocument();
   });
 
-  test('given no district data in output but context started then shows title', () => {
-    // Given - output has no district data, but context mock has hasStarted: true
-    // so component will show title (loading or complete state, not "no data" message)
+  test('given no district data in output then shows unavailable state', () => {
+    // Given
     const output = MOCK_US_REPORT_OUTPUT_NO_DISTRICT;
 
     // When
     render(<AbsoluteChangeByDistrict output={output} />);
 
-    // Then - shows title since context has started (would show progress or map)
+    // Then
+    expect(screen.getByText('No congressional district data available')).toBeInTheDocument();
     expect(
-      screen.getByText('Absolute household income change by congressional district')
-    ).toBeInTheDocument();
+      screen.queryByText('Absolute household income change by congressional district')
+    ).not.toBeInTheDocument();
   });
 
   test('given district data then renders choropleth map', () => {

--- a/app/src/tests/unit/pages/report-output/congressional-district/RelativeChangeByDistrict.test.tsx
+++ b/app/src/tests/unit/pages/report-output/congressional-district/RelativeChangeByDistrict.test.tsx
@@ -42,18 +42,18 @@ describe('RelativeChangeByDistrict', () => {
     ).toBeInTheDocument();
   });
 
-  test('given no district data in output but context started then shows title', () => {
-    // Given - output has no district data, but context mock has hasStarted: true
-    // so component will show title (loading or complete state, not "no data" message)
+  test('given no district data in output then shows unavailable state', () => {
+    // Given
     const output = MOCK_US_REPORT_OUTPUT_NO_DISTRICT;
 
     // When
     render(<RelativeChangeByDistrict output={output} />);
 
-    // Then - shows title since context has started (would show progress or map)
+    // Then
+    expect(screen.getByText('No congressional district data available')).toBeInTheDocument();
     expect(
-      screen.getByText('Relative household income change by congressional district')
-    ).toBeInTheDocument();
+      screen.queryByText('Relative household income change by congressional district')
+    ).not.toBeInTheDocument();
   });
 
   test('given district data then renders choropleth map', () => {

--- a/app/src/types/metadata/ReportOutputSocietyWideByCongressionalDistrict.ts
+++ b/app/src/types/metadata/ReportOutputSocietyWideByCongressionalDistrict.ts
@@ -28,6 +28,9 @@ export interface USCongressionalDistrictBreakdownItem {
 
   /** Share of people in the district with effectively no income change, as a decimal */
   no_change_percentage?: number;
+
+  /** Population represented by the district result */
+  population?: number;
 }
 
 /**

--- a/app/src/types/metadata/ReportOutputSocietyWideByCongressionalDistrict.ts
+++ b/app/src/types/metadata/ReportOutputSocietyWideByCongressionalDistrict.ts
@@ -36,8 +36,9 @@ export interface USCongressionalDistrictBreakdownItem {
 /**
  * Complete congressional district-level breakdown for US economy-wide reports
  *
- * Contains impact data for all 436 congressional districts (435 voting + DC).
- * This is returned as part of US society-wide report output.
+ * Contains impact data for every congressional district in the report scope.
+ * Nationwide reports contain all 436 congressional districts (435 voting + DC);
+ * state-level reports contain the selected state's districts.
  *
  * @example
  * ```typescript
@@ -45,12 +46,12 @@ export interface USCongressionalDistrictBreakdownItem {
  *   districts: [
  *     { district: 'AL-01', average_household_income_change: 312.45, relative_household_income_change: 0.0187 },
  *     { district: 'AL-02', average_household_income_change: -45.30, relative_household_income_change: -0.0028 },
- *     // ... 436 total
+ *     // ... additional districts in the requested report scope
  *   ]
  * };
  * ```
  */
 export interface USCongressionalDistrictBreakdown {
-  /** Array of impact data for all congressional districts */
+  /** Array of impact data for congressional districts in the report scope */
   districts: USCongressionalDistrictBreakdownItem[];
 }


### PR DESCRIPTION
Fixes #1088.

Summary:
- Removes automatic fallback polling for congressional district maps and uses `congressional_district_impact` from report output.
- Keeps the district context for label/focus metadata and optional manual fetching only.
- Adds `population` to the district report output type and verifies requests do not send deprecated district-breakdown query keys.

Merge dependencies:
- Requires PolicyEngine/policyengine-api-v2#618 to be fully merged before this PR merges.
- Requires PolicyEngine/policyengine-api#3726 to be fully merged before this PR merges.

Verification:
- `bun run vitest src/tests/unit/api/societyWideCalculation.test.ts src/tests/unit/contexts/congressional-district/CongressionalDistrictDataContext.test.tsx src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx src/tests/unit/pages/report-output/congressional-district/AbsoluteChangeByDistrict.test.tsx src/tests/unit/pages/report-output/congressional-district/RelativeChangeByDistrict.test.tsx`
- `bun run typecheck`
- `bun run lint`
- `bun run prettier`