### PR TITLE
Add /uk/young-worker-nics app-zone route

### DIFF
--- a/.github/scripts/audit-app-zone-shell.mjs
+++ b/.github/scripts/audit-app-zone-shell.mjs
@@ -47,12 +47,14 @@ const TOP_SHELL_SELECTOR =
 //   /us/obbba-household-explorer    — PolicyEngine/obbba-household-by-household#240
 //   /uk/uc-rebalancing              — PolicyEngine/uc-rebalancing
 //   /uk/cancelling-fuel-duty-rise   — PolicyEngine/cancelling-fuel-duty-rise
+//   /uk/young-worker-nics           — PolicyEngine/young-worker-nics
 export const SHELL_BRAND_EXEMPT_SOURCES = [
   "/uk/scotland-income-tax-reform",
   "/uk/student-loan-visualisation",
   "/us/obbba-household-explorer",
   "/uk/uc-rebalancing",
   "/uk/cancelling-fuel-duty-rise",
+  "/uk/young-worker-nics",
 ];
 
 export function isShellBrandExempt(source) {

--- a/.github/scripts/audit-app-zone-shell.test.mjs
+++ b/.github/scripts/audit-app-zone-shell.test.mjs
@@ -248,6 +248,7 @@ describe("isShellBrandExempt", () => {
     );
     assert.equal(isShellBrandExempt("/uk/uc-rebalancing"), true);
     assert.equal(isShellBrandExempt("/us/obbba-household-explorer"), true);
+    assert.equal(isShellBrandExempt("/uk/young-worker-nics"), true);
   });
 
   test("does not exempt other routes or partial-name collisions", () => {

--- a/website/src/data/appZoneRoutes.ts
+++ b/website/src/data/appZoneRoutes.ts
@@ -36,6 +36,10 @@ export const appZoneRoutes: AppZoneRoute[] = [
     destination: "https://uk-cliff-watch.vercel.app/uk/uk-cliff-watch",
   },
   {
+    source: "/uk/young-worker-nics",
+    destination: "https://young-worker-nics.vercel.app/uk/young-worker-nics",
+  },
+  {
     source: "/us/pe84",
     destination: "https://april-fools-2026-two.vercel.app/us/pe84/calculator",
     deepDestination: "https://april-fools-2026-two.vercel.app/us/pe84/:path*",


### PR DESCRIPTION
`/uk/young-worker-nics` currently 404s: the dashboard is registered in `apps.json` (merged) but had no matching multizone rewrite, since the `[countryId]/[slug]` catch-all was removed in favour of `appZoneRoutes.ts`.

Adds the app-zone rewrite to the `young-worker-nics` Vercel deployment, following the matching-basePath convention (uk-cliff-watch, scotland-income-tax-reform). `withDeepRoute` also generates the `/uk/young-worker-nics/:path*` rewrite that proxies the app's `/_next` assets.

**Coordinated with** PolicyEngine/young-worker-nics#2, which builds the dashboard under `basePath: /uk/young-worker-nics`. Merge + deploy that first (or together) so assets resolve under the proxied path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)