### PR TITLE
Explain silent no-op society-wide reports with an informational callout

### DIFF
--- a/app/src/pages/report-output/NoOpReportCallout.tsx
+++ b/app/src/pages/report-output/NoOpReportCallout.tsx
@@ -1,0 +1,29 @@
+import { IconInfoCircle } from '@tabler/icons-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui';
+import { colors } from '@/designTokens';
+
+interface NoOpReportCalloutProps {
+  /** Simulated year from the report context, or null when unavailable. */
+  year: string | null;
+}
+
+/**
+ * Informational callout shown on the society-wide overview when a reform is a
+ * complete no-op — every output is identical to current law. It explains WHY
+ * everything reads "No change", instead of leaving the user to wonder whether
+ * their reform genuinely costs nothing or never touched anything in effect
+ * that year.
+ */
+export default function NoOpReportCallout({ year }: NoOpReportCalloutProps) {
+  const yearLabel = year ?? 'the simulated year';
+
+  return (
+    <Alert className="tw:border-primary-500">
+      <IconInfoCircle size={20} style={{ color: colors.primary[600] }} />
+      <AlertTitle>{`This reform doesn't change any policy in ${yearLabel}`}</AlertTitle>
+      <AlertDescription>
+        {`Every output is identical to current law. Check that your parameters' start dates cover ${yearLabel}, and that the programs you edited are in effect that year — some credits phase in later or expire.`}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/app/src/pages/report-output/SocietyWideOverview.story.tsx
+++ b/app/src/pages/report-output/SocietyWideOverview.story.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { CountryProvider } from '@/contexts/CountryContext';
+import { ReportYearProvider } from '@/contexts/ReportYearContext';
 import type { ReportOutputSocietyWideUS } from '@/types/metadata/ReportOutputSocietyWideUS';
 import SocietyWideOverview from './SocietyWideOverview';
 
@@ -186,4 +188,31 @@ export const Neutral: Story = {
       noChange: 0.94,
     }),
   },
+};
+
+// Complete no-op: every output is identical to current law (for example a
+// reform that only edits a program which has sunset by the simulated year).
+// The overview shows an informational callout above the cards.
+export const CompleteNoOp: Story = {
+  args: {
+    output: buildMockOutput({
+      budgetaryImpact: 0,
+      povertyBaseline: 0.112,
+      povertyReform: 0.112,
+      winnersGainMore: 0,
+      winnersGainLess: 0,
+      losersLoseMore: 0,
+      losersLoseLess: 0,
+      noChange: 1,
+    }),
+  },
+  decorators: [
+    (StoryComponent) => (
+      <CountryProvider value="us">
+        <ReportYearProvider year="2029">
+          <StoryComponent />
+        </ReportYearProvider>
+      </CountryProvider>
+    ),
+  ],
 };

--- a/app/src/pages/report-output/SocietyWideOverview.tsx
+++ b/app/src/pages/report-output/SocietyWideOverview.tsx
@@ -20,11 +20,13 @@ import { USDistrictChoroplethMap } from '@/components/visualization/USDistrictCh
 import { useCongressionalDistrictData } from '@/contexts/CongressionalDistrictDataContext';
 import { colors, spacing, typography } from '@/designTokens';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
+import { useReportYear } from '@/hooks/useReportYear';
 import type { RootState } from '@/store';
 import type { ReportOutputSocietyWideUS } from '@/types/metadata/ReportOutputSocietyWideUS';
 import { formatParameterValue } from '@/utils/chartValueUtils';
 import { formatBudgetaryImpact } from '@/utils/formatPowers';
 import { currencySymbol, formatCurrencyAbbr } from '@/utils/formatters';
+import { isSocietyWideReportNoOp } from '@/utils/isSocietyWideReportNoOp';
 import { DIVERGING_GRAY_TEAL } from '@/utils/visualization/colorScales';
 import BudgetaryImpactSubPage from './budgetary-impact/BudgetaryImpactSubPage';
 import { getBudgetChartTitle, getBudgetCsvRows } from './budgetary-impact/budgetChartUtils';
@@ -41,6 +43,7 @@ import DistributionalImpactIncomeRelativeSubPage from './distributional-impact/D
 import WinnersLosersIncomeDecileSubPage from './distributional-impact/WinnersLosersIncomeDecileSubPage';
 import { getInequalityCsvRows, getInequalityTitle } from './inequality-impact/inequalityChartUtils';
 import InequalityImpactSubPage from './inequality-impact/InequalityImpactSubPage';
