### PR TITLE
Enforce the site shell on /ai-beliefs

### DIFF
--- a/.github/scripts/audit-app-zone-shell.mjs
+++ b/.github/scripts/audit-app-zone-shell.mjs
@@ -47,14 +47,12 @@ const TOP_SHELL_SELECTOR =
 //   /us/obbba-household-explorer    — PolicyEngine/obbba-household-by-household#240
 //   /uk/uc-rebalancing              — PolicyEngine/uc-rebalancing
 //   /uk/cancelling-fuel-duty-rise   — PolicyEngine/cancelling-fuel-duty-rise
-//   /ai-beliefs                     — PolicyEngine/llm-econ-beliefs
 export const SHELL_BRAND_EXEMPT_SOURCES = [
   "/uk/scotland-income-tax-reform",
   "/uk/student-loan-visualisation",
   "/us/obbba-household-explorer",
   "/uk/uc-rebalancing",
   "/uk/cancelling-fuel-duty-rise",
-  "/ai-beliefs",
 ];
 
 export function isShellBrandExempt(source) {


### PR DESCRIPTION
Removes the shell-brand exemption added in #1102: the zone now renders the PolicyEngine header/footer itself (PolicyEngine/llm-econ-beliefs#2, deployed), so the audit can enforce the full shell. Nav labels verified in the served HTML at https://ai-beliefs.vercel.app/ai-beliefs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)