### PR TITLE
Re-land /policybench vanity redirect on app-v2

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -5,6 +5,7 @@
       - Add the Introducing PolicyBench research post
       - Add UK Universal Credit rebalancing analysis dashboard at /uk/uc-rebalancing
       - Add UK fuel duty rise cancellation analysis dashboard at /uk/cancelling-fuel-duty-rise
+      - Redirect the /policybench and /:countryId/policybench vanity paths to policybench.org
     changed:
       - Proxy UK Python package docs at /uk/python and UK API docs at /uk/api so the country-parameterized "Python" and "API" nav links work on UK pages
       - Align the calculator app header (e.g. /us/reports) with the main website header — hover-open dropdowns, per-item underline, Model dropdown with sub-items, Python link, and Events under About

--- a/vercel.json
+++ b/vercel.json
@@ -23,6 +23,16 @@
       "source": "/pe84",
       "destination": "/us/pe84",
       "permanent": false
+    },
+    {
+      "source": "/policybench",
+      "destination": "https://policybench.org",
+      "permanent": false
+    },
+    {
+      "source": "/:countryId/policybench",
+      "destination": "https://policybench.org",
+      "permanent": false
     }
   ],
   "rewrites": [

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -84,6 +84,19 @@ const nextConfig: NextConfig = {
         destination: "/us/pe84",
         permanent: true,
       },
+      // Vanity redirects to the standalone PolicyBench site (external).
+      // policybench.org is country-agnostic, so both the bare and
+      // country-prefixed paths land on its root.
+      {
+        source: "/policybench",
+        destination: "https://policybench.org",
+        permanent: false,
+      },
+      {
+        source: "/:countryId/policybench",
+        destination: "https://policybench.org",
+        permanent: false,
+      },
       {
         source: "/uk/ads-dashboard",
         destination: "/us/ads-dashboard",

--- a/website/src/__tests__/config/next-config.test.ts
+++ b/website/src/__tests__/config/next-config.test.ts
@@ -53,6 +53,14 @@ async function getBeforeFileRewrites() {
   return rewrites.beforeFiles ?? [];
 }
 
+async function getRedirects() {
+  if (!nextConfig.redirects) {
+    throw new Error("Expected Next config to define redirects.");
+  }
+
+  return nextConfig.redirects();
+}
+
 describe("nextConfig rewrites", () => {
   test("serves PolicyEngine icon fallbacks before app-zone proxies", async () => {
     const beforeFiles = await getBeforeFileRewrites();
@@ -66,5 +74,27 @@ describe("nextConfig rewrites", () => {
         (rewrite) => rewrite.source === "/us/tanf-calculator",
       ),
     ).toBeGreaterThan(expectedPolicyEngineIconRewrites.length - 1);
+  });
+});
+
+describe("nextConfig redirects", () => {
+  test("redirects the bare /policybench vanity path to policybench.org", async () => {
+    const redirects = await getRedirects();
+
+    expect(redirects).toContainEqual({
+      source: "/policybench",
+      destination: "https://policybench.org",
+      permanent: false,
+    });
+  });
+
+  test("redirects the country-prefixed /policybench vanity path to policybench.org", async () => {
+    const redirects = await getRedirects();
+
+    expect(redirects).toContainEqual({
+      source: "/:countryId/policybench",
+      destination: "https://policybench.org",
+      permanent: false,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Re-lands the `/policybench` vanity redirect on **app-v2**, part of the v1 → v2 wind-down content-rescue sweep.

The `/policybench` and `/:countryId/policybench` → policybench.org vanity redirects were added to **policyengine-app (v1)** in [#2842](https://github.com/PolicyEngine/policyengine-app/pull/2842), merged 2026-06-16 — **after** app-v2 took over serving `policyengine.org` (the domain shift landed 2026-03-30; v1 moved to `legacy.policyengine.org`). So the redirect never went live. Both paths **404 on production today**:

```
$ curl -sIL https://www.policyengine.org/policybench      → 404
$ curl -sIL https://www.policyengine.org/us/policybench   → 404
```

(The PolicyBench launch blog post from the same launch kit, [#2841](https://github.com/PolicyEngine/policyengine-app/pull/2841), is **not affected** — it was independently landed on v2 and is live at [/us/research/introducing-policybench](https://policyengine.org/us/research/introducing-policybench).)

## Changes

- **`website/next.config.ts`** `redirects()` — the authoritative layer. Verified that `/pe84` resolves here on prod (`308 → /us/pe84`), so this is where the redirect must live to take effect.
- **`vercel.json`** (root) — mirror the redirect, matching how `/pe84` exists in **both** layers during the ongoing Vite→Next migration.
- **`website/src/__tests__/config/next-config.test.ts`** — assert both redirect entries resolve to `policybench.org`.
- **`changelog_entry.yaml`** — user-facing line.

## Design notes

- **External destination, `permanent: false` (307)** — matches the `/pe84` root-`vercel.json` entry. Avoids browsers hard-caching a cross-domain jump if the vanity target ever moves. (v1 used `window.location.replace`, i.e. temporary semantics, so this preserves intent.)
- `policybench.org` is country-agnostic, so both the bare and country-prefixed paths land on its root — same behavior as v1's `ExternalRedirect`.
- Not a country-prefixed `*.vercel.app` zone rewrite, so the `guard-vercel-zone-rewrites` check is satisfied (verified locally: "no unauthorized zone-shaped rewrites").

## Local checks

- `next-config.test.ts` — 3 pass (2 new)
- `typecheck` — clean
- `lint` — exit 0
- `prettier --check` — clean
- `vercel.json` — valid JSON
- `guard-vercel-zone-rewrites` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
