### PR TITLE
Update David Trimmer bio

### DIFF
--- a/app/src/pages/Team.page.tsx
+++ b/app/src/pages/Team.page.tsx
@@ -39,7 +39,7 @@ const staff: TeamMember[] = [
   },
   {
     name: 'David Trimmer',
-    bio: "is a research analyst at PolicyEngine. Previously, he was a contributor at the People's Policy Project and a social policy intern at the Niskanen Center. David holds an MPA from The George Washington University and a B.S. in Political Science from The Rochester Institute of Technology.",
+    bio: "is a policy research fellow at PolicyEngine. He is also a contributor at the People's Policy Project. Previously, he was a social policy intern at the Niskanen Center and a staff writer for Policy Perspectives. David holds an MPA from The George Washington University and a B.S. in Political Science from The Rochester Institute of Technology.",
     image: '/assets/team/david-trimmer.webp',
   },
   {

--- a/app/src/pages/Team.page.tsx
+++ b/app/src/pages/Team.page.tsx
@@ -39,7 +39,7 @@ const staff: TeamMember[] = [
   },
   {
     name: 'David Trimmer',
-    bio: "is a policy research fellow at PolicyEngine. He is also a contributor at the People's Policy Project. Previously, he was a social policy intern at the Niskanen Center and a staff writer for Policy Perspectives. David holds an MPA from The George Washington University and a B.S. in Political Science from The Rochester Institute of Technology.",
+    bio: "is a research analyst at PolicyEngine. Previously, he was a contributor at the People's Policy Project and a social policy intern at the Niskanen Center. David holds an MPA from The George Washington University and a B.S. in Political Science from The Rochester Institute of Technology.",
     image: '/assets/team/david-trimmer.webp',
   },
   {

--- a/website/src/data/team.ts
+++ b/website/src/data/team.ts
@@ -36,7 +36,7 @@ export const staff: TeamMember[] = [
   },
   {
     name: "David Trimmer",
-    bio: "is a policy research fellow at PolicyEngine. He is also a contributor at the People's Policy Project. Previously, he was a social policy intern at the Niskanen Center and a staff writer for Policy Perspectives. David holds an MPA from The George Washington University and a B.S. in Political Science from The Rochester Institute of Technology.",
+    bio: "is a research analyst at PolicyEngine. Previously, he was a contributor at the People's Policy Project and a social policy intern at the Niskanen Center. David holds an MPA from The George Washington University and a B.S. in Political Science from The Rochester Institute of Technology.",
     image: "/assets/team/david-trimmer.webp",
   },
   {


### PR DESCRIPTION
Updates David Trimmer's team bio:

- Title changed to "research analyst"
- Condensed career history (combined People's Policy Project and Niskanen Center into one sentence, removed the Policy Perspectives line)

Updated in both the Next.js website (`website/src/data/team.ts`) and the legacy calculator app (`app/src/pages/Team.page.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)