### PR TITLE
Move the bill tracker to /us/bill-tracker with permanent redirects

### DIFF
--- a/app/scripts/generate-sitemap.ts
+++ b/app/scripts/generate-sitemap.ts
@@ -122,8 +122,16 @@ function generateSitemap(): string {
     }
   }
 
+  // Bill tracker (updates daily, so listed explicitly instead of via the
+  // apps.json loop below — seeded into `seen` to avoid a duplicate entry)
+  const seen = new Set<string>(['us/bill-tracker']);
+  entries.push({
+    url: `${BASE_URL}/us/bill-tracker`,
+    changefreq: 'daily',
+    priority: '0.8',
+  });
+
   // Interactive tools/apps (deduplicate by slug+country)
-  const seen = new Set<string>();
   for (const app of apps) {
     const key = `${app.countryId}/${app.slug}`;
     if (seen.has(key)) {
@@ -138,13 +146,6 @@ function generateSitemap(): string {
       priority: '0.8',
     });
   }
-
-  // State legislative tracker
-  entries.push({
-    url: `${BASE_URL}/us/state-legislative-tracker`,
-    changefreq: 'daily',
-    priority: '0.8',
-  });
 
   // TAXSIM emulator (US-only, served via Vercel rewrite)
   entries.push({

--- a/app/src/data/apps/apps.json
+++ b/app/src/data/apps/apps.json
@@ -346,7 +346,7 @@
   },
   {
     "type": "iframe",
-    "slug": "state-legislative-tracker",
+    "slug": "bill-tracker",
     "title": "2026 state legislative tracker",
     "description": "Interactive map of 2026 state legislative sessions and tax policy changes, with links to PolicyEngine analysis",
     "source": "https://policyengine--state-legislative-tracker.modal.run/",

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -12,6 +12,7 @@
       - Proxy the AI beliefs research dashboard (elicited LLM beliefs about economic elasticities across 17 models) at /ai-beliefs
       - Add the NJ Child Tax Credit increase calculator zone route at /us/nj-ctc-increase
     changed:
+      - Move the bill tracker to /us/bill-tracker (canonical URL); /us/state-legislative-tracker now permanently redirects there
       - Stop mirroring policy, household, and region writes to the deprecated API v2 alpha service; the app now uses the v1 API exclusively
       - Proxy UK Python package docs at /uk/python and UK API docs at /uk/api so the country-parameterized "Python" and "API" nav links work on UK pages
       - Align the calculator app header (e.g. /us/reports) with the main website header — hover-open dropdowns, per-item underline, Model dropdown with sub-items, Python link, and Events under About

--- a/middleware.ts
+++ b/middleware.ts
@@ -80,7 +80,7 @@ export function isLLMBot(userAgent: string | null): boolean {
   return LLM_USER_AGENTS_LOWER.some((bot) => lower.includes(bot));
 }
 
-export const TRACKER_PREFIX = "/us/state-legislative-tracker";
+export const TRACKER_PREFIX = "/us/bill-tracker";
 export const TRACKER_MODAL_ORIGIN =
   "https://policyengine--state-legislative-tracker.modal.run";
 

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -128,6 +128,18 @@ const nextConfig: NextConfig = {
         destination: "/:countryId/cliffwatch/:path*",
         permanent: true,
       },
+      // Bill tracker renamed from state-legislative-tracker → bill-tracker
+      // (it now covers federal bills too); /us/bill-tracker is canonical
+      {
+        source: "/:countryId/state-legislative-tracker",
+        destination: "/:countryId/bill-tracker",
+        permanent: true,
+      },
+      {
+        source: "/:countryId/state-legislative-tracker/:path*",
+        destination: "/:countryId/bill-tracker/:path*",
+        permanent: true,
+      },
     ];
   },
 

--- a/website/src/components/home/HomeTrackerPreview.tsx
+++ b/website/src/components/home/HomeTrackerPreview.tsx
@@ -66,7 +66,7 @@ export default function HomeTrackerPreview({
 
         {/* Tracker card */}
         <Link
-          href={`/${countryId}/state-legislative-tracker`}
+          href={`/${countryId}/bill-tracker`}
           style={{ textDecoration: "none", color: "inherit", display: "block" }}
         >
           <div

--- a/website/src/data/appZoneRoutes.ts
+++ b/website/src/data/appZoneRoutes.ts
@@ -147,7 +147,7 @@ export const appZoneRoutes: AppZoneRoute[] = [
       "https://marriage-zeta-beryl.vercel.app/us/marriage/:path*?country=uk",
   },
   {
-    source: "/:countryId/state-legislative-tracker",
+    source: "/:countryId/bill-tracker",
     destination: "https://policyengine--state-legislative-tracker.modal.run/",
     deepDestination:
       "https://policyengine--state-legislative-tracker.modal.run/:path*",


### PR DESCRIPTION
## Summary

Moves the bill tracker zone from `/us/state-legislative-tracker` to `/us/bill-tracker` and makes the new path canonical. The tracker now covers federal bills too, so the old name no longer fits (the app already brands itself "Bill Tracker").

- `website/src/data/appZoneRoutes.ts` — zone source becomes `/:countryId/bill-tracker`; destination (Modal) unchanged
- `website/next.config.ts` — permanent (308) redirects from `/:countryId/state-legislative-tracker` and `/:countryId/state-legislative-tracker/:path*` to the bill-tracker equivalents, following the cliff-watch → cliffwatch pattern
- `app/src/data/apps/apps.json` — slug renamed to `bill-tracker` (research-page card and crawler OG tags follow)
- `website/src/components/home/HomeTrackerPreview.tsx` — home card links to `/us/bill-tracker`
- `middleware.ts` — legacy crawler-proxy `TRACKER_PREFIX` updated (existing unit tests cover it via the constant; 89 pass)
- `app/scripts/generate-sitemap.ts` — explicit tracker entry now `/us/bill-tracker`, and seeded into the dedup set so the apps.json loop no longer emits a duplicate URL

Not changed on purpose: the Modal destination/label (`policyengine--state-legislative-tracker.modal.run`), the `/_tracker/*` asset rewrites, the `state-legislative-tracker.webp/png` asset filenames, and the legacy `app/` HomeTrackerPreview copy (per CLAUDE.md it stays untouched; its old link rides the redirect).

## Companion PR

PolicyEngine/state-legislative-tracker#208 updates the tracker's own canonical/og:url metadata, prerender BASE_URL, sitemap, robots.txt, and runtime base path. **Merge this PR first**, then the tracker PR (its pages will emit `/us/bill-tracker` links, which need this redirect/route live).

After both deploy, resubmit the tracker sitemap in Search Console as `https://www.policyengine.org/us/bill-tracker/sitemap.xml` (the old sitemap URL now redirects).

## Verification (local `next dev` from this branch)

- `GET /us/state-legislative-tracker` → `308`, `location: /us/bill-tracker`
- `GET /us/state-legislative-tracker/CA/ca-sb100` → `308`, `location: /us/bill-tracker/CA/ca-sb100`
- `GET /uk/state-legislative-tracker` → `308`, `location: /uk/bill-tracker` (same country-generic shape as the old zone route)
- `GET /us/bill-tracker` → 200, serves the Modal tracker (map, bill list, and Federal/State tabs render; verified by click-through from the home card)
- Website: 111 vitest tests pass, `tsc --noEmit` clean, eslint clean; app: 89 vitest tests pass (incl. `proxyTrackerRequest`), prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
