### PR TITLE
Add NJ Child Tax Credit increase calculator zone route at /us/nj-ctc-increase

### DIFF
--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -570,6 +570,15 @@
   },
   {
     "type": "iframe",
+    "slug": "nj-ctc-increase",
+    "title": "NJ Child Tax Credit increase calculator",
+    "description": "See the impact of New Jersey's enacted 25% Child Tax Credit increase (P.L.2026, c.26) on New Jersey households, statewide and by congressional district",
+    "source": "https://nj-ctc-increase.vercel.app/us/nj-ctc-increase",
+    "tags": ["us", "policy", "interactives"],
+    "countryId": "us"
+  },
+  {
+    "type": "iframe",
     "slug": "obbba-household-by-household",
     "title": "The One Big Beautiful Bill Act, household by household",
     "description": "Our latest interactive shows how the reconciliation bill affects each of 20,000 representative households across income levels, states, and provisions.",

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -10,6 +10,7 @@
       - Add UK fuel duty rise cancellation analysis dashboard at /uk/cancelling-fuel-duty-rise
       - Redirect the /policybench and /:countryId/policybench vanity paths to policybench.org
       - Proxy the AI beliefs research dashboard (elicited LLM beliefs about economic elasticities across 17 models) at /ai-beliefs
+      - Add the NJ Child Tax Credit increase calculator zone route at /us/nj-ctc-increase
     changed:
       - Stop mirroring policy, household, and region writes to the deprecated API v2 alpha service; the app now uses the v1 API exclusively
       - Proxy UK Python package docs at /uk/python and UK API docs at /uk/api so the country-parameterized "Python" and "API" nav links work on UK pages

--- a/website/src/data/appZoneRoutes.ts
+++ b/website/src/data/appZoneRoutes.ts
@@ -248,6 +248,10 @@ export const appZoneRoutes: AppZoneRoute[] = [
       "https://ri-ctc-calculator-policy-engine.vercel.app/us/rhode-island-ctc-calculator",
   },
   {
+    source: "/us/nj-ctc-increase",
+    destination: "https://nj-ctc-increase.vercel.app/us/nj-ctc-increase",
+  },
+  {
     source: "/us/snap-district-map",
     destination: "https://snap-district-map.vercel.app/us/snap-district-map",
   },


### PR DESCRIPTION
Registers the [nj-ctc-increase](https://github.com/PolicyEngine/nj-ctc-increase) dashboard (New Jersey's enacted 25% CTC increase, S-4531 / P.L.2026, c.26) as a multizone at `/us/nj-ctc-increase`. The tool's metadata has pointed its canonical URL at `https://policyengine.org/us/nj-ctc-increase` since it shipped, but the slug was never added to the zone registry, so that URL 404s today.

- `website/src/data/appZoneRoutes.ts`: zone route → `https://nj-ctc-increase.vercel.app/us/nj-ctc-increase` (the zone sets `basePath: /us/nj-ctc-increase`, so the default deep route covers `/_next/*` and `/data/*` assets)
- `app/src/data/apps/apps.json`: minimal registry entry (sitemap + OG), following the Rhode Island CTC calculator pattern; no research-feed card for now (can add `displayWithResearch` + image later)

Pre-verified against the live zone: it renders the PolicyEngine shell nav (Research/Model/API/Donate) and carries GA4 `G-2YHG89FY0N` + the gtag loader in served HTML, so `app-zone-shell-audit` and `multizone-tracking-audit` should pass. No `vercel.json` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
