### PR TITLE
Wire no-tax-on-social-security-dashboard zone

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -199,6 +199,23 @@ const nextConfig: NextConfig = {
           destination:
             "https://household-api-docs-policy-engine.vercel.app/_zones/household-api-docs/:path*",
         },
+        // No tax on Social Security dashboard (HR 904) — path-mounted static-export zone
+        {
+          source: "/us/no-tax-on-social-security-dashboard",
+          destination:
+            "https://no-tax-on-social-security-dashboard-policy-engine.vercel.app/us/no-tax-on-social-security-dashboard",
+        },
+        {
+          source: "/us/no-tax-on-social-security-dashboard/:path*",
+          destination:
+            "https://no-tax-on-social-security-dashboard-policy-engine.vercel.app/us/no-tax-on-social-security-dashboard/:path*",
+        },
+        // Zone asset proxy — assetPrefix: '/_zones/no-tax-on-social-security-dashboard'
+        {
+          source: "/_zones/no-tax-on-social-security-dashboard/:path*",
+          destination:
+            "https://no-tax-on-social-security-dashboard-policy-engine.vercel.app/_zones/no-tax-on-social-security-dashboard/:path*",
+        },
       ],
       // afterFiles: checked after pages/public files but before dynamic routes.
       afterFiles: [


### PR DESCRIPTION
Adds host rewrites so the HR 904 dashboard (built by the reform-publication pipeline, [repo](https://github.com/PolicyEngine/no-tax-on-social-security-dashboard)) is reachable at policyengine.org/us/no-tax-on-social-security-dashboard.

- Two route rewrites preserving the basePath (path-mounted zone)
- `/_zones/no-tax-on-social-security-dashboard` asset proxy (static export with assetPrefix)
- Zone URL: https://no-tax-on-social-security-dashboard-policy-engine.vercel.app/us/no-tax-on-social-security-dashboard/ (verified live, all four pages 200)

**Note on apps.json:** the plan has `register_in_apps_json: true`, but the /deploy-dashboard doc's multizone entry format (`path` field, no iframe type) isn't supported by `app/src/types/apps.ts` — the schema only has iframe/streamlit/obbba/custom with a required `source`. Leaving the research-listing entry for a follow-up once the schema supports multizone entries (or guidance says otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)