### PR TITLE
Fix broken team headshots and supporter logos on retina displays

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -24,3 +24,4 @@
     fixed:
       - Point "Reproduce in Python" snippets for a US national run at the certified populace-us dataset instead of the deprecated policyengine-us-data repo
       - Add a callout on society-wide results explaining why every output reads "No change" when a reform changes nothing in effect in the simulated year (for example a credit that has sunset), so users can tell a genuine no-op from a start-date or sunset mismatch
+      - Declare the image optimiser width allowlist in website/next.config.ts (the vercel.json images block is ignored for Next.js projects), fixing team headshots and supporter logos that returned 400 on retina displays because their 2x srcSet width of 512 was not allowed

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -15,6 +15,7 @@
       - Add the NICs exemption for recently-inactive employees dashboard at /uk/nics-exemption-inactive-employees
       - Add the temporary VAT cut on domestic electricity dashboard at /uk/electricity-vat-cut
     changed:
+      - Remove Ben Ogorek from the team page
       - Move the Claude plugin page to /:countryId/ai-agents (runtime-agnostic — the skills catalog serves Claude Code and Codex) with a permanent redirect from /:countryId/claude-plugin; refresh the hero eyebrow and add the Codex install path
       - Correct the Claude plugin page stats (they were frozen at 24 skills / 21 agents / 4 commands / 7 bundles) and read them from a checked-in pluginStats.json regenerated from policyengine-skills, so the page tracks the rebuilt catalog
       - Move the bill tracker to /us/bill-tracker (canonical URL); /us/state-legislative-tracker now permanently redirects there

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -40,6 +40,21 @@ const policyEngineIconRewrites = [
 ];
 
 const nextConfig: NextConfig = {
+  // Vercel's image optimiser (/_vercel/image) only accepts widths from this
+  // allowlist (imageSizes ∪ deviceSizes). For Next.js projects this config is
+  // the source of truth — the `images` block in vercel.json is ignored — and
+  // without it Next's defaults apply, which lack 512, so OptimisedImage's 2x
+  // srcSet variant for width≤256 images (team headshots, supporter logos)
+  // returned 400 on retina displays.
+  // Must stay a superset of ALLOWED_WIDTHS in src/components/ui/OptimisedImage.tsx
+  // (enforced by src/__tests__/config/next-config.test.ts).
+  images: {
+    imageSizes: [128, 256, 384, 512],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    formats: ["image/avif", "image/webp"],
+    minimumCacheTTL: 86400,
+  },
+
   async redirects() {
     return [
       // Root → /us (temporary — will be replaced with geolocation)

--- a/website/src/__tests__/components/optimised-image.test.tsx
+++ b/website/src/__tests__/components/optimised-image.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import OptimisedImage from "../../components/ui/OptimisedImage";
+
+describe("OptimisedImage", () => {
+  // Regression test for the production incident where the 2x srcSet variant
+  // of the 250px team headshots requested w=512, which the optimizer rejected
+  // with 400 because next.config.ts declared no images allowlist and Next's
+  // defaults lack 512 — breaking every headshot on retina displays.
+  test("snaps a 250px image to w=256 with a w=512 2x variant", () => {
+    render(
+      <OptimisedImage
+        src="/assets/team/max-ghenis.webp"
+        width={250}
+        alt="Max Ghenis"
+      />,
+    );
+
+    const img = screen.getByAltText("Max Ghenis");
+    expect(img).toHaveAttribute(
+      "src",
+      "/_vercel/image?url=%2Fassets%2Fteam%2Fmax-ghenis.webp&q=80&w=256",
+    );
+    expect(img).toHaveAttribute(
+      "srcset",
+      "/_vercel/image?url=%2Fassets%2Fteam%2Fmax-ghenis.webp&q=80&w=256 1x, " +
+        "/_vercel/image?url=%2Fassets%2Fteam%2Fmax-ghenis.webp&q=80&w=512 2x",
+    );
+  });
+
+  test("serves external and SVG sources unoptimised", () => {
+    render(
+      <OptimisedImage
+        src="https://example.com/photo.jpg"
+        width={250}
+        alt="external"
+      />,
+    );
+    render(<OptimisedImage src="/assets/logo.svg" width={100} alt="svg" />);
+
+    expect(screen.getByAltText("external")).toHaveAttribute(
+      "src",
+      "https://example.com/photo.jpg",
+    );
+    expect(screen.getByAltText("svg")).toHaveAttribute(
+      "src",
+      "/assets/logo.svg",
+    );
+  });
+});

--- a/website/src/__tests__/config/next-config.test.ts
+++ b/website/src/__tests__/config/next-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import nextConfig from "../../../next.config";
+import { ALLOWED_WIDTHS } from "../../components/ui/OptimisedImage";
 
 const tealSquareLogoPath = "/assets/logos/policyengine/teal-square.png";
 
@@ -74,6 +75,33 @@ describe("nextConfig rewrites", () => {
         (rewrite) => rewrite.source === "/us/tanf-calculator",
       ),
     ).toBeGreaterThan(expectedPolicyEngineIconRewrites.length - 1);
+  });
+});
+
+describe("nextConfig images", () => {
+  // Vercel's optimiser only serves widths in imageSizes ∪ deviceSizes; any
+  // width OptimisedImage can emit but the config doesn't allow becomes a 400
+  // (broken image) in production — e.g. the w=512 2x variant of the 250px
+  // team headshots before this config existed.
+  test("allows every width OptimisedImage can request", () => {
+    const { imageSizes, deviceSizes } = nextConfig.images ?? {};
+    const allowed = new Set([...(imageSizes ?? []), ...(deviceSizes ?? [])]);
+
+    for (const width of ALLOWED_WIDTHS) {
+      expect(allowed).toContain(width);
+    }
+  });
+
+  test("keeps imageSizes below the smallest deviceSize, as Next requires", () => {
+    const { imageSizes, deviceSizes } = nextConfig.images ?? {};
+
+    expect(imageSizes?.length).toBeGreaterThan(0);
+    expect(deviceSizes?.length).toBeGreaterThan(0);
+
+    const smallestDeviceSize = Math.min(...(deviceSizes ?? []));
+    for (const size of imageSizes ?? []) {
+      expect(size).toBeLessThan(smallestDeviceSize);
+    }
   });
 });
 