+import NoOpReportCallout from './NoOpReportCallout';
 import DeepPovertyImpactByAgeSubPage from './poverty-impact/DeepPovertyImpactByAgeSubPage';
 import DeepPovertyImpactByGenderSubPage from './poverty-impact/DeepPovertyImpactByGenderSubPage';
 import {
@@ -800,6 +803,8 @@ export default function SocietyWideOverview({
   const countryId = useCurrentCountry();
   const metadata = useSelector((state: RootState) => state.metadata);
   const symbol = currencySymbol(countryId);
+  const reportYear = useReportYear();
+  const isNoOp = isSocietyWideReportNoOp(output);
   const [expandedCard, setExpandedCard] = useState<CardKey | null>(null);
   const [decileMode, setDecileMode] = useState<DecileMode>('absolute');
   const [povertyDepth, setPovertyDepth] = useState<PovertyDepth>('regular');
@@ -1047,387 +1052,390 @@ export default function SocietyWideOverview({
   );
 
   return (
-    <div className="tw:grid tw:grid-cols-2" style={{ gap: GRID_GAP }}>
-      {/* Budgetary Impact — full width hero */}
-      <DashboardCard
-        mode={modeOf('budget')}
-        zIndex={zOf('budget')}
-        expandDirection="down-right"
-        gridGap={GRID_GAP}
-        colSpan={2}
-        shrunkenBackground={`linear-gradient(135deg, ${colors.primary[50]} 0%, ${colors.background.primary} 100%)`}
-        shrunkenBorderColor={colors.primary[100]}
-        padding={spacing.xl}
-        shrunkenHeader={cardHeader(IconCoin, 'Budgetary impact', true)}
-        shrunkenBody={
-          <div
-            style={{
-              display: 'flex',
-              gap: spacing.xl,
-              alignItems: 'flex-start',
-              paddingLeft: '4%',
-              paddingRight: '2%',
-            }}
-          >
-            <div style={{ flex: '0 0 auto' }}>
-              <MetricCard
-                value={budgetValue}
-                subtext={budgetSubtext}
-                trend={
-                  budgetaryImpact === 0 ? 'neutral' : budgetIsPositive ? 'positive' : 'negative'
-                }
-                hero
-              />
-            </div>
-            {/* Spacer pushes chart toward right half */}
-            <div style={{ flex: '1 1 10%' }} />
-            <div style={{ flex: '0 1 55%', minWidth: 0 }}>
-              <Plot
-                data={
-                  [
-                    {
-                      x: budgetMiniLabels,
-                      y: budgetMiniValues,
-                      type: 'waterfall',
-                      orientation: 'v',
-                      measure:
-                        budgetMiniValues.length > 1
-                          ? Array(budgetMiniValues.length - 1)
-                              .fill('relative')
-                              .concat(['total'])
-                          : undefined,
-                      text: budgetMiniValues.map((v) =>
-                        formatCurrencyAbbr(v * budgetMagnitude.divisor, countryId, {
-                          maximumFractionDigits: 1,
-                        })
-                      ),
-                      textposition: 'inside',
-                      increasing: { marker: { color: colors.primary[500] } },
-                      decreasing: { marker: { color: colors.gray[600] } },
-                      totals: {
-                        marker: {
-                          color: budgetaryImpact < 0 ? colors.gray[600] : colors.primary[700],
-                        },
-                      },
-                      connector: {
-                        line: { color: colors.gray[400], width: 1, dash: 'dot' },
-                      },
-                    },
-                  ] as any
-                }
-                layout={
-                  {
-                    margin: { t: 5, b: 50, l: 55, r: 15 },
-                    showlegend: false,
-                    paper_bgcolor: 'transparent',
-                    plot_bgcolor: 'transparent',
-                    xaxis: {
-                      fixedrange: true,
-                      tickfont: { size: 9, color: colors.text.secondary },
-                    },
-                    yaxis: {
-                      fixedrange: true,
-                      title: {
-                        text: budgetMagnitude.label,
-                        font: { size: 10, color: colors.text.secondary },
-                        standoff: 5,
-                      },
-                      ...currencyTicks(budgetMiniValues, symbol, 1),
-                      tickfont: { color: colors.text.secondary },
-                    },
-                    uniformtext: { mode: 'hide', minsize: 8 },
-                  } as any
-                }
-                config={MINI_CHART_CONFIG}
-                style={{ width: '100%', height: 120 }}
-              />
-            </div>
-          </div>
-        }
-        expandedTitle={getBudgetChartTitle(output.budget.budgetary_impact, countryId, metadata)}
-        downloadFilename="budgetary-impact.svg"
-        csvFilename="budgetary-impact.csv"
-        csvData={getBudgetCsvRows(output, countryId)}
-        expandedContent={<BudgetaryImpactSubPage output={output} fillHeight />}
-        onToggleMode={() => toggle('budget')}
-      />
-
-      {/* Decile Impacts */}
-      <DashboardCard
-        mode={modeOf('decile')}
-        zIndex={zOf('decile')}
-        expandDirection="down-right"
-        gridGap={GRID_GAP}
-        shrunkenHeader={cardHeader(IconChartBar, 'Decile impacts')}
-        shrunkenBody={
-          <div>
-            <Plot
-              data={[
-                {
-                  x: decileKeys,
-                  y: decileAbsValues,
-                  type: 'bar' as const,
-                  marker: {
-                    color: decileAbsValues.map((v) =>
-                      v >= 0 ? colors.primary[500] : colors.gray[600]
-                    ),
-                  },
-                },
-              ]}
-              layout={{
-                margin: { t: 5, b: 20, l: 50, r: 5 },
-                showlegend: false,
-                paper_bgcolor: 'transparent',
-                plot_bgcolor: 'transparent',
-                xaxis: {
-                  fixedrange: true,
-                  tickvals: decileKeys,
-                  ticktext: decileKeys,
-                  dtick: 1,
-                  tickfont: { color: colors.text.secondary },
-                },
-                yaxis: {
-                  fixedrange: true,
-                  ...currencyTicks(decileAbsValues, symbol),
-                  tickfont: { color: colors.text.secondary },
-                },
-              }}
-              config={MINI_CHART_CONFIG}
-              style={{ width: '100%', height: MINI_CHART_HEIGHT }}
-            />
-          </div>
-        }
-        expandedControls={
-          <SegmentedControl
-            value={decileMode}
-            onValueChange={(value) => setDecileMode(value as DecileMode)}
-            size="xs"
-            options={DECILE_MODE_OPTIONS}
-          />
-        }
-        expandedTitle={
-          decileMode === 'absolute'
-            ? getDistributionalAverageTitle(output, countryId, metadata)
-            : getDistributionalRelativeTitle(output, countryId, metadata)
-        }
-        downloadFilename={
-          decileMode === 'absolute'
-            ? 'distributional-impact-income-average.svg'
-            : 'distributional-impact-income-relative.svg'
-        }
-        csvFilename={decileCsvFilename}
-        csvData={decileCsvData}
-        expandedContent={
-          decileMode === 'absolute' ? (
-            <DistributionalImpactIncomeAverageSubPage output={output} fillHeight />
-          ) : (
-            <DistributionalImpactIncomeRelativeSubPage output={output} fillHeight />
-          )
-        }
-        onToggleMode={() => toggle('decile')}
-      />
-
-      {/* Winners and Losers */}
-      <DashboardCard
-        mode={modeOf('winners')}
-        zIndex={zOf('winners')}
-        expandDirection="down-left"
-        gridGap={GRID_GAP}
-        shrunkenHeader={cardHeader(IconUsers, 'Winners and losers')}
-        shrunkenBody={
-          <div>
-            {/* Distribution Bar */}
+    <Stack gap="lg">
+      {isNoOp && <NoOpReportCallout year={reportYear} />}
+      <div className="tw:grid tw:grid-cols-2" style={{ gap: GRID_GAP }}>
+        {/* Budgetary Impact — full width hero */}
+        <DashboardCard
+          mode={modeOf('budget')}
+          zIndex={zOf('budget')}
+          expandDirection="down-right"
+          gridGap={GRID_GAP}
+          colSpan={2}
+          shrunkenBackground={`linear-gradient(135deg, ${colors.primary[50]} 0%, ${colors.background.primary} 100%)`}
+          shrunkenBorderColor={colors.primary[100]}
+          padding={spacing.xl}
+          shrunkenHeader={cardHeader(IconCoin, 'Budgetary impact', true)}
+          shrunkenBody={
             <div
               style={{
                 display: 'flex',
-                height: 8,
-                borderRadius: 4,
-                overflow: 'hidden',
-                backgroundColor: colors.gray[200],
+                gap: spacing.xl,
+                alignItems: 'flex-start',
+                paddingLeft: '4%',
+                paddingRight: '2%',
               }}
             >
-              <div
-                style={{
-                  width: `${winnersPercent * 100}%`,
-                  height: '100%',
-                  backgroundColor: colors.primary[500],
-                  transition: 'width 0.3s ease',
+              <div style={{ flex: '0 0 auto' }}>
+                <MetricCard
+                  value={budgetValue}
+                  subtext={budgetSubtext}
+                  trend={
+                    budgetaryImpact === 0 ? 'neutral' : budgetIsPositive ? 'positive' : 'negative'
+                  }
+                  hero
+                />
+              </div>
+              {/* Spacer pushes chart toward right half */}
+              <div style={{ flex: '1 1 10%' }} />
+              <div style={{ flex: '0 1 55%', minWidth: 0 }}>
+                <Plot
+                  data={
+                    [
+                      {
+                        x: budgetMiniLabels,
+                        y: budgetMiniValues,
+                        type: 'waterfall',
+                        orientation: 'v',
+                        measure:
+                          budgetMiniValues.length > 1
+                            ? Array(budgetMiniValues.length - 1)
+                                .fill('relative')
+                                .concat(['total'])
+                            : undefined,
+                        text: budgetMiniValues.map((v) =>
+                          formatCurrencyAbbr(v * budgetMagnitude.divisor, countryId, {
+                            maximumFractionDigits: 1,
+                          })
+                        ),
+                        textposition: 'inside',
+                        increasing: { marker: { color: colors.primary[500] } },
+                        decreasing: { marker: { color: colors.gray[600] } },
+                        totals: {
+                          marker: {
+                            color: budgetaryImpact < 0 ? colors.gray[600] : colors.primary[700],
+                          },
+                        },
+                        connector: {
+                          line: { color: colors.gray[400], width: 1, dash: 'dot' },
+                        },
+                      },
+                    ] as any
+                  }
+                  layout={
+                    {
+                      margin: { t: 5, b: 50, l: 55, r: 15 },
+                      showlegend: false,
+                      paper_bgcolor: 'transparent',
+                      plot_bgcolor: 'transparent',
+                      xaxis: {
+                        fixedrange: true,
+                        tickfont: { size: 9, color: colors.text.secondary },
+                      },
+                      yaxis: {
+                        fixedrange: true,
+                        title: {
+                          text: budgetMagnitude.label,
+                          font: { size: 10, color: colors.text.secondary },
+                          standoff: 5,
+                        },
+                        ...currencyTicks(budgetMiniValues, symbol, 1),
+                        tickfont: { color: colors.text.secondary },
+                      },
+                      uniformtext: { mode: 'hide', minsize: 8 },
+                    } as any
+                  }
+                  config={MINI_CHART_CONFIG}
+                  style={{ width: '100%', height: 120 }}
+                />
+              </div>
+            </div>
+          }
+          expandedTitle={getBudgetChartTitle(output.budget.budgetary_impact, countryId, metadata)}
+          downloadFilename="budgetary-impact.svg"
+          csvFilename="budgetary-impact.csv"
+          csvData={getBudgetCsvRows(output, countryId)}
+          expandedContent={<BudgetaryImpactSubPage output={output} fillHeight />}
+          onToggleMode={() => toggle('budget')}
+        />
+
+        {/* Decile Impacts */}
+        <DashboardCard
+          mode={modeOf('decile')}
+          zIndex={zOf('decile')}
+          expandDirection="down-right"
+          gridGap={GRID_GAP}
+          shrunkenHeader={cardHeader(IconChartBar, 'Decile impacts')}
+          shrunkenBody={
+            <div>
+              <Plot
+                data={[
+                  {
+                    x: decileKeys,
+                    y: decileAbsValues,
+                    type: 'bar' as const,
+                    marker: {
+                      color: decileAbsValues.map((v) =>
+                        v >= 0 ? colors.primary[500] : colors.gray[600]
+                      ),
+                    },
+                  },
+                ]}
+                layout={{
+                  margin: { t: 5, b: 20, l: 50, r: 5 },
+                  showlegend: false,
+                  paper_bgcolor: 'transparent',
+                  plot_bgcolor: 'transparent',
+                  xaxis: {
+                    fixedrange: true,
+                    tickvals: decileKeys,
+                    ticktext: decileKeys,
+                    dtick: 1,
+                    tickfont: { color: colors.text.secondary },
+                  },
+                  yaxis: {
+                    fixedrange: true,
+                    ...currencyTicks(decileAbsValues, symbol),
+                    tickfont: { color: colors.text.secondary },
+                  },
                 }}
-              />
-              <div
-                style={{
-                  width: `${unchangedPercent * 100}%`,
-                  height: '100%',
-                  backgroundColor: colors.gray[300],
-                  transition: 'width 0.3s ease',
-                }}
-              />
-              <div
-                style={{
-                  width: `${losersPercent * 100}%`,
-                  height: '100%',
-                  backgroundColor: colors.gray[500],
-                  transition: 'width 0.3s ease',
-                }}
+                config={MINI_CHART_CONFIG}
+                style={{ width: '100%', height: MINI_CHART_HEIGHT }}
               />
             </div>
-
-            {/* Legend */}
-            <Group gap="lg" wrap="wrap" style={{ marginTop: spacing.sm }}>
-              <Group gap="xs">
-                <div
-                  style={{
-                    width: 10,
-                    height: 10,
-                    borderRadius: 2,
-                    backgroundColor: colors.primary[500],
-                    flexShrink: 0,
-                  }}
-                />
-                <Text size="xs" c={colors.text.secondary}>
-                  Gain: {(winnersPercent * 100).toFixed(1)}%
-                </Text>
-              </Group>
-              <Group gap="xs">
-                <div
-                  style={{
-                    width: 10,
-                    height: 10,
-                    borderRadius: 2,
-                    backgroundColor: colors.gray[300],
-                    flexShrink: 0,
-                  }}
-                />
-                <Text size="xs" c={colors.text.secondary}>
-                  No change: {(unchangedPercent * 100).toFixed(1)}%
-                </Text>
-              </Group>
-              <Group gap="xs">
-                <div
-                  style={{
-                    width: 10,
-                    height: 10,
-                    borderRadius: 2,
-                    backgroundColor: colors.gray[500],
-                    flexShrink: 0,
-                  }}
-                />
-                <Text size="xs" c={colors.text.secondary}>
-                  Lose: {(losersPercent * 100).toFixed(1)}%
-                </Text>
-              </Group>
-            </Group>
-          </div>
-        }
-        expandedTitle={getWinnersLosersTitle(output, countryId, metadata)}
-        downloadFilename="winners-losers-income-decile.svg"
-        csvFilename="winners-losers-income-decile.csv"
-        csvData={getWinnersLosersCsvRows(output)}
-        expandedContent={<WinnersLosersIncomeDecileSubPage output={output} fillHeight />}
-        onToggleMode={() => toggle('winners')}
-      />
-
-      {/* Poverty Impact */}
-      <DashboardCard
-        mode={modeOf('poverty')}
-        zIndex={zOf('poverty')}
-        expandDirection="down-right"
-        gridGap={GRID_GAP}
-        shrunkenHeader={cardHeader(IconHome, 'Poverty impact')}
-        shrunkenBody={
-          <Group gap="sm" grow>
-            <MetricCard
-              label="Overall"
-              value={povertyValue}
-              subtext={povertySubtext}
-              trend={povertyTrend as 'positive' | 'negative' | 'neutral'}
-              invertArrow
-              centered
-            />
-            <MetricCard
-              label="Child"
-              value={childPovertyValue}
-              subtext={childPovertySubtext}
-              trend={childPovertyTrend}
-              invertArrow
-              centered
-            />
-          </Group>
-        }
-        expandedControls={
-          <>
+          }
+          expandedControls={
             <SegmentedControl
-              value={povertyDepth}
-              onValueChange={handleDepthChange}
+              value={decileMode}
+              onValueChange={(value) => setDecileMode(value as DecileMode)}
               size="xs"
-              options={POVERTY_DEPTH_OPTIONS}
+              options={DECILE_MODE_OPTIONS}
             />
-            <SegmentedControl
-              value={povertyBreakdown}
-              onValueChange={(value) => setPovertyBreakdown(value as PovertyBreakdown)}
-              size="xs"
-              options={breakdownOptions}
-            />
-          </>
-        }
-        expandedTitle={
-          povertyDepth === 'regular'
-            ? getPovertyTitle(output, countryId, metadata)
-            : getDeepPovertyTitle(output, countryId, metadata)
-        }
-        downloadFilename={povertyDownloadFilename}
-        csvFilename={povertyCsvFilename}
-        csvData={povertyCsvData}
-        expandedContent={povertyChart}
-        onToggleMode={() => toggle('poverty')}
-      />
-
-      {/* Inequality Impact */}
-      <DashboardCard
-        mode={modeOf('inequality')}
-        zIndex={zOf('inequality')}
-        expandDirection="down-left"
-        gridGap={GRID_GAP}
-        shrunkenHeader={cardHeader(IconScale, 'Inequality impact')}
-        shrunkenBody={
-          <Group gap="sm" grow>
-            <MetricCard
-              label="Gini index"
-              value={giniValue}
-              subtext={giniSubtext}
-              trend={giniTrend}
-              invertArrow
-              centered
-            />
-            <MetricCard
-              label="Top 1% share"
-              value={top1Value}
-              subtext={top1Subtext}
-              trend={top1Trend}
-              invertArrow
-              centered
-            />
-          </Group>
-        }
-        expandedTitle={getInequalityTitle(output, metadata)}
-        downloadFilename="inequality-impact.svg"
-        csvFilename="inequality-impact.csv"
-        csvData={getInequalityCsvRows(output)}
-        expandedContent={<InequalityImpactSubPage output={output} fillHeight />}
-        onToggleMode={() => toggle('inequality')}
-      />
-
-      {/* Congressional District Impact — US only, full width */}
-      {showCongressionalCard && (
-        <CongressionalDistrictCard
-          output={output}
-          mode={modeOf('congressional')}
-          zIndex={zOf('congressional')}
-          gridGap={GRID_GAP}
-          header={cardHeader(IconMap, 'Congressional district impact')}
-          onToggleMode={() => toggle('congressional')}
+          }
+          expandedTitle={
+            decileMode === 'absolute'
+              ? getDistributionalAverageTitle(output, countryId, metadata)
+              : getDistributionalRelativeTitle(output, countryId, metadata)
+          }
+          downloadFilename={
+            decileMode === 'absolute'
+              ? 'distributional-impact-income-average.svg'
+              : 'distributional-impact-income-relative.svg'
+          }
+          csvFilename={decileCsvFilename}
+          csvData={decileCsvData}
+          expandedContent={
+            decileMode === 'absolute' ? (
+              <DistributionalImpactIncomeAverageSubPage output={output} fillHeight />
+            ) : (
+              <DistributionalImpactIncomeRelativeSubPage output={output} fillHeight />
+            )
+          }
+          onToggleMode={() => toggle('decile')}
         />
-      )}
-    </div>
+
+        {/* Winners and Losers */}
+        <DashboardCard
+          mode={modeOf('winners')}
+          zIndex={zOf('winners')}
+          expandDirection="down-left"
+          gridGap={GRID_GAP}
+          shrunkenHeader={cardHeader(IconUsers, 'Winners and losers')}
+          shrunkenBody={
+            <div>
+              {/* Distribution Bar */}
+              <div
+                style={{
+                  display: 'flex',
+                  height: 8,
+                  borderRadius: 4,
+                  overflow: 'hidden',
+                  backgroundColor: colors.gray[200],
+                }}
+              >
+                <div
+                  style={{
+                    width: `${winnersPercent * 100}%`,
+                    height: '100%',
+                    backgroundColor: colors.primary[500],
+                    transition: 'width 0.3s ease',
+                  }}
+                />
+                <div
+                  style={{
+                    width: `${unchangedPercent * 100}%`,
+                    height: '100%',
+                    backgroundColor: colors.gray[300],
+                    transition: 'width 0.3s ease',
+                  }}
+                />
+                <div
+                  style={{
+                    width: `${losersPercent * 100}%`,
+                    height: '100%',
+                    backgroundColor: colors.gray[500],
+                    transition: 'width 0.3s ease',
+                  }}
+                />
+              </div>
+
+              {/* Legend */}
+              <Group gap="lg" wrap="wrap" style={{ marginTop: spacing.sm }}>
+                <Group gap="xs">
+                  <div
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: 2,
+                      backgroundColor: colors.primary[500],
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Text size="xs" c={colors.text.secondary}>
+                    Gain: {(winnersPercent * 100).toFixed(1)}%
+                  </Text>
+                </Group>
+                <Group gap="xs">
+                  <div
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: 2,
+                      backgroundColor: colors.gray[300],
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Text size="xs" c={colors.text.secondary}>
+                    No change: {(unchangedPercent * 100).toFixed(1)}%
+                  </Text>
+                </Group>
+                <Group gap="xs">
+                  <div
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: 2,
+                      backgroundColor: colors.gray[500],
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Text size="xs" c={colors.text.secondary}>
+                    Lose: {(losersPercent * 100).toFixed(1)}%
+                  </Text>
+                </Group>
+              </Group>
+            </div>
+          }
+          expandedTitle={getWinnersLosersTitle(output, countryId, metadata)}
+          downloadFilename="winners-losers-income-decile.svg"
+          csvFilename="winners-losers-income-decile.csv"
+          csvData={getWinnersLosersCsvRows(output)}
+          expandedContent={<WinnersLosersIncomeDecileSubPage output={output} fillHeight />}
+          onToggleMode={() => toggle('winners')}
+        />
+
+        {/* Poverty Impact */}
+        <DashboardCard
+          mode={modeOf('poverty')}
+          zIndex={zOf('poverty')}
+          expandDirection="down-right"
+          gridGap={GRID_GAP}
+          shrunkenHeader={cardHeader(IconHome, 'Poverty impact')}
+          shrunkenBody={
+            <Group gap="sm" grow>
+              <MetricCard
+                label="Overall"
+                value={povertyValue}
+                subtext={povertySubtext}
+                trend={povertyTrend as 'positive' | 'negative' | 'neutral'}
+                invertArrow
+                centered
+              />
+              <MetricCard
+                label="Child"
+                value={childPovertyValue}
+                subtext={childPovertySubtext}
+                trend={childPovertyTrend}
+                invertArrow
+                centered
+              />
+            </Group>
+          }
+          expandedControls={
+            <>
+              <SegmentedControl
+                value={povertyDepth}
+                onValueChange={handleDepthChange}
+                size="xs"
+                options={POVERTY_DEPTH_OPTIONS}
+              />
+              <SegmentedControl
+                value={povertyBreakdown}
+                onValueChange={(value) => setPovertyBreakdown(value as PovertyBreakdown)}
+                size="xs"
+                options={breakdownOptions}
+              />
+            </>
+          }
+          expandedTitle={
+            povertyDepth === 'regular'
+              ? getPovertyTitle(output, countryId, metadata)
+              : getDeepPovertyTitle(output, countryId, metadata)
+          }
+          downloadFilename={povertyDownloadFilename}
+          csvFilename={povertyCsvFilename}
+          csvData={povertyCsvData}
+          expandedContent={povertyChart}
+          onToggleMode={() => toggle('poverty')}
+        />
+
+        {/* Inequality Impact */}
+        <DashboardCard
+          mode={modeOf('inequality')}
+          zIndex={zOf('inequality')}
+          expandDirection="down-left"
+          gridGap={GRID_GAP}
+          shrunkenHeader={cardHeader(IconScale, 'Inequality impact')}
+          shrunkenBody={
+            <Group gap="sm" grow>
+              <MetricCard
+                label="Gini index"
+                value={giniValue}
+                subtext={giniSubtext}
+                trend={giniTrend}
+                invertArrow
+                centered
+              />
+              <MetricCard
+                label="Top 1% share"
+                value={top1Value}
+                subtext={top1Subtext}
+                trend={top1Trend}
+                invertArrow
+                centered
+              />
+            </Group>
+          }
+          expandedTitle={getInequalityTitle(output, metadata)}
+          downloadFilename="inequality-impact.svg"
+          csvFilename="inequality-impact.csv"
+          csvData={getInequalityCsvRows(output)}
+          expandedContent={<InequalityImpactSubPage output={output} fillHeight />}
+          onToggleMode={() => toggle('inequality')}
+        />
+
+        {/* Congressional District Impact — US only, full width */}
+        {showCongressionalCard && (
+          <CongressionalDistrictCard
+            output={output}
+            mode={modeOf('congressional')}
+            zIndex={zOf('congressional')}
+            gridGap={GRID_GAP}
+            header={cardHeader(IconMap, 'Congressional district impact')}
+            onToggleMode={() => toggle('congressional')}
+          />
+        )}
+      </div>
+    </Stack>
   );
 }

--- a/app/src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
+++ b/app/src/tests/unit/pages/report-output/SocietyWideOverview.test.tsx
@@ -1,11 +1,31 @@
 import { render, screen } from '@test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ReportYearProvider } from '@/contexts/ReportYearContext';
 import SocietyWideOverview, {
   buildOutcomeMapData,
   getDistrictPayloadAvailability,
   hasCompleteDistrictOutcomePayload,
 } from '@/pages/report-output/SocietyWideOverview';
 import { createMockSocietyWideOutput } from '@/tests/fixtures/pages/reportOutputMocks';
+
+// Budget with every component exactly zero (an exact no-op). The mock's shallow
+// merge replaces `budget` wholesale, so the full object is provided here.
+const ALL_ZERO_BUDGET = {
+  baseline_net_income: 12_000_000_000_000,
+  benefit_spending_impact: 0,
+  budgetary_impact: 0,
+  households: 130_000_000,
+  state_tax_revenue_impact: 0,
+  tax_revenue_impact: 0,
+};
+
+const ALL_NO_CHANGE = {
+  'Gain more than 5%': 0,
+  'Gain less than 5%': 0,
+  'Lose more than 5%': 0,
+  'Lose less than 5%': 0,
+  'No change': 1,
+};
 
 const { mockUseCongressionalDistrictData } = vi.hoisted(() => ({
   mockUseCongressionalDistrictData: vi.fn(),
@@ -271,6 +291,76 @@ describe('SocietyWideOverview', () => {
     expect(screen.getByText('Budgetary impact')).toBeInTheDocument();
     expect(screen.getByText('Poverty impact')).toBeInTheDocument();
     expect(screen.getByText('Winners and losers')).toBeInTheDocument();
+  });
+
+  describe('no-op callout', () => {
+    test('given a complete no-op report then shows the informational callout with the simulated year', () => {
+      // Given - every budget component is zero and 100% of the population is unchanged
+      const output = createMockSocietyWideOutput({
+        budget: { ...ALL_ZERO_BUDGET },
+        intra_decile: { all: { ...ALL_NO_CHANGE } },
+      });
+
+      // When
+      render(
+        <ReportYearProvider year="2029">
+          <SocietyWideOverview output={output} />
+        </ReportYearProvider>
+      );
+
+      // Then
+      expect(screen.getByText("This reform doesn't change any policy in 2029")).toBeInTheDocument();
+      expect(screen.getByText(/Every output is identical to current law/)).toBeInTheDocument();
+    });
+
+    test('given no report year context then the callout falls back to a generic year phrase', () => {
+      // Given
+      const output = createMockSocietyWideOutput({
+        budget: { ...ALL_ZERO_BUDGET },
+        intra_decile: { all: { ...ALL_NO_CHANGE } },
+      });
+
+      // When - rendered without a ReportYearProvider
+      render(<SocietyWideOverview output={output} />);
+
+      // Then
+      expect(
+        screen.getByText("This reform doesn't change any policy in the simulated year")
+      ).toBeInTheDocument();
+    });
+
+    test('given a report with real impacts then the callout is absent', () => {
+      // Given - the default mock has a nonzero budget and only 60% no change
+      const output = createMockSocietyWideOutput();
+
+      // When
+      render(<SocietyWideOverview output={output} />);
+
+      // Then
+      expect(screen.queryByText(/doesn't change any policy/)).not.toBeInTheDocument();
+    });
+
+    test('given a revenue-neutral reform with winners and losers then the callout is absent', () => {
+      // Given - budget nets to zero but only 60% of the population is unchanged
+      const output = createMockSocietyWideOutput({
+        budget: { ...ALL_ZERO_BUDGET },
+        intra_decile: {
+          all: {
+            'Gain more than 5%': 0.1,
+            'Gain less than 5%': 0.15,
+            'Lose more than 5%': 0.05,
+            'Lose less than 5%': 0.1,
+            'No change': 0.6,
+          },
+        },
+      });
+
+      // When
+      render(<SocietyWideOverview output={output} />);
+
+      // Then
+      expect(screen.queryByText(/doesn't change any policy/)).not.toBeInTheDocument();
+    });
   });
 
   test('buildOutcomeMapData reads winner shares from the district payload and tracks gaps', () => {

--- a/app/src/tests/unit/utils/isSocietyWideReportNoOp.test.ts
+++ b/app/src/tests/unit/utils/isSocietyWideReportNoOp.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from 'vitest';
+import type { SocietyWideReportOutput } from '@/api/societyWideCalculation';
+import { isSocietyWideReportNoOp } from '@/utils/isSocietyWideReportNoOp';
+
+/**
+ * The detection util only reads `budget` (budgetary/benefit-spending/tax-revenue
+ * impacts) and `intra_decile.all['No change']`, which are identical in the US
+ * and UK report shapes. These builders produce faithful all-zero fixtures for
+ * each shape (with a country-specific marker field) plus targeted overrides.
+ */
+
+function buildBudget(overrides: Record<string, number> = {}) {
+  return {
+    baseline_net_income: 12_000_000_000_000,
+    benefit_spending_impact: 0,
+    budgetary_impact: 0,
+    households: 130_000_000,
+    state_tax_revenue_impact: 0,
+    tax_revenue_impact: 0,
+    ...overrides,
+  };
+}
+
+function buildIntraDecile(noChange: number) {
+  const split = (1 - noChange) / 2;
+  return {
+    all: {
+      'Gain less than 5%': split,
+      'Gain more than 5%': 0,
+      'Lose less than 5%': split,
+      'Lose more than 5%': 0,
+      'No change': noChange,
+    },
+    deciles: {
+      'Gain less than 5%': Array(10).fill(split),
+      'Gain more than 5%': Array(10).fill(0),
+      'Lose less than 5%': Array(10).fill(split),
+      'Lose more than 5%': Array(10).fill(0),
+      'No change': Array(10).fill(noChange),
+    },
+  };
+}
+
+function usOutput(overrides: Record<string, unknown> = {}): SocietyWideReportOutput {
+  return {
+    budget: buildBudget(),
+    intra_decile: buildIntraDecile(1),
+    // US-specific markers
+    congressional_district_impact: null,
+    poverty_by_race: { poverty: {} },
+    wealth_decile: null,
+    ...overrides,
+  } as unknown as SocietyWideReportOutput;
+}
+
+function ukOutput(overrides: Record<string, unknown> = {}): SocietyWideReportOutput {
+  return {
+    budget: buildBudget(),
+    intra_decile: buildIntraDecile(1),
+    // UK-specific markers
+    constituency_impact: { by_constituency: {}, outcomes_by_region: {} },
+    intra_wealth_decile: { all: {}, deciles: {} },
+    poverty_by_race: null,
+    ...overrides,
+  } as unknown as SocietyWideReportOutput;
+}
+
+describe('isSocietyWideReportNoOp', () => {
+  describe('exact no-op is detected', () => {
+    test('given an all-zero US report then returns true', () => {
+      expect(isSocietyWideReportNoOp(usOutput())).toBe(true);
+    });
+
+    test('given an all-zero UK report then returns true', () => {
+      expect(isSocietyWideReportNoOp(ukOutput())).toBe(true);
+    });
+  });
+
+  describe('real impacts are not treated as a no-op', () => {
+    test('given a tiny nonzero budgetary impact then returns false', () => {
+      expect(
+        isSocietyWideReportNoOp(usOutput({ budget: buildBudget({ budgetary_impact: 1 }) }))
+      ).toBe(false);
+    });
+
+    test('given a nonzero benefit-spending component then returns false', () => {
+      expect(
+        isSocietyWideReportNoOp(
+          usOutput({ budget: buildBudget({ benefit_spending_impact: 1_000_000 }) })
+        )
+      ).toBe(false);
+    });
+
+    test('given a nonzero tax-revenue component then returns false', () => {
+      expect(
+        isSocietyWideReportNoOp(
+          usOutput({ budget: buildBudget({ tax_revenue_impact: -1_000_000 }) })
+        )
+      ).toBe(false);
+    });
+
+    test('given 99.9% no change then returns false', () => {
+      expect(isSocietyWideReportNoOp(usOutput({ intra_decile: buildIntraDecile(0.999) }))).toBe(
+        false
+      );
+    });
+
+    test('given a revenue-neutral reform with real winners and losers then returns false', () => {
+      // Budgetary impact nets to zero, but benefit-spending and tax-revenue move
+      // and only 60% of the population is unchanged — a single zero panel must
+      // not trigger the callout.
+      expect(
+        isSocietyWideReportNoOp(
+          usOutput({
+            budget: buildBudget({
+              benefit_spending_impact: 5_000_000_000,
+              tax_revenue_impact: 5_000_000_000,
+            }),
+            intra_decile: buildIntraDecile(0.6),
+          })
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('missing or malformed data is treated as NOT a no-op', () => {
+    test('given null then returns false', () => {
+      expect(isSocietyWideReportNoOp(null)).toBe(false);
+    });
+
+    test('given undefined then returns false', () => {
+      expect(isSocietyWideReportNoOp(undefined)).toBe(false);
+    });
+
+    test('given a missing budget then returns false', () => {
+      const { budget: _budget, ...withoutBudget } = usOutput() as unknown as Record<
+        string,
+        unknown
+      >;
+      expect(isSocietyWideReportNoOp(withoutBudget as unknown as SocietyWideReportOutput)).toBe(
+        false
+      );
+    });
+
+    test('given a budget missing the tax-revenue component then returns false', () => {
+      const partialBudget = buildBudget() as Record<string, unknown>;
+      delete partialBudget.tax_revenue_impact;
+      expect(isSocietyWideReportNoOp(usOutput({ budget: partialBudget }))).toBe(false);
+    });
+
+    test('given a missing intra_decile breakdown then returns false', () => {
+      const { intra_decile: _intra, ...withoutIntra } = usOutput() as unknown as Record<
+        string,
+        unknown
+      >;
+      expect(isSocietyWideReportNoOp(withoutIntra as unknown as SocietyWideReportOutput)).toBe(
+        false
+      );
+    });
+
+    test('given an intra_decile without a No change entry then returns false', () => {
+      expect(
+        isSocietyWideReportNoOp(
+          usOutput({
+            intra_decile: {
+              all: {
+                'Gain less than 5%': 0,
+                'Gain more than 5%': 0,
+                'Lose less than 5%': 0,
+                'Lose more than 5%': 0,
+              },
+            },
+          })
+        )
+      ).toBe(false);
+    });
+
+    test('given a non-numeric budgetary impact then returns false', () => {
+      expect(
+        isSocietyWideReportNoOp(
+          usOutput({ budget: buildBudget({ budgetary_impact: null as unknown as number }) })
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/app/src/utils/isSocietyWideReportNoOp.ts
+++ b/app/src/utils/isSocietyWideReportNoOp.ts
@@ -1,0 +1,69 @@
+import type { SocietyWideReportOutput } from '@/api/societyWideCalculation';
+
+/**
+ * Fraction of the population in the "No change" bucket that counts as a
+ * complete no-op. A genuine no-op leaves every household untouched, so the
+ * winners/losers breakdown reports exactly 100% "No change".
+ */
+const FULLY_UNCHANGED = 1;
+
+function isExactlyZero(value: unknown): boolean {
+  return typeof value === 'number' && value === 0;
+}
+
+/**
+ * Detects whether a society-wide report is a complete no-op — every output is
+ * identical to current law.
+ *
+ * This happens when a reform only edits parameters that don't apply in the
+ * simulated year (for example a credit that has sunset, or start dates that
+ * don't cover the year), so the report shows "No change" everywhere with no
+ * explanation of why.
+ *
+ * Returns true ONLY when the report is an exact no-op:
+ * - budgetary impact is exactly 0
+ * - benefit-spending and tax-revenue components are exactly 0
+ * - the winners/losers intra-decile breakdown is 100% "No change"
+ *
+ * All four conditions must hold, so a single zero panel (for example a
+ * revenue-neutral reform that still moves money between households) does not
+ * trigger it. Missing or malformed fields are treated as NOT a no-op, and the
+ * function never throws — both US and UK report shapes are handled.
+ */
+export function isSocietyWideReportNoOp(
+  output: SocietyWideReportOutput | null | undefined
+): boolean {
+  if (!output || typeof output !== 'object') {
+    return false;
+  }
+
+  const budget = (output as { budget?: unknown }).budget;
+  if (!budget || typeof budget !== 'object') {
+    return false;
+  }
+
+  const { budgetary_impact, benefit_spending_impact, tax_revenue_impact } = budget as Record<
+    string,
+    unknown
+  >;
+  if (
+    !isExactlyZero(budgetary_impact) ||
+    !isExactlyZero(benefit_spending_impact) ||
+    !isExactlyZero(tax_revenue_impact)
+  ) {
+    return false;
+  }
+
+  const intraDecile = (output as { intra_decile?: unknown }).intra_decile;
+  if (!intraDecile || typeof intraDecile !== 'object') {
+    return false;
+  }
+
+  const all = (intraDecile as { all?: unknown }).all;
+  if (!all || typeof all !== 'object') {
+    return false;
+  }
+
+  const noChange = (all as Record<string, unknown>)['No change'];
+  return noChange === FULLY_UNCHANGED;
+}

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -21,3 +21,4 @@
       - Align the calculator app header (e.g. /us/reports) with the main website header — hover-open dropdowns, per-item underline, Model dropdown with sub-items, Python link, and Events under About
     fixed:
       - Point "Reproduce in Python" snippets for a US national run at the certified populace-us dataset instead of the deprecated policyengine-us-data repo
+      - Add a callout on society-wide results explaining why every output reads "No change" when a reform changes nothing in effect in the simulated year (for example a credit that has sunset), so users can tell a genuine no-op from a start-date or sunset mismatch


### PR DESCRIPTION
## What

The society-wide report output now shows an informational callout above the result cards when a reform is a complete no-op — every output is identical to current law. Previously the page rendered "No change" everywhere (budget, deciles, winners/losers at 100% no change, poverty, inequality) with no explanation, so users could not tell a genuine zero-impact reform from one that never touched anything in effect that year.

This is the "exact-zero callout" from #1116 (suggestion 1). Motivating repro: an Oregon Kids' Credit expansion modeled for 2029, after the credit sunsets (HB 3235) — editing its amount for 2029+ changes nothing, and the null result read as user error.

## Why

Silent no-ops are indistinguishable from real zero-impact reforms and from plain start-date / simulated-year mismatches. The callout names the likely cause and the year to check.

## Detection rule

`isSocietyWideReportNoOp(output)` returns true only for an exact whole-report no-op — all four must hold:

- `budget.budgetary_impact` exactly 0
- `budget.benefit_spending_impact` exactly 0
- `budget.tax_revenue_impact` exactly 0
- `intra_decile.all['No change']` exactly 1 (100% of the population unchanged)

Missing or malformed fields are treated as NOT a no-op, and the function never throws. Both US and UK report shapes are handled (the checked fields are identical across them). Because all four conditions are required, a single zero panel — e.g. a revenue-neutral reform that still moves money between households — does not trigger the callout.

## Callout

Reuses the repo's `Alert` idiom (`@/components/ui`, informational teal-bordered styling with `IconInfoCircle`, matching `FloatingAlert`'s info type). Copy is sentence case, with `<year>` from the report context via `useReportYear()`:

- Title: "This reform doesn't change any policy in `<year>`"
- Body: "Every output is identical to current law. Check that your parameters' start dates cover `<year>`, and that the programs you edited are in effect that year — some credits phase in later or expire."

## Files

- `app/src/utils/isSocietyWideReportNoOp.ts` — pure detection util
- `app/src/pages/report-output/NoOpReportCallout.tsx` — the callout component
- `app/src/pages/report-output/SocietyWideOverview.tsx` — renders the callout above the card grid when the util returns true (the large line count is prettier re-indentation from the new `Stack` wrapper; the logical change is ~7 lines — see the `git diff -w`)
- `app/src/pages/report-output/SocietyWideOverview.story.tsx` — adds a `CompleteNoOp` story (plus the `CountryProvider` / `ReportYearProvider` decorators it needs to render)
- `changelog_entry.yaml` — user-facing `fixed` line

## Test coverage

- Util unit tests (`app/src/tests/unit/utils/isSocietyWideReportNoOp.test.ts`): all-zero US → true; all-zero UK → true; tiny nonzero budgetary / benefit-spending / tax-revenue → false; 99.9% no change → false; revenue-neutral with real winners and losers → false; null / undefined / missing budget / missing intra_decile / missing "No change" / non-numeric → false.
- Component tests (`SocietyWideOverview.test.tsx`): callout renders with the interpolated year on an all-zero fixture; falls back to a generic year phrase when there is no report-year context; absent on the default (nonzero) fixture; absent on a revenue-neutral fixture.

## Verification

- `vitest` (util + component suites): 36 passed
- `tsc --noEmit` clean; `eslint . --cache` 0 warnings; `prettier --check` clean
- Visual: rendered the `CompleteNoOp` Storybook story and confirmed the callout appears above the cards with the informational styling and the 2029 year interpolated.

Fixes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
