### PR TITLE
Mount refundable-credit-conversion at /us/refundable-credit-conversion

### DIFF
--- a/website/src/data/appZoneRoutes.ts
+++ b/website/src/data/appZoneRoutes.ts
@@ -27,6 +27,11 @@ export const appZoneRoutes: AppZoneRoute[] = [
       "https://crfb-tob-impacts.vercel.app/us/taxation-of-benefits-reforms",
   },
   {
+    source: "/us/refundable-credit-conversion",
+    destination:
+      "https://refundable-credit-conversion.vercel.app/us/refundable-credit-conversion",
+  },
+  {
     source: "/uk/scotland-income-tax-reform",
     destination:
       "https://scotland-income-tax-reform.vercel.app/uk/scotland-income-tax-reform",


### PR DESCRIPTION
Adds the app-zone route for the refundable-credit-conversion dashboard (standalone Vercel deployment, basePath already `/us/refundable-credit-conversion`), following the existing `appZoneRoutes` pattern. Routing only — no nav entry; the tool stays unlisted.

`withDeepRoute` generates the `:path*` pair, so pages, `/_next` assets, and the precompute data fetches (all basePath-prefixed) proxy through. The tool's Modal backend calls are absolute URLs; its CORS allowlist gains the policyengine.org origins in the companion dashboard-repo PR.

## Test plan
- [x] `tsc --noEmit` clean.
- [ ] Preview deployment: `/us/refundable-credit-conversion` renders the explorer, wizard instant estimate works (precompute fetch via the rewrite), Validation tab renders.
- [ ] After merge: prod URL end to end incl. a live Modal run (CORS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)