--- a/website/src/components/ui/OptimisedImage.tsx
+++ b/website/src/components/ui/OptimisedImage.tsx
@@ -29,8 +29,13 @@ interface OptimisedImageProps extends Omit<
   src?: string | StaticImageData;
 }
 
-// Must match the "sizes" array in vercel.json
-const ALLOWED_WIDTHS = [128, 256, 384, 512, 640, 750, 828, 1080, 1200, 1920];
+// Must be a subset of imageSizes ∪ deviceSizes in next.config.ts — that config
+// is what Vercel's optimiser actually enforces for Next.js projects (the
+// "images" block in vercel.json is ignored). Kept in sync by
+// src/__tests__/config/next-config.test.ts.
+export const ALLOWED_WIDTHS = [
+  128, 256, 384, 512, 640, 750, 828, 1080, 1200, 1920,
+];
 
 /** Snap to the smallest allowed width that is >= the requested width. */
 function snapWidth(w: number): number {

--- a/website/src/data/team.ts
+++ b/website/src/data/team.ts
@@ -49,9 +49,4 @@ export const staff: TeamMember[] = [
     bio: "is a policy modeling fellow at PolicyEngine. He focuses on implementing and analyzing tax and benefit systems. He develops simulation models to evaluate the impacts of policy reforms. Ziming holds a bachelor's degree in mathematical finance from the University of California, Irvine, and a master's degree in business analytics from Boston University.",
     image: "/assets/team/ziming-hua.webp",
   },
-  {
-    name: "Ben Ogorek",
-    bio: "is a data scientist at PolicyEngine. He co-founded Google's People Analytics Data Science team and previously held data science leadership positions at Spencer Health Solutions and Nationwide Insurance. Ben holds a PhD in Statistics from North Carolina State University.",
-    image: "/assets/team/ben-ogorek.webp",
-  },
 ];

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,24 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "images": {
-    "sizes": [
-      128,
-      256,
-      384,
-      512,
-      640,
-      750,
-      828,
-      1080,
-      1200,
-      1920
-    ],
-    "formats": [
-      "image/avif",
-      "image/webp"
-    ],
-    "minimumCacheTTL": 86400
-  },
   "installCommand": "cd .. && bun install --frozen-lockfile",
   "buildCommand": "bash scripts/vercel-build.sh",
   "outputDirectory": ".next",


### PR DESCRIPTION
Fixes #1120

Every team headshot on [/us/team](https://www.policyengine.org/us/team) (and supporter logo on /us/supporters) is a broken image on retina/high-DPI displays: `OptimisedImage`'s 2x srcSet variant requests `w=512`, which the production optimizer rejects with 400 `INVALID_IMAGE_OPTIMIZE_REQUEST`.

## Root cause

Two configs disagreed about the width allowlist:

- `website/vercel.json` declares `images.sizes: [128, 256, 384, 512, ...]`, and `OptimisedImage.ALLOWED_WIDTHS` was written to match it ("Must match the sizes array in vercel.json").
- But **Vercel ignores the `images` block in `vercel.json` for Next.js projects** — the framework's `images` config is what reaches the optimizer. `website/next.config.ts` had no `images` key, so the Next.js defaults applied: `imageSizes [16...384] ∪ deviceSizes [640...3840]`, which **don't include 512**.

Production probe confirms (all Next-default widths 200, 512 400s — note 64/96 succeed despite not being in vercel.json's list, proving that block is inert):

```
w=64  -> 200   w=384 -> 200   w=640 -> 200
w=96  -> 200   w=512 -> 400   w=750 -> 200
```

`TeamMemberCard` (width 250 → 2x = 512) and `SupporterCard` (width 200 → 2x snaps to 512) are the two affected consumers; every other usage happens to snap to widths in the defaults.

## Changes

- **`website/next.config.ts`**: declare `images.imageSizes [128, 256, 384, 512]` + `deviceSizes [640, 750, 828, 1080, 1200, 1920]` — exactly the list both `vercel.json` and the component always intended — plus the `formats`/`minimumCacheTTL` values carried over from the (inert) `vercel.json` block so they now actually take effect.
- **`website/vercel.json`**: remove the ignored `images` block so dead config can't mislead again.
- **`website/src/components/ui/OptimisedImage.tsx`**: export `ALLOWED_WIDTHS`, point the comment at the config that is actually enforced.
- **`website/src/__tests__/config/next-config.test.ts`**: assert every width the component can emit is in `imageSizes ∪ deviceSizes`, and that `imageSizes` stay below the smallest `deviceSize` (Next's requirement).
- **`changelog_entry.yaml`**: user-facing line under `fixed`.

## Also

- Remove Ben Ogorek from the team page (`website/src/data/team.ts`), per Max.

## Verification

- 113/113 website vitest tests pass (including 2 new), `tsc --noEmit` clean, `eslint` clean, prettier clean.
- The optimizer allowlist only exists on Vercel infra (dev mode bypasses optimization by design), so the definitive check is the preview deployment: `/_vercel/image?url=%2Fassets%2Fteam%2Fmax-ghenis.webp&q=80&w=512` should return 200 on the preview URL. I'll verify on the preview and post the result here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
