### PR TITLE
Proxy the AI beliefs research dashboard at /ai-beliefs

### DIFF
--- a/.github/scripts/audit-app-zone-shell.mjs
+++ b/.github/scripts/audit-app-zone-shell.mjs
@@ -47,12 +47,14 @@ const TOP_SHELL_SELECTOR =
 //   /us/obbba-household-explorer    — PolicyEngine/obbba-household-by-household#240
 //   /uk/uc-rebalancing              — PolicyEngine/uc-rebalancing
 //   /uk/cancelling-fuel-duty-rise   — PolicyEngine/cancelling-fuel-duty-rise
+//   /ai-beliefs                     — PolicyEngine/llm-econ-beliefs
 export const SHELL_BRAND_EXEMPT_SOURCES = [
   "/uk/scotland-income-tax-reform",
   "/uk/student-loan-visualisation",
   "/us/obbba-household-explorer",
   "/uk/uc-rebalancing",
   "/uk/cancelling-fuel-duty-rise",
+  "/ai-beliefs",
 ];
 
 export function isShellBrandExempt(source) {
@@ -122,7 +124,9 @@ export function extractRoutes(source) {
       /deepDestination:\s*"([^"]+)"/,
     )?.[1];
     if (!sourcePath) continue;
-    if (SKIP_IF_DESTINATION_CONTAINS.some((part) => destination.includes(part))) {
+    if (
+      SKIP_IF_DESTINATION_CONTAINS.some((part) => destination.includes(part))
+    ) {
       continue;
     }
 
@@ -309,9 +313,13 @@ async function discoverSitemapRoutes(
   allowDestinationFallback,
   maxSitemapRoutes,
 ) {
-  const sitemapUrls = [appendPath(resolveUrl(baseUrl, route.source), "/sitemap.xml")];
+  const sitemapUrls = [
+    appendPath(resolveUrl(baseUrl, route.source), "/sitemap.xml"),
+  ];
   if (allowDestinationFallback) {
-    sitemapUrls.push(appendPath(resolveUrl(baseUrl, route.destination), "/sitemap.xml"));
+    sitemapUrls.push(
+      appendPath(resolveUrl(baseUrl, route.destination), "/sitemap.xml"),
+    );
   }
 
   const discovered = new Map();
@@ -322,7 +330,8 @@ async function discoverSitemapRoutes(
 
     for (const loc of extractSitemapLocs(xml)) {
       const source = sourcePathFromSitemapLoc(loc, route, baseUrl);
-      if (!source || source === route.source || discovered.has(source)) continue;
+      if (!source || source === route.source || discovered.has(source))
+        continue;
 
       discovered.set(source, {
         source,
@@ -396,7 +405,11 @@ export function inspectTopShellData(
       continue;
     }
 
-    parts.push(element.textContent ?? "", element.ariaLabel ?? "", element.alt ?? "");
+    parts.push(
+      element.textContent ?? "",
+      element.ariaLabel ?? "",
+      element.alt ?? "",
+    );
   }
 
   const text = parts.join("\n").replace(/\s+/g, " ").trim();
@@ -444,10 +457,16 @@ async function inspectShell(page, url, timeout, enforceShell = true) {
       waitUntil: "domcontentloaded",
       timeout,
     });
-    await page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => {});
+    await page
+      .waitForLoadState("networkidle", { timeout: 10000 })
+      .catch(() => {});
     await page.waitForTimeout(500);
   } catch (error) {
-    return { ok: false, status: null, reason: `navigation failed: ${error.message}` };
+    return {
+      ok: false,
+      status: null,
+      reason: `navigation failed: ${error.message}`,
+    };
   }
 
   const status = response?.status() ?? null;
@@ -455,9 +474,10 @@ async function inspectShell(page, url, timeout, enforceShell = true) {
     return { ok: false, status, reason: `HTTP ${status}` };
   }
 
-  const bodyText = await page.locator("body").innerText({ timeout: 5000 }).catch(
-    () => "",
-  );
+  const bodyText = await page
+    .locator("body")
+    .innerText({ timeout: 5000 })
+    .catch(() => "");
   if (bodyText.trim().length < 50) {
     return { ok: false, status, reason: "empty or nearly empty page" };
   }
@@ -503,7 +523,13 @@ async function inspectShell(page, url, timeout, enforceShell = true) {
   return { ok: true, status, reason: "PolicyEngine shell present" };
 }
 
-async function auditRoute(browser, route, baseUrl, timeout, allowDestinationFallback) {
+async function auditRoute(
+  browser,
+  route,
+  baseUrl,
+  timeout,
+  allowDestinationFallback,
+) {
   const page = await browser.newPage({
     viewport: { width: 1440, height: 1000 },
     userAgent: "policyengine-app-zone-shell-audit/1.0",
@@ -546,9 +572,8 @@ async function runWithConcurrency(items, concurrency, worker) {
   }
 
   await Promise.all(
-    Array.from(
-      { length: Math.min(concurrency, items.length) },
-      () => runWorker(),
+    Array.from({ length: Math.min(concurrency, items.length) }, () =>
+      runWorker(),
     ),
   );
   return results;
@@ -591,7 +616,9 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
     maxSitemapRoutes,
   );
 
-  console.log(`Auditing ${routes.length} app-zone route(s) for PolicyEngine shell.`);
+  console.log(
+    `Auditing ${routes.length} app-zone route(s) for PolicyEngine shell.`,
+  );
   console.log(`Base URL: ${baseUrl}\n`);
   if (routes.length > baseRoutes.length) {
     console.log(
@@ -601,37 +628,47 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
 
   const { chromium } = await import("playwright");
   const browser = await chromium.launch();
-  const results = await runWithConcurrency(routes, concurrency, async (route) => {
-    const result = await auditRoute(
-      browser,
-      route,
-      baseUrl,
-      timeout,
-      allowDestinationFallback,
-    );
-    const mark = result.ok ? (result.exempt ? "SKIP" : "OK") : "FAIL";
-    console.log(`${mark} ${result.source}`);
-    console.log(`    ${result.reason}`);
-    if (result.usedFallback) {
-      console.log("    tested destination directly because source returned 404");
-    }
-    if (result.discoveredFromSitemap) {
-      console.log(`    discovered from ${result.discoveredFromSitemap}`);
-    }
-    if (result.testedUrl !== result.sourceUrl) {
-      console.log(`    tested ${result.testedUrl}`);
-    }
-    return result;
-  });
+  const results = await runWithConcurrency(
+    routes,
+    concurrency,
+    async (route) => {
+      const result = await auditRoute(
+        browser,
+        route,
+        baseUrl,
+        timeout,
+        allowDestinationFallback,
+      );
+      const mark = result.ok ? (result.exempt ? "SKIP" : "OK") : "FAIL";
+      console.log(`${mark} ${result.source}`);
+      console.log(`    ${result.reason}`);
+      if (result.usedFallback) {
+        console.log(
+          "    tested destination directly because source returned 404",
+        );
+      }
+      if (result.discoveredFromSitemap) {
+        console.log(`    discovered from ${result.discoveredFromSitemap}`);
+      }
+      if (result.testedUrl !== result.sourceUrl) {
+        console.log(`    tested ${result.testedUrl}`);
+      }
+      return result;
+    },
+  );
   await browser.close();
 
   const failures = results.filter((result) => !result.ok);
   const exempt = results.filter((result) => result.exempt);
   const enforced = results.length - exempt.length;
-  console.log(`\n${enforced - failures.length}/${enforced} enforced app-zone routes have the PolicyEngine shell.`);
+  console.log(
+    `\n${enforced - failures.length}/${enforced} enforced app-zone routes have the PolicyEngine shell.`,
+  );
 
   if (exempt.length > 0) {
-    console.log(`\n${exempt.length} route(s) skipped the PolicyEngine shell brand/nav check (loaded OK, header intentionally omitted):`);
+    console.log(
+      `\n${exempt.length} route(s) skipped the PolicyEngine shell brand/nav check (loaded OK, header intentionally omitted):`,
+    );
     for (const route of exempt) {
       console.log(`  - ${route.source}`);
     }
@@ -644,8 +681,12 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
       console.error(`    source: ${failure.sourceUrl}`);
       console.error(`    destination: ${failure.destination}`);
     }
-    console.error("\nChild apps served through policyengine.org should render the");
-    console.error("PolicyEngine header/nav themselves. Multizone rewrites do not");
+    console.error(
+      "\nChild apps served through policyengine.org should render the",
+    );
+    console.error(
+      "PolicyEngine header/nav themselves. Multizone rewrites do not",
+    );
     console.error("inject the parent app shell into the child response.");
     return 1;
   }

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -3,14 +3,12 @@
     added:
       - Add SMF citation on AI and junior hiring, which cites PolicyEngine UK's estimate for extending the employer NI exemption to age 25
       - Add the Introducing PolicyBench research post
-<<<<<<< HEAD
       - Add the "How we used Claude Code to apply for the Public Benefit Innovation Fund" research post
-=======
       - Add the "Expansion of free childcare hours" UK research post covering the 2023 extended childcare entitlement reform
->>>>>>> c2295c02 (Add "Expansion of free childcare hours" UK research post)
       - Add UK Universal Credit rebalancing analysis dashboard at /uk/uc-rebalancing
       - Add UK fuel duty rise cancellation analysis dashboard at /uk/cancelling-fuel-duty-rise
       - Redirect the /policybench and /:countryId/policybench vanity paths to policybench.org
+      - Proxy the AI beliefs research dashboard (elicited LLM beliefs about economic elasticities across 17 models) at /ai-beliefs
     changed:
       - Proxy UK Python package docs at /uk/python and UK API docs at /uk/api so the country-parameterized "Python" and "API" nav links work on UK pages
       - Align the calculator app header (e.g. /us/reports) with the main website header — hover-open dropdowns, per-item underline, Model dropdown with sub-items, Python link, and Events under About

--- a/website/src/data/appZoneRoutes.ts
+++ b/website/src/data/appZoneRoutes.ts
@@ -33,8 +33,7 @@ export const appZoneRoutes: AppZoneRoute[] = [
   },
   {
     source: "/uk/uk-cliff-watch",
-    destination:
-      "https://uk-cliff-watch.vercel.app/uk/uk-cliff-watch",
+    destination: "https://uk-cliff-watch.vercel.app/uk/uk-cliff-watch",
   },
   {
     source: "/us/pe84",
@@ -112,6 +111,10 @@ export const appZoneRoutes: AppZoneRoute[] = [
   {
     source: "/us/tanf-calculator",
     destination: "https://tanf-calculator.vercel.app/us/tanf-calculator",
+  },
+  {
+    source: "/ai-beliefs",
+    destination: "https://ai-beliefs.vercel.app/ai-beliefs",
   },
   {
     source: "/us/coverage-compass",


### PR DESCRIPTION
Adds a multizone route so https://policyengine.org/ai-beliefs serves the AI beliefs dashboard from [PolicyEngine/llm-econ-beliefs](https://github.com/PolicyEngine/llm-econ-beliefs).

**What the zone is:** elicited beliefs about economic elasticities from 17 frontier models — point estimates, p05–p95 quantiles, and literature anchors for 26 U.S.-scoped quantities (Frisch, ETI, capital-gains realizations, CRRA, and the PolicyEngine simulation-facing substitution elasticities), 15 runs per model-quantity cell, pooled with mixture/REML/Bayesian intervals. April 2026 panel (11 models) plus July 2026 additions (Claude Fable 5, Claude Opus 4.8, Claude Sonnet 5, GPT-5.5, Gemini 3.5 Flash, Grok 4.3).

**Live zone destination:** https://ai-beliefs.vercel.app/ai-beliefs (project `ai-beliefs` in this team; `basePath /ai-beliefs`, GA4 bootstrap with `G-2YHG89FY0N` in the served HTML).

Changes:
- `website/src/data/appZoneRoutes.ts`: add the `/ai-beliefs` route (root-level path, same as `/2025-year-in-review`)
- `.github/scripts/audit-app-zone-shell.mjs`: shell-brand exemption for `/ai-beliefs` — the dashboard renders its own header/footer with a PolicyEngine attribution, same pattern as the exempted analysis dashboards
- `changelog_entry.yaml`: user-facing line, plus resolves the merge-conflict markers committed in #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
