### PR TITLE
Handle partial saved ingredient load failures

### DIFF
--- a/app/src/components/IngredientReadView.tsx
+++ b/app/src/components/IngredientReadView.tsx
@@ -1,4 +1,4 @@
-import { IconPlus } from '@tabler/icons-react';
+import { IconAlertTriangle, IconPlus } from '@tabler/icons-react';
 import {
   Button,
   Spinner,
@@ -11,6 +11,7 @@ import {
   Text,
   Title,
 } from '@/components/ui';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { colors, spacing, typography } from '@/designTokens';
 import { ColumnConfig, ColumnRenderer, IngredientRecord } from './columns';
 import EmptyState from './common/EmptyState';
@@ -147,13 +148,40 @@ export default function IngredientReadView({
                 </TableHeader>
                 <TableBody>
                   {data.map((record) => (
-                    <TableRow key={record.id}>
-                      {columns.map((column) => (
+                    <TableRow
+                      key={record.id}
+                      aria-disabled={record.isDisabled || undefined}
+                      style={{
+                        backgroundColor: record.isDisabled ? colors.gray[50] : undefined,
+                        opacity: record.isDisabled ? 0.72 : 1,
+                      }}
+                    >
+                      {columns.map((column, columnIndex) => (
                         <TableCell
                           key={column.key}
                           style={{ padding: `${spacing.md} ${spacing.lg}` }}
                         >
-                          <ColumnRenderer config={column} record={record} />
+                          <div className="tw:flex tw:items-center tw:gap-2">
+                            {record.isDisabled && columnIndex === 0 && (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span
+                                    aria-label={
+                                      record.errorMessage || `Error loading this ${ingredient}`
+                                    }
+                                    className="tw:inline-flex tw:shrink-0 tw:items-center"
+                                    style={{ color: colors.error }}
+                                  >
+                                    <IconAlertTriangle size={16} />
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">
+                                  {record.errorMessage || `Error loading this ${ingredient}`}
+                                </TooltipContent>
+                              </Tooltip>
+                            )}
+                            <ColumnRenderer config={column} record={record} />
+                          </div>
                         </TableCell>
                       ))}
                     </TableRow>

--- a/app/src/components/IngredientReadView.tsx
+++ b/app/src/components/IngredientReadView.tsx
@@ -1,4 +1,4 @@
-import { IconAlertTriangle, IconPlus } from '@tabler/icons-react';
+import { IconPlus } from '@tabler/icons-react';
 import {
   Button,
   Spinner,
@@ -11,10 +11,10 @@ import {
   Text,
   Title,
 } from '@/components/ui';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { colors, spacing, typography } from '@/designTokens';
 import { ColumnConfig, ColumnRenderer, IngredientRecord } from './columns';
 import EmptyState from './common/EmptyState';
+import { IngredientErrorIcon } from './common/IngredientErrorIcon';
 
 // Main component props
 interface IngredientReadViewProps {
@@ -163,22 +163,9 @@ export default function IngredientReadView({
                         >
                           <div className="tw:flex tw:items-center tw:gap-2">
                             {record.isDisabled && columnIndex === 0 && (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <span
-                                    aria-label={
-                                      record.errorMessage || `Error loading this ${ingredient}`
-                                    }
-                                    className="tw:inline-flex tw:shrink-0 tw:items-center"
-                                    style={{ color: colors.error }}
-                                  >
-                                    <IconAlertTriangle size={16} />
-                                  </span>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom">
-                                  {record.errorMessage || `Error loading this ${ingredient}`}
-                                </TooltipContent>
-                              </Tooltip>
+                              <IngredientErrorIcon
+                                message={record.errorMessage || `Error loading this ${ingredient}`}
+                              />
                             )}
                             <ColumnRenderer config={column} record={record} />
                           </div>

--- a/app/src/components/IngredientSubmissionView.tsx
+++ b/app/src/components/IngredientSubmissionView.tsx
@@ -1,4 +1,5 @@
 import { IconCheck } from '@tabler/icons-react';
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Badge, Container, Group, Stack, Text, Title } from '@/components/ui';
 import { colors, spacing, typography } from '@/designTokens';
 import { cn } from '@/lib/utils';
@@ -11,6 +12,7 @@ export interface SummaryBoxItem {
   isFulfilled?: boolean;
   isDisabled?: boolean;
   badge?: string | number;
+  errorMessage?: string;
 }
 
 export interface TextListItem {
@@ -76,19 +78,23 @@ export default function IngredientSubmissionView({
               className={cn(
                 'tw:w-full tw:text-left tw:rounded-element tw:border tw:p-md tw:transition-all',
                 item.isDisabled
-                  ? 'tw:opacity-60 tw:border-border-light tw:bg-gray-50 tw:pointer-events-none'
+                  ? 'tw:opacity-60 tw:border-border-light tw:bg-gray-50'
                   : 'tw:border-border-light tw:bg-white tw:hover:bg-gray-50 tw:hover:border-border-medium'
               )}
             >
               <Group gap="sm" className="tw:items-center">
                 <div className="tw:w-5 tw:shrink-0" style={{ marginTop: '2px' }}>
-                  {item.isFulfilled && (
-                    <IconCheck
-                      size={20}
-                      style={{
-                        color: colors.primary[600],
-                      }}
-                    />
+                  {item.errorMessage ? (
+                    <IngredientErrorIcon message={item.errorMessage} size={20} />
+                  ) : (
+                    item.isFulfilled && (
+                      <IconCheck
+                        size={20}
+                        style={{
+                          color: colors.primary[600],
+                        }}
+                      />
+                    )
                   )}
                 </div>
                 <Stack gap="xs" style={{ flex: 1 }}>

--- a/app/src/components/columns/ActionsColumn.tsx
+++ b/app/src/components/columns/ActionsColumn.tsx
@@ -16,7 +16,12 @@ export function ActionsColumn({ config, record }: ActionsColumnProps) {
             <Button
               variant="ghost"
               size="icon"
-              onClick={() => config.onAction(action.action, record.id)}
+              disabled={record.isDisabled}
+              onClick={() => {
+                if (!record.isDisabled) {
+                  config.onAction(action.action, record.id);
+                }
+              }}
               aria-label={action.tooltip}
             >
               {action.icon}

--- a/app/src/components/columns/ColumnRenderer.tsx
+++ b/app/src/components/columns/ColumnRenderer.tsx
@@ -53,7 +53,13 @@ export function ColumnRenderer({ config, record }: ColumnRendererProps) {
       return <TextColumn config={config as TextColumnConfig} value={value as TextValue} />;
 
     case 'link':
-      return <LinkColumn config={config as LinkColumnConfig} value={value as LinkValue} />;
+      return (
+        <LinkColumn
+          config={config as LinkColumnConfig}
+          value={value as LinkValue}
+          disabled={record.isDisabled}
+        />
+      );
 
     case 'bullets':
       return <BulletsColumn config={config as BulletsColumnConfig} value={value as BulletsValue} />;

--- a/app/src/components/columns/LinkColumn.tsx
+++ b/app/src/components/columns/LinkColumn.tsx
@@ -11,9 +11,25 @@ const fontSizeMap: Record<string, string> = {
 interface LinkColumnProps {
   config: LinkColumnConfig;
   value: LinkValue;
+  disabled?: boolean;
 }
 
-export function LinkColumn({ config, value }: LinkColumnProps) {
+export function LinkColumn({ config, value, disabled }: LinkColumnProps) {
+  if (disabled) {
+    return (
+      <span
+        className="tw:no-underline"
+        style={{
+          color: colors.text.secondary,
+          fontSize: fontSizeMap[config.size || 'sm'],
+          cursor: 'not-allowed',
+        }}
+      >
+        {value.text}
+      </span>
+    );
+  }
+
   return (
     <AppLink
       to={value.url || `${config.urlPrefix || '#'}${value.text}`}

--- a/app/src/components/columns/MenuColumn.tsx
+++ b/app/src/components/columns/MenuColumn.tsx
@@ -17,7 +17,7 @@ export function MenuColumn({ config, record }: MenuColumnProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon">
+        <Button variant="ghost" size="icon" disabled={record.isDisabled}>
           <IconDots size={16} />
         </Button>
       </DropdownMenuTrigger>
@@ -25,7 +25,11 @@ export function MenuColumn({ config, record }: MenuColumnProps) {
         {config.actions.map((action) => (
           <DropdownMenuItem
             key={action.action}
-            onClick={() => config.onAction(action.action, record.id)}
+            onClick={() => {
+              if (!record.isDisabled) {
+                config.onAction(action.action, record.id);
+              }
+            }}
             className={action.color === 'red' ? 'tw:text-red-500' : ''}
           >
             {action.label}

--- a/app/src/components/columns/SplitMenuColumn.tsx
+++ b/app/src/components/columns/SplitMenuColumn.tsx
@@ -25,12 +25,15 @@ export function SplitMenuColumn({ config, record }: SplitMenuColumnProps) {
   const secondaryActions = config.actions.slice(1);
 
   const handlePrimaryAction = () => {
-    if (primaryAction) {
+    if (primaryAction && !record.isDisabled) {
       config.onAction(primaryAction.action, record.id);
     }
   };
 
   const handleSecondaryAction = (action: string) => {
+    if (record.isDisabled) {
+      return;
+    }
     config.onAction(action, record.id);
     setOpened(false);
   };

--- a/app/src/components/columns/types.ts
+++ b/app/src/components/columns/types.ts
@@ -95,5 +95,7 @@ export type ColumnValue = TextValue | LinkValue | BulletsValue | CustomValue | n
 // Record interface
 export interface IngredientRecord {
   id: string;
-  [key: string]: ColumnValue | string;
+  isDisabled?: boolean;
+  errorMessage?: string;
+  [key: string]: ColumnValue | string | boolean | undefined;
 }

--- a/app/src/components/common/IngredientErrorIcon.tsx
+++ b/app/src/components/common/IngredientErrorIcon.tsx
@@ -1,0 +1,25 @@
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { colors } from '@/designTokens';
+
+interface IngredientErrorIconProps {
+  message: string;
+  size?: number;
+}
+
+export function IngredientErrorIcon({ message, size = 16 }: IngredientErrorIconProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          aria-label={message}
+          className="tw:inline-flex tw:shrink-0 tw:items-center"
+          style={{ color: colors.error }}
+        >
+          <IconAlertTriangle size={size} />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{message}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/app/src/components/common/MultiButtonFooter.tsx
+++ b/app/src/components/common/MultiButtonFooter.tsx
@@ -7,6 +7,7 @@ export interface ButtonConfig {
   variant?: 'filled' | 'outline' | 'disabled' | 'default';
   onClick: () => void;
   isLoading?: boolean;
+  isDisabled?: boolean;
 }
 
 export type { PaginationConfig };
@@ -89,7 +90,7 @@ export default function MultiButtonFooter(props: MultiButtonFooterProps) {
         <Button
           key={index}
           variant={button.variant === 'filled' ? 'default' : 'outline'}
-          disabled={button.variant === 'disabled' || button.isLoading}
+          disabled={button.variant === 'disabled' || button.isLoading || button.isDisabled}
           onClick={button.onClick}
         >
           {button.isLoading && <Spinner size="sm" />}

--- a/app/src/components/flowView/CardListVariant.tsx
+++ b/app/src/components/flowView/CardListVariant.tsx
@@ -1,3 +1,4 @@
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Stack, Text } from '@/components/ui';
 import { colors, typography } from '@/designTokens';
 import { cn } from '@/lib/utils';
@@ -9,6 +10,7 @@ export interface CardListItem {
   onClick: () => void;
   isSelected?: boolean;
   isDisabled?: boolean;
+  errorMessage?: string;
 }
 
 interface CardListVariantProps {
@@ -37,7 +39,9 @@ export default function CardListVariant({
           type="button"
           key={item.id || index}
           onClick={item.isDisabled ? undefined : item.onClick}
-          disabled={item.isDisabled}
+          disabled={item.isDisabled && !item.errorMessage}
+          aria-disabled={item.isDisabled || undefined}
+          tabIndex={item.isDisabled ? -1 : 0}
           className={cn(
             'tw:w-full tw:text-left tw:rounded-element tw:border tw:p-sm tw:transition-all',
             item.isDisabled
@@ -47,14 +51,17 @@ export default function CardListVariant({
                 : 'tw:border-border-light tw:bg-white tw:cursor-pointer tw:hover:bg-gray-50 tw:hover:border-border-medium'
           )}
         >
-          <Stack gap="xs">
-            <Text fw={typography.fontWeight.semibold}>{item.title}</Text>
-            {item.subtitle && (
-              <Text size="sm" style={{ color: colors.gray[600] }}>
-                {item.subtitle}
-              </Text>
-            )}
-          </Stack>
+          <div className="tw:flex tw:items-start tw:justify-between tw:gap-sm">
+            <Stack gap="xs">
+              <Text fw={typography.fontWeight.semibold}>{item.title}</Text>
+              {item.subtitle && (
+                <Text size="sm" style={{ color: colors.gray[600] }}>
+                  {item.subtitle}
+                </Text>
+              )}
+            </Stack>
+            {item.errorMessage && <IngredientErrorIcon message={item.errorMessage} />}
+          </div>
         </button>
       ))}
     </Stack>

--- a/app/src/components/flowView/SetupConditionsVariant.tsx
+++ b/app/src/components/flowView/SetupConditionsVariant.tsx
@@ -1,4 +1,5 @@
 import { IconCheck } from '@tabler/icons-react';
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Group, Stack, Text } from '@/components/ui';
 import { colors, typography } from '@/designTokens';
 import { cn } from '@/lib/utils';
@@ -10,6 +11,7 @@ export interface SetupConditionCard {
   isSelected?: boolean;
   isDisabled?: boolean;
   isFulfilled?: boolean;
+  errorMessage?: string;
 }
 
 interface SetupConditionsVariantProps {
@@ -40,13 +42,17 @@ export default function SetupConditionsVariant({ cards }: SetupConditionsVariant
         >
           <Group gap="sm" className="tw:items-center">
             <div className="tw:w-5 tw:shrink-0" style={{ marginTop: '2px' }}>
-              {card.isFulfilled && (
-                <IconCheck
-                  size={20}
-                  style={{
-                    color: colors.primary[600],
-                  }}
-                />
+              {card.errorMessage ? (
+                <IngredientErrorIcon message={card.errorMessage} size={20} />
+              ) : (
+                card.isFulfilled && (
+                  <IconCheck
+                    size={20}
+                    style={{
+                      color: colors.primary[600],
+                    }}
+                  />
+                )
               )}
             </div>
             <Stack gap="xs" style={{ flex: 1 }}>

--- a/app/src/hooks/useUserHousehold.ts
+++ b/app/src/hooks/useUserHousehold.ts
@@ -256,7 +256,7 @@ export const useUserHouseholds = (userId: string) => {
 
   // Combine the results
   const isLoading = associationsLoading || householdQueries.some((q) => q.isLoading);
-  const error = associationsError || householdQueries.find((q) => q.error)?.error;
+  const error = associationsError;
   const isError = !!error;
 
   // Map associations to households - filter out associations without householdId

--- a/app/src/hooks/useUserHousehold.ts
+++ b/app/src/hooks/useUserHousehold.ts
@@ -236,6 +236,7 @@ export const useUserHouseholds = (userId: string) => {
     data: associations,
     isLoading: associationsLoading,
     error: associationsError,
+    refetch: refetchAssociations,
   } = useHouseholdAssociationsByUser(userId);
 
   // Extract household IDs
@@ -281,6 +282,7 @@ export const useUserHouseholds = (userId: string) => {
     isLoading,
     isError,
     error,
+    refetchAssociations,
     associations, // Still available if needed separately
   };
 };

--- a/app/src/hooks/useUserPolicy.ts
+++ b/app/src/hooks/useUserPolicy.ts
@@ -193,6 +193,7 @@ export const useUserPolicies = (userId: string) => {
     data: associations,
     isLoading: associationsLoading,
     error: associationsError,
+    refetch: refetchAssociations,
   } = usePolicyAssociationsByUser(userId);
 
   // Extract policy IDs
@@ -244,6 +245,7 @@ export const useUserPolicies = (userId: string) => {
     isLoading,
     isError,
     error,
+    refetchAssociations,
     associations, // Still available if needed separately
   };
 };

--- a/app/src/hooks/useUserPolicy.ts
+++ b/app/src/hooks/useUserPolicy.ts
@@ -225,7 +225,7 @@ export const useUserPolicies = (userId: string) => {
 
   // Combine the results
   const isLoading = associationsLoading || policyQueries.some((q) => q.isLoading);
-  const error = associationsError || policyQueries.find((q) => q.error)?.error;
+  const error = associationsError;
   const isError = !!error;
 
   // Simple index-based mapping since queries are in same order as associations
@@ -235,7 +235,7 @@ export const useUserPolicies = (userId: string) => {
       policy: policyQueries[index]?.data,
       isLoading: policyQueries[index]?.isLoading ?? false,
       error: policyQueries[index]?.error ?? null,
-      isError: !!error,
+      isError: !!policyQueries[index]?.error,
     })
   );
 

--- a/app/src/hooks/useUserReports.ts
+++ b/app/src/hooks/useUserReports.ts
@@ -167,16 +167,25 @@ export const useUserReports = (userId: string) => {
     staleTime: 5 * 60 * 1000,
   });
 
-  // Step 9: Combine loading states
+  const reportQueryById = new Map(reportIds.map((id, index) => [id, reportResults.queries[index]]));
+  const simulationQueryById = new Map(
+    simulationIds.map((id, index) => [id, simulationResults.queries[index]])
+  );
+  const policyQueryById = new Map(policyIds.map((id, index) => [id, policyResults.queries[index]]));
+  const householdQueryById = new Map(
+    householdIds.map((id, index) => [id, householdResults.queries[index]])
+  );
+
+  // Step 9: Combine fatal loading and error states. Detail fetch errors stay on rows.
   const { isLoading, error } = combineLoadingStates(
     { isLoading: repAssocLoading, error: repAssocError },
     { isLoading: simAssocLoading, error: simAssocError },
     { isLoading: polAssocLoading, error: polAssocError },
     { isLoading: housAssocLoading, error: housAssocError },
-    { isLoading: reportResults.isLoading, error: reportResults.error },
-    { isLoading: simulationResults.isLoading, error: simulationResults.error },
-    { isLoading: policyResults.isLoading, error: policyResults.error },
-    { isLoading: householdResults.isLoading, error: householdResults.error }
+    { isLoading: reportResults.isLoading },
+    { isLoading: simulationResults.isLoading },
+    { isLoading: policyResults.isLoading },
+    { isLoading: householdResults.isLoading }
   );
 
   // Step 10: Build enhanced results with all relationships
@@ -185,6 +194,7 @@ export const useUserReports = (userId: string) => {
       ?.filter((userRep) => userRep.reportId) // Filter out associations without reportId
       .map((userRep) => {
         // Get report from query results
+        const reportQuery = reportQueryById.get(userRep.reportId);
         const report = reports.find((r) => r.id === userRep.reportId);
 
         // Get related simulations from query results
@@ -193,12 +203,20 @@ export const useUserReports = (userId: string) => {
             ?.map((simId) => simulations.find((s) => s.id === simId))
             .filter((s): s is Simulation => !!s) ?? [];
 
+        const reportSimulationQueries =
+          report?.simulationIds?.map((simId) => simulationQueryById.get(simId)).filter(Boolean) ??
+          [];
+
         // Get policies from query results
         const reportPolicies = reportSimulations
           .map((sim) => sim.policyId)
           .filter((id): id is string => !!id)
           .map((policyId) => policyResults.queries.find((q) => q.data?.id === policyId)?.data)
           .filter((p): p is Policy => !!p);
+
+        const reportPolicyQueries = reportSimulations
+          .map((sim) => (sim.policyId ? policyQueryById.get(sim.policyId) : null))
+          .filter(Boolean);
 
         // Get unique policy IDs for finding user associations
         const uniquePolicyIds = [
@@ -231,6 +249,25 @@ export const useUserReports = (userId: string) => {
           }
         });
 
+        const reportHouseholdQueries = reportSimulations
+          .filter((sim) => sim.populationType === 'household' && sim.populationId)
+          .map((sim) => householdQueryById.get(sim.populationId as string))
+          .filter(Boolean);
+
+        const itemError =
+          reportQuery?.error ||
+          reportSimulationQueries.find((q) => q?.error)?.error ||
+          reportPolicyQueries.find((q) => q?.error)?.error ||
+          reportHouseholdQueries.find((q) => q?.error)?.error ||
+          null;
+
+        const itemIsLoading =
+          reportQuery?.isLoading ||
+          reportSimulationQueries.some((q) => q?.isLoading) ||
+          reportPolicyQueries.some((q) => q?.isLoading) ||
+          reportHouseholdQueries.some((q) => q?.isLoading) ||
+          false;
+
         // Find user associations for related entities
         const reportUserSimulations =
           simulationAssociations?.filter((sa) =>
@@ -255,8 +292,8 @@ export const useUserReports = (userId: string) => {
           userSimulations: reportUserSimulations,
           userPolicies: reportUserPolicies,
           userHouseholds: reportUserHouseholds,
-          isLoading: false,
-          error: null,
+          isLoading: itemIsLoading,
+          error: itemError,
         };
       }) ?? [];
 

--- a/app/src/hooks/useUserSimulations.ts
+++ b/app/src/hooks/useUserSimulations.ts
@@ -132,14 +132,22 @@ export const useUserSimulations = (userId: string) => {
     staleTime: 5 * 60 * 1000,
   });
 
-  // Step 7: Combine loading states
+  const simulationQueryById = new Map(
+    simulationIds.map((id, index) => [id, simulationResults.queries[index]])
+  );
+  const policyQueryById = new Map(policyIds.map((id, index) => [id, policyResults.queries[index]]));
+  const householdQueryById = new Map(
+    householdIds.map((id, index) => [id, householdResults.queries[index]])
+  );
+
+  // Step 7: Combine fatal loading and error states. Detail fetch errors stay on rows.
   const { isLoading, error } = combineLoadingStates(
     { isLoading: simAssocLoading, error: simAssocError },
     { isLoading: polAssocLoading, error: polAssocError },
     { isLoading: housAssocLoading, error: housAssocError },
-    { isLoading: simulationResults.isLoading, error: simulationResults.error },
-    { isLoading: policyResults.isLoading, error: policyResults.error },
-    { isLoading: householdResults.isLoading, error: householdResults.error }
+    { isLoading: simulationResults.isLoading },
+    { isLoading: policyResults.isLoading },
+    { isLoading: householdResults.isLoading }
   );
 
   // Step 8: Build enhanced results with all relationships
@@ -148,23 +156,23 @@ export const useUserSimulations = (userId: string) => {
       ?.filter((userSim) => userSim.simulationId) // Filter out associations without simulationId
       .map((userSim) => {
         // Get simulation from query results
+        const simulationQuery = simulationQueryById.get(userSim.simulationId);
         const simulation = simulations.find((s) => s.id === userSim.simulationId);
 
         // Get related policy from query results
-        const policy = simulation?.policyId
-          ? policyResults.queries.find((q) => q.data?.id === simulation.policyId)?.data
-          : undefined;
+        const policyQuery = simulation?.policyId ? policyQueryById.get(simulation.policyId) : null;
+        const policy = policyQuery?.data;
 
         // Determine if populationId is household or geography based on populationType
         let household: HouseholdModel | undefined;
         let geography: Geography | undefined;
         let userHousehold: UserHouseholdPopulation | undefined;
+        let householdQuery: (typeof householdResults.queries)[number] | null | undefined = null;
 
         if (simulation?.populationId && simulation?.populationType && simulation.countryId) {
           if (simulation.populationType === 'household') {
-            household = householdResults.queries.find(
-              (q) => q.data?.id === simulation.populationId
-            )?.data;
+            householdQuery = householdQueryById.get(simulation.populationId);
+            household = householdQuery?.data;
             userHousehold = householdAssociations?.find(
               (ha) => ha.householdId === simulation.populationId
             );
@@ -189,8 +197,9 @@ export const useUserSimulations = (userId: string) => {
           geography,
           userPolicy,
           userHousehold,
-          isLoading: false,
-          error: null,
+          isLoading:
+            simulationQuery?.isLoading || policyQuery?.isLoading || householdQuery?.isLoading || false,
+          error: simulationQuery?.error || policyQuery?.error || householdQuery?.error || null,
         };
       }) ?? [];
 

--- a/app/src/hooks/useUserSimulations.ts
+++ b/app/src/hooks/useUserSimulations.ts
@@ -198,7 +198,10 @@ export const useUserSimulations = (userId: string) => {
           userPolicy,
           userHousehold,
           isLoading:
-            simulationQuery?.isLoading || policyQuery?.isLoading || householdQuery?.isLoading || false,
+            simulationQuery?.isLoading ||
+            policyQuery?.isLoading ||
+            householdQuery?.isLoading ||
+            false,
           error: simulationQuery?.error || policyQuery?.error || householdQuery?.error || null,
         };
       }) ?? [];

--- a/app/src/pages/Policies.page.tsx
+++ b/app/src/pages/Policies.page.tsx
@@ -14,6 +14,7 @@ import { PolicyCreationModal } from '@/pages/reportBuilder/modals/PolicyCreation
 import { PolicyStateProps } from '@/types/pathwayState';
 import { countPolicyModifications } from '@/utils/countParameterChanges';
 import { formatDate } from '@/utils/dateUtils';
+import { getUserPolicyAvailability } from '@/utils/ingredientAvailability';
 
 export default function PoliciesPage() {
   const userId = MOCK_USER_ID.toString(); // TODO: Replace with actual user ID retrieval logic
@@ -120,8 +121,7 @@ export default function PoliciesPage() {
 
       return {
         id: item.association.id?.toString() || item.association.policyId.toString(), // Use user association ID, not base policy ID
-        isDisabled: !!item.error,
-        errorMessage: 'Error loading this policy',
+        ...getUserPolicyAvailability(item),
         policyName: {
           text: item.association.label || `Policy #${item.association.policyId}`,
         } as TextValue,

--- a/app/src/pages/Policies.page.tsx
+++ b/app/src/pages/Policies.page.tsx
@@ -120,6 +120,8 @@ export default function PoliciesPage() {
 
       return {
         id: item.association.id?.toString() || item.association.policyId.toString(), // Use user association ID, not base policy ID
+        isDisabled: !!item.error,
+        errorMessage: 'Error loading this policy',
         policyName: {
           text: item.association.label || `Policy #${item.association.policyId}`,
         } as TextValue,

--- a/app/src/pages/Populations.page.tsx
+++ b/app/src/pages/Populations.page.tsx
@@ -14,6 +14,11 @@ import { getCountryDisplayName, getGeographyRegionTypeLabel } from '@/models/geo
 import { Household } from '@/models/Household';
 import { Geography } from '@/types/ingredients/Geography';
 import { formatDate } from '@/utils/dateUtils';
+import {
+  getLoadErrorAvailability,
+  getUserHouseholdAvailability,
+  POPULATION_LOAD_ERROR_MESSAGE,
+} from '@/utils/ingredientAvailability';
 
 export default function PopulationsPage() {
   const userId = MOCK_USER_ID.toString(); // TODO: Replace with actual user ID retrieval logic
@@ -202,8 +207,7 @@ export default function PopulationsPage() {
 
       return {
         id: item.association.id || item.association.householdId.toString(),
-        isDisabled: !!item.error,
-        errorMessage: 'Error loading this population',
+        ...getUserHouseholdAvailability(item),
         type: 'household',
         userId: item.association.userId,
         populationName: {
@@ -232,8 +236,7 @@ export default function PopulationsPage() {
 
       return {
         id: association.association.geographyId,
-        isDisabled: !!association.error,
-        errorMessage: 'Error loading this population',
+        ...getLoadErrorAvailability(association.error, POPULATION_LOAD_ERROR_MESSAGE),
         type: 'geography',
         userId: association.association.userId,
         geographyId: association.geography?.geographyId ?? association.association.geographyId,

--- a/app/src/pages/Populations.page.tsx
+++ b/app/src/pages/Populations.page.tsx
@@ -202,6 +202,8 @@ export default function PopulationsPage() {
 
       return {
         id: item.association.id || item.association.householdId.toString(),
+        isDisabled: !!item.error,
+        errorMessage: 'Error loading this population',
         type: 'household',
         userId: item.association.userId,
         populationName: {
@@ -230,6 +232,8 @@ export default function PopulationsPage() {
 
       return {
         id: association.association.geographyId,
+        isDisabled: !!association.error,
+        errorMessage: 'Error loading this population',
         type: 'geography',
         userId: association.association.userId,
         geographyId: association.geography?.geographyId ?? association.association.geographyId,

--- a/app/src/pages/Reports.page.tsx
+++ b/app/src/pages/Reports.page.tsx
@@ -167,6 +167,8 @@ export default function ReportsPage() {
 
         return {
           id: item.userReport.id,
+          isDisabled: !!item.error,
+          errorMessage: 'Error loading this report',
           report: {
             text: item.userReport.label || `Report #${item.userReport.reportId}`,
             url: `/${countryId}/report-output/${item.userReport.id}`,

--- a/app/src/pages/Simulations.page.tsx
+++ b/app/src/pages/Simulations.page.tsx
@@ -101,6 +101,8 @@ export default function SimulationsPage() {
   const transformedData: IngredientRecord[] =
     data?.map((item) => ({
       id: item.userSimulation.id?.toString() || item.userSimulation.simulationId.toString(), // Use user association ID, not base simulation ID
+      isDisabled: !!item.error,
+      errorMessage: 'Error loading this simulation',
       simulation: {
         text: item.userSimulation.label || `Simulation #${item.userSimulation.simulationId}`,
       } as TextValue,

--- a/app/src/pages/reportBuilder/ModifyReportPage.tsx
+++ b/app/src/pages/reportBuilder/ModifyReportPage.tsx
@@ -43,14 +43,15 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
     ingredientType: 'policy',
   });
 
-  const { handleSaveAsNew, handleReplace, isSavingNew, isReplacing } = useModifyReportSubmission({
-    reportState: reportState ?? { label: null, year: '', simulations: [] },
-    countryId,
-    existingUserReportId: userReportId ?? '',
-    onSuccess: (resultUserReportId) => {
-      nav.push(getReportOutputPath(countryId, resultUserReportId));
-    },
-  });
+  const { handleSaveAsNew, handleReplace, isSavingNew, isReplacing, isReportSubmissionBlocked } =
+    useModifyReportSubmission({
+      reportState: reportState ?? { label: null, year: '', simulations: [] },
+      countryId,
+      existingUserReportId: userReportId ?? '',
+      onSuccess: (resultUserReportId) => {
+        nav.push(getReportOutputPath(countryId, resultUserReportId));
+      },
+    });
 
   // View/edit mode state
   const [isEditing, setIsEditing] = useState(false);
@@ -109,7 +110,7 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
         variant: 'secondary' as const,
         loading: isReplacing,
         loadingLabel: 'Updating report...',
-        disabled: isSavingNew,
+        disabled: isSavingNew || isReportSubmissionBlocked,
       },
       {
         key: 'save-new',
@@ -119,7 +120,7 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
         variant: 'primary' as const,
         loading: isSavingNew,
         loadingLabel: 'Creating report...',
-        disabled: isReplacing,
+        disabled: isReplacing || isReportSubmissionBlocked,
       },
     ];
   }, [
@@ -130,6 +131,7 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
     isSavingNew,
     isReplacing,
     isEitherSubmitting,
+    isReportSubmissionBlocked,
   ]);
 
   if (isLoading || !reportState) {
@@ -187,6 +189,7 @@ export default function ModifyReportPage({ userReportId }: { userReportId?: stri
                 Cancel
               </Button>
               <Button
+                disabled={isReportSubmissionBlocked}
                 onClick={() => {
                   setShowSameNameWarning(false);
                   handleSaveAsNew(reportState?.label || 'Untitled report');

--- a/app/src/pages/reportBuilder/components/IngredientSection.tsx
+++ b/app/src/pages/reportBuilder/components/IngredientSection.tsx
@@ -11,6 +11,7 @@ import {
   IconSparkles,
   IconUsers,
 } from '@tabler/icons-react';
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Group, Text } from '@/components/ui';
 import { colors, spacing } from '@/designTokens';
 import { COUNTRY_CONFIG, FONT_SIZES, INGREDIENT_COLORS } from '../constants';
@@ -38,6 +39,7 @@ export function IngredientSection({
   inheritedPopulationLabel: _inheritedPopulationLabel,
   savedPolicies = [],
   recentPopulations = [],
+  selectedErrorMessage,
 }: IngredientSectionProps) {
   const countryConfig = COUNTRY_CONFIG[countryId] || COUNTRY_CONFIG.us;
   const colorConfig = INGREDIENT_COLORS[type];
@@ -54,6 +56,9 @@ export function IngredientSection({
   };
 
   const iconSize = 16;
+  const isSelectedErrorVisible =
+    (type === 'policy' && savedPolicies.slice(0, 3).some((item) => item.id === currentId)) ||
+    (type === 'population' && recentPopulations.slice(0, 4).some((item) => item.id === currentId));
 
   return (
     <div
@@ -82,6 +87,9 @@ export function IngredientSection({
           {typeLabels[type]}
         </Text>
         {isInherited && <Text style={styles.inheritedBadge}>(inherited from baseline)</Text>}
+        {selectedErrorMessage && !isSelectedErrorVisible && (
+          <IngredientErrorIcon message={selectedErrorMessage} />
+        )}
       </div>
 
       {/* Chips container */}
@@ -119,7 +127,11 @@ export function IngredientSection({
                   />
                 }
                 label={policy.label}
-                description={`${policy.paramCount} param${policy.paramCount !== 1 ? 's' : ''} changed`}
+                description={
+                  policy.isDisabled
+                    ? 'Failed to load'
+                    : `${policy.paramCount} param${policy.paramCount !== 1 ? 's' : ''} changed`
+                }
                 isSelected={currentId === policy.id}
                 onClick={() => {
                   if (currentId === policy.id && onDeselectPolicy) {
@@ -129,6 +141,8 @@ export function IngredientSection({
                   }
                 }}
                 colorConfig={colorConfig}
+                isDisabled={policy.isDisabled}
+                errorMessage={policy.errorMessage}
               />
             ))}
             {/* More options - always shown for searching/browsing all policies */}
@@ -187,9 +201,18 @@ export function IngredientSection({
                   )
                 }
                 label={pop.label}
-                description={pop.type === 'household' ? 'Household' : 'Geography'}
+                description={
+                  pop.isDisabled
+                    ? 'Failed to load'
+                    : pop.type === 'household'
+                      ? 'Household'
+                      : 'Geography'
+                }
                 isSelected={currentId === pop.id}
                 onClick={() => {
+                  if (pop.isDisabled || !pop.population) {
+                    return;
+                  }
                   if (currentId === pop.id && onDeselectPopulation) {
                     onDeselectPopulation();
                   } else {
@@ -197,6 +220,8 @@ export function IngredientSection({
                   }
                 }}
                 colorConfig={colorConfig}
+                isDisabled={pop.isDisabled}
+                errorMessage={pop.errorMessage}
               />
             ))}
             {/* More options - always shown for searching/browsing all populations */}

--- a/app/src/pages/reportBuilder/components/IngredientSectionFull.tsx
+++ b/app/src/pages/reportBuilder/components/IngredientSectionFull.tsx
@@ -20,6 +20,7 @@ import {
   IconUsers,
   IconX,
 } from '@tabler/icons-react';
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Group, Text, Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui';
 import { colors, spacing } from '@/designTokens';
 import { COUNTRY_CONFIG, FONT_SIZES, INGREDIENT_COLORS } from '../constants';
@@ -47,6 +48,7 @@ export function IngredientSectionFull({
   savedPolicies = [],
   recentPopulations = [],
   currentLabel,
+  selectedErrorMessage,
   isReadOnly,
   onViewPolicy,
   onViewPopulation,
@@ -151,9 +153,14 @@ export function IngredientSectionFull({
 
   // Show policy details action for non-current-law policies.
   const showViewPolicyButton =
-    type === 'policy' && !isCurrentLaw(currentId) && !!currentId && onViewPolicy;
+    type === 'policy' &&
+    !selectedErrorMessage &&
+    !isCurrentLaw(currentId) &&
+    !!currentId &&
+    onViewPolicy;
   const showViewPopulationButton =
     type === 'population' &&
+    !selectedErrorMessage &&
     selectedPopulationLabel?.populationType === 'household' &&
     !!currentId &&
     onViewPopulation;
@@ -210,6 +217,7 @@ export function IngredientSectionFull({
       ) : hasSelection ? (
         /* Selected item - full-width card */
         <div
+          aria-disabled={Boolean(selectedErrorMessage)}
           style={{
             padding: `${spacing.md} ${spacing.lg}`,
             borderRadius: spacing.radius.container,
@@ -223,6 +231,7 @@ export function IngredientSectionFull({
             gap: spacing.md,
             minWidth: 0,
             overflow: 'hidden',
+            opacity: selectedErrorMessage ? 0.65 : 1,
           }}
         >
           <div
@@ -237,18 +246,24 @@ export function IngredientSectionFull({
               flexShrink: 0,
             }}
           >
-            {type === 'policy' &&
-              (isCurrentLaw(currentId) ? (
-                <IconScale size={18} color={colorConfig.icon} />
-              ) : (
-                <IconFileDescription size={18} color={colorConfig.icon} />
-              ))}
-            {type === 'population' &&
-              (selectedPopulationLabel?.populationType === 'household' ? (
-                <IconHome size={18} color={colorConfig.icon} />
-              ) : (
-                <CountryMapIcon countryId={countryId} size={18} color={colorConfig.icon} />
-              ))}
+            {selectedErrorMessage ? (
+              <IngredientErrorIcon message={selectedErrorMessage} size={18} />
+            ) : (
+              <>
+                {type === 'policy' &&
+                  (isCurrentLaw(currentId) ? (
+                    <IconScale size={18} color={colorConfig.icon} />
+                  ) : (
+                    <IconFileDescription size={18} color={colorConfig.icon} />
+                  ))}
+                {type === 'population' &&
+                  (selectedPopulationLabel?.populationType === 'household' ? (
+                    <IconHome size={18} color={colorConfig.icon} />
+                  ) : (
+                    <CountryMapIcon countryId={countryId} size={18} color={colorConfig.icon} />
+                  ))}
+              </>
+            )}
           </div>
           <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
             <Text
@@ -263,13 +278,16 @@ export function IngredientSectionFull({
             >
               {type === 'policy' ? selectedPolicyLabel?.label : selectedPopulationLabel?.label}
             </Text>
-            {(type === 'policy'
-              ? selectedPolicyLabel?.description
-              : selectedPopulationLabel?.description) && (
+            {(selectedErrorMessage ||
+              (type === 'policy'
+                ? selectedPolicyLabel?.description
+                : selectedPopulationLabel?.description)) && (
               <Text c={colors.gray[500]} style={{ fontSize: FONT_SIZES.small }}>
-                {type === 'policy'
-                  ? selectedPolicyLabel?.description
-                  : selectedPopulationLabel?.description}
+                {selectedErrorMessage
+                  ? 'Failed to load'
+                  : type === 'policy'
+                    ? selectedPolicyLabel?.description
+                    : selectedPopulationLabel?.description}
               </Text>
             )}
           </div>

--- a/app/src/pages/reportBuilder/components/SimulationBlock.tsx
+++ b/app/src/pages/reportBuilder/components/SimulationBlock.tsx
@@ -34,13 +34,15 @@ export function SimulationBlock({
   inheritedPopulation,
   savedPolicies,
   recentPopulations,
+  policyErrorMessage,
+  populationErrorMessage,
 }: SimulationBlockProps) {
-  const isPolicyConfigured = !!simulation.policy.id;
+  const isPolicyConfigured = !!simulation.policy.id && !policyErrorMessage;
   const effectivePopulation =
     populationInherited && inheritedPopulation ? inheritedPopulation : simulation.population;
-  const isPopulationConfigured = !!(
-    effectivePopulation?.household?.id || effectivePopulation?.geography?.id
-  );
+  const isPopulationConfigured =
+    !!(effectivePopulation?.household?.id || effectivePopulation?.geography?.id) &&
+    !populationErrorMessage;
   const isFullyConfigured = isPolicyConfigured && isPopulationConfigured;
 
   const defaultLabel = index === 0 ? 'Baseline simulation' : 'Reform simulation';
@@ -143,6 +145,7 @@ export function SimulationBlock({
         onCreateCustom={() => {}}
         onBrowseMore={onBrowseMorePolicies}
         savedPolicies={savedPolicies}
+        selectedErrorMessage={policyErrorMessage}
       />
 
       <IngredientSection
@@ -159,6 +162,7 @@ export function SimulationBlock({
         inheritedPopulationType={inheritedPopulationType}
         inheritedPopulationLabel={inheritedPopulationLabel}
         recentPopulations={recentPopulations}
+        selectedErrorMessage={populationErrorMessage}
       />
     </div>
   );

--- a/app/src/pages/reportBuilder/components/SimulationBlockFull.tsx
+++ b/app/src/pages/reportBuilder/components/SimulationBlockFull.tsx
@@ -37,14 +37,16 @@ export function SimulationBlockFull({
   inheritedPopulation,
   savedPolicies,
   recentPopulations,
+  policyErrorMessage,
+  populationErrorMessage,
   isReadOnly,
 }: SimulationBlockProps) {
-  const isPolicyConfigured = !!simulation.policy.id;
+  const isPolicyConfigured = !!simulation.policy.id && !policyErrorMessage;
   const effectivePopulation =
     populationInherited && inheritedPopulation ? inheritedPopulation : simulation.population;
-  const isPopulationConfigured = !!(
-    effectivePopulation?.household?.id || effectivePopulation?.geography?.id
-  );
+  const isPopulationConfigured =
+    !!(effectivePopulation?.household?.id || effectivePopulation?.geography?.id) &&
+    !populationErrorMessage;
   const isFullyConfigured = isPolicyConfigured && isPopulationConfigured;
 
   const defaultLabel = index === 0 ? 'Baseline simulation' : 'Reform simulation';
@@ -156,6 +158,7 @@ export function SimulationBlockFull({
         onCreateCustom={() => {}}
         onBrowseMore={onBrowseMorePolicies}
         savedPolicies={savedPolicies}
+        selectedErrorMessage={policyErrorMessage}
         isReadOnly={isReadOnly}
       />
 
@@ -175,6 +178,7 @@ export function SimulationBlockFull({
         inheritedPopulationType={inheritedPopulationType}
         inheritedPopulationLabel={inheritedPopulationLabel}
         recentPopulations={recentPopulations}
+        selectedErrorMessage={populationErrorMessage}
         isReadOnly={isReadOnly}
       />
     </div>

--- a/app/src/pages/reportBuilder/components/SimulationCanvas.tsx
+++ b/app/src/pages/reportBuilder/components/SimulationCanvas.tsx
@@ -5,6 +5,8 @@
  * and callback logic lives in useSimulationCanvas.
  */
 
+import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
+import { Alert, AlertDescription, AlertTitle, Button, Spinner } from '@/components/ui';
 import { useSimulationCanvas } from '../hooks/useSimulationCanvas';
 import {
   HouseholdCreationModal,
@@ -54,6 +56,30 @@ export function SimulationCanvas({
     return <SimulationCanvasSkeleton />;
   }
 
+  if (canvas.catalogError) {
+    return (
+      <div style={styles.canvasContainer} className="tw:p-xl">
+        <Alert variant="destructive" className="tw:max-w-2xl">
+          <IconAlertCircle size={20} />
+          <AlertTitle>Saved ingredients unavailable</AlertTitle>
+          <AlertDescription>
+            <p>{canvas.catalogErrorMessage}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={canvas.retryCatalogs}
+              disabled={canvas.isRetryingCatalogs}
+              className="tw:mt-sm"
+            >
+              {canvas.isRetryingCatalogs ? <Spinner size="sm" /> : <IconRefresh size={16} />}
+              Try again
+            </Button>
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
   return (
     <>
       <div style={styles.canvasContainer}>
@@ -87,6 +113,10 @@ export function SimulationCanvas({
             canRemove={false}
             savedPolicies={canvas.savedPolicies}
             recentPopulations={canvas.recentPopulations}
+            policyErrorMessage={canvas.getPolicyErrorMessage(reportState.simulations[0]?.policy.id)}
+            populationErrorMessage={canvas.getPopulationErrorMessage(
+              reportState.simulations[0]?.population.household?.id
+            )}
             isReadOnly={isReadOnly}
           />
 
@@ -125,6 +155,12 @@ export function SimulationCanvas({
               inheritedPopulation={reportState.simulations[0].population}
               savedPolicies={canvas.savedPolicies}
               recentPopulations={canvas.recentPopulations}
+              policyErrorMessage={canvas.getPolicyErrorMessage(
+                reportState.simulations[1]?.policy.id
+              )}
+              populationErrorMessage={canvas.getPopulationErrorMessage(
+                reportState.simulations[0]?.population.household?.id
+              )}
               isReadOnly={isReadOnly}
             />
           ) : (

--- a/app/src/pages/reportBuilder/components/chips/OptionChipRow.tsx
+++ b/app/src/pages/reportBuilder/components/chips/OptionChipRow.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { IconCheck } from '@tabler/icons-react';
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Stack, Text } from '@/components/ui';
 import { colors } from '@/designTokens';
 import { FONT_SIZES } from '../../constants';
@@ -13,24 +14,33 @@ export function OptionChipRow({
   isSelected,
   onClick,
   colorConfig,
+  isDisabled,
+  errorMessage,
 }: OptionChipRowProps) {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
     <div
       role="button"
-      tabIndex={0}
+      tabIndex={isDisabled ? -1 : 0}
+      aria-disabled={isDisabled || undefined}
       style={{
         ...chipStyles.chipRow,
         borderColor: isSelected ? colorConfig.accent : colors.border.light,
-        background: isSelected ? colorConfig.bg : isHovered ? colors.gray[50] : colors.white,
+        background: isSelected
+          ? colorConfig.bg
+          : isHovered && !isDisabled
+            ? colors.gray[50]
+            : colors.white,
+        cursor: isDisabled ? 'not-allowed' : 'pointer',
+        opacity: isDisabled ? 0.6 : 1,
         ...(isSelected ? chipStyles.chipRowSelected : {}),
       }}
-      onMouseEnter={() => setIsHovered(true)}
+      onMouseEnter={() => !isDisabled && setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      onClick={onClick}
+      onClick={() => !isDisabled && onClick()}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
+        if (!isDisabled && (e.key === 'Enter' || e.key === ' ')) {
           e.preventDefault();
           onClick();
         }
@@ -58,7 +68,11 @@ export function OptionChipRow({
           </Text>
         )}
       </Stack>
-      {isSelected && <IconCheck size={18} color={colorConfig.accent} stroke={2.5} />}
+      {errorMessage ? (
+        <IngredientErrorIcon message={errorMessage} />
+      ) : (
+        isSelected && <IconCheck size={18} color={colorConfig.accent} stroke={2.5} />
+      )}
     </div>
   );
 }

--- a/app/src/pages/reportBuilder/components/chips/OptionChipSquare.tsx
+++ b/app/src/pages/reportBuilder/components/chips/OptionChipSquare.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Text } from '@/components/ui';
 import { colors, spacing } from '@/designTokens';
 import { FONT_SIZES } from '../../constants';
@@ -12,17 +13,27 @@ export function OptionChipSquare({
   isSelected,
   onClick,
   colorConfig,
+  isDisabled,
+  errorMessage,
 }: OptionChipSquareProps) {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
     <div
       role="button"
-      tabIndex={0}
+      tabIndex={isDisabled ? -1 : 0}
+      aria-disabled={isDisabled || undefined}
       style={{
         ...chipStyles.chipSquare,
+        position: 'relative',
         borderColor: isSelected ? colorConfig.accent : colors.border.light,
-        background: isSelected ? colorConfig.bg : isHovered ? colors.gray[50] : colors.white,
+        background: isSelected
+          ? colorConfig.bg
+          : isHovered && !isDisabled
+            ? colors.gray[50]
+            : colors.white,
+        cursor: isDisabled ? 'not-allowed' : 'pointer',
+        opacity: isDisabled ? 0.6 : 1,
         ...(isSelected
           ? {
               ...chipStyles.chipSquareSelected,
@@ -30,16 +41,21 @@ export function OptionChipSquare({
             }
           : {}),
       }}
-      onMouseEnter={() => setIsHovered(true)}
+      onMouseEnter={() => !isDisabled && setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      onClick={onClick}
+      onClick={() => !isDisabled && onClick()}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
+        if (!isDisabled && (e.key === 'Enter' || e.key === ' ')) {
           e.preventDefault();
           onClick();
         }
       }}
     >
+      {errorMessage && (
+        <span className="tw:absolute tw:right-2 tw:top-2">
+          <IngredientErrorIcon message={errorMessage} />
+        </span>
+      )}
       <div
         style={{
           width: 28,

--- a/app/src/pages/reportBuilder/hooks/useModifyReportSubmission.ts
+++ b/app/src/pages/reportBuilder/hooks/useModifyReportSubmission.ts
@@ -12,10 +12,8 @@
 import { useCallback, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
-import { ReportAdapter, SimulationAdapter } from '@/adapters';
+import { ReportAdapter } from '@/adapters';
 import { createReport as createBaseReport, createReportAndAssociateWithUser } from '@/api/report';
-import { createSimulation } from '@/api/simulation';
-import { LocalStorageSimulationStore } from '@/api/simulationAssociation';
 import { MOCK_USER_ID } from '@/constants';
 import { useCalcOrchestratorManager } from '@/contexts/CalcOrchestratorContext';
 import { useUpdateReportAssociation } from '@/hooks/useUserReportAssociations';
@@ -23,8 +21,9 @@ import { reportAssociationKeys, reportKeys } from '@/libs/queryKeys';
 import { RootState } from '@/store';
 import { Report } from '@/types/ingredients/Report';
 import { Simulation } from '@/types/ingredients/Simulation';
-import { toApiPolicyId } from '../currentLaw';
 import { ReportBuilderState } from '../types';
+import { createReportSimulations } from '../utils/createReportSimulations';
+import { useReportIngredientAvailability } from './useReportIngredientAvailability';
 
 interface UseModifyReportSubmissionArgs {
   reportState: ReportBuilderState;
@@ -38,6 +37,7 @@ interface UseModifyReportSubmissionReturn {
   handleReplace: () => Promise<void>;
   isSavingNew: boolean;
   isReplacing: boolean;
+  isReportSubmissionBlocked: boolean;
 }
 
 export function useModifyReportSubmission({
@@ -52,77 +52,19 @@ export function useModifyReportSubmission({
   const queryClient = useQueryClient();
   const [isSavingNew, setIsSavingNew] = useState(false);
   const [isReplacing, setIsReplacing] = useState(false);
+  const { isReportConfigured } = useReportIngredientAvailability(reportState);
+  const isReportSubmissionBlocked = !isReportConfigured;
 
   /**
    * Shared logic: create simulations via API and build the report payload.
    * Returns the created simulation IDs, domain-model simulations, and report payload.
    */
   const createSimulationsAndReport = useCallback(async () => {
-    const simulationIds: string[] = [];
-    const simulations: (Simulation | null)[] = [];
-
-    for (const simState of reportState.simulations) {
-      const policyId = simState.policy?.id
-        ? toApiPolicyId(simState.policy.id, currentLawId)
-        : undefined;
-
-      if (!policyId) {
-        console.error('[useModifyReportSubmission] Simulation missing policy ID');
-        continue;
-      }
-
-      let populationId: string | undefined;
-      let populationType: 'household' | 'geography' | undefined;
-
-      if (simState.population?.household?.id) {
-        populationId = simState.population.household.id;
-        populationType = 'household';
-      } else if (simState.population?.geography?.geographyId) {
-        populationId = simState.population.geography.geographyId;
-        populationType = 'geography';
-      }
-
-      if (!populationId || !populationType) {
-        console.error('[useModifyReportSubmission] Simulation missing population');
-        continue;
-      }
-
-      const payload = SimulationAdapter.toCreationPayload({
-        populationId,
-        policyId,
-        populationType,
-      });
-      const result = await createSimulation(countryId, payload);
-      const simulationId = result.result.simulation_id;
-      simulationIds.push(simulationId);
-
-      // Create UserSimulation association in localStorage so sharing works
-      const simulationStore = new LocalStorageSimulationStore();
-      await simulationStore.create({
-        userId: MOCK_USER_ID,
-        simulationId,
-        countryId,
-        label: simState.label ?? undefined,
-        isCreated: true,
-      });
-
-      simulations.push({
-        id: simulationId,
-        countryId,
-        apiVersion: undefined,
-        policyId,
-        populationId,
-        populationType,
-        label: simState.label,
-        isCreated: true,
-        output: null,
-        status: 'pending',
-      });
-    }
-
-    if (simulationIds.length === 0) {
-      throw new Error('No simulations created');
-    }
+    const { simulationIds, simulations } = await createReportSimulations({
+      simulationStates: reportState.simulations,
+      countryId,
+      currentLawId,
+    });
 
     const reportPayload = ReportAdapter.toCreationPayload({
       countryId,
@@ -199,7 +141,7 @@ export function useModifyReportSubmission({
    */
   const handleSaveAsNew = useCallback(
     async (label: string) => {
-      if (isSavingNew || isReplacing) {
+      if (isSavingNew || isReplacing || isReportSubmissionBlocked) {
         return;
       }
       setIsSavingNew(true);
@@ -227,6 +169,7 @@ export function useModifyReportSubmission({
     [
       isSavingNew,
       isReplacing,
+      isReportSubmissionBlocked,
       createSimulationsAndReport,
       countryId,
       queryClient,
@@ -240,7 +183,7 @@ export function useModifyReportSubmission({
    * existing UserReport association to point to the new base report ID.
    */
   const handleReplace = useCallback(async () => {
-    if (isSavingNew || isReplacing) {
+    if (isSavingNew || isReplacing || isReportSubmissionBlocked) {
       return;
     }
     setIsReplacing(true);
@@ -268,6 +211,7 @@ export function useModifyReportSubmission({
   }, [
     isSavingNew,
     isReplacing,
+    isReportSubmissionBlocked,
     createSimulationsAndReport,
     countryId,
     existingUserReportId,
@@ -277,5 +221,11 @@ export function useModifyReportSubmission({
     onSuccess,
   ]);
 
-  return { handleSaveAsNew, handleReplace, isSavingNew, isReplacing };
+  return {
+    handleSaveAsNew,
+    handleReplace,
+    isSavingNew,
+    isReplacing,
+    isReportSubmissionBlocked,
+  };
 }

--- a/app/src/pages/reportBuilder/hooks/useReportIngredientAvailability.ts
+++ b/app/src/pages/reportBuilder/hooks/useReportIngredientAvailability.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import { MOCK_USER_ID } from '@/constants';
+import { useUserHouseholds } from '@/hooks/useUserHousehold';
+import { useUserPolicies } from '@/hooks/useUserPolicy';
+import {
+  hasRequiredSimulationIngredients,
+  hasUnavailableSimulationIngredients,
+} from '@/utils/ingredientAvailability';
+import type { ReportBuilderState } from '../types';
+
+export function useReportIngredientAvailability(reportState: ReportBuilderState) {
+  const userId = MOCK_USER_ID.toString();
+  const { data: policies, isLoading: policiesLoading } = useUserPolicies(userId);
+  const { data: households, isLoading: householdsLoading } = useUserHouseholds(userId);
+
+  const hasUnavailableIngredients = useMemo(
+    () => hasUnavailableSimulationIngredients(reportState.simulations, policies, households),
+    [households, policies, reportState.simulations]
+  );
+  const isCheckingIngredientAvailability =
+    policiesLoading || householdsLoading || policies === undefined || households === undefined;
+  const hasRequiredIngredientIds = hasRequiredSimulationIngredients(reportState.simulations);
+  const isReportConfigured =
+    hasRequiredIngredientIds && !hasUnavailableIngredients && !isCheckingIngredientAvailability;
+
+  return {
+    hasUnavailableIngredients,
+    isCheckingIngredientAvailability,
+    isReportConfigured,
+  };
+}

--- a/app/src/pages/reportBuilder/hooks/useReportSubmission.ts
+++ b/app/src/pages/reportBuilder/hooks/useReportSubmission.ts
@@ -12,18 +12,14 @@
  */
 import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { ReportAdapter, SimulationAdapter } from '@/adapters';
-import { createSimulation } from '@/api/simulation';
-import { LocalStorageSimulationStore } from '@/api/simulationAssociation';
-import { MOCK_USER_ID } from '@/constants';
+import { ReportAdapter } from '@/adapters';
 import { useCreateReport } from '@/hooks/useCreateReport';
 import { RootState } from '@/store';
 import { Report } from '@/types/ingredients/Report';
-import { Simulation } from '@/types/ingredients/Simulation';
-import { SimulationStateProps } from '@/types/pathwayState';
 import { trackReportStarted } from '@/utils/analytics';
-import { toApiPolicyId } from '../currentLaw';
 import { ReportBuilderState } from '../types';
+import { createReportSimulations } from '../utils/createReportSimulations';
+import { useReportIngredientAvailability } from './useReportIngredientAvailability';
 
 interface UseReportSubmissionArgs {
   reportState: ReportBuilderState;
@@ -49,46 +45,6 @@ function getJourneyProfiler(): {
   return (window as any).__journeyProfiler ?? null;
 }
 
-function convertToSimulation(
-  simState: SimulationStateProps,
-  simulationId: string,
-  countryId: 'us' | 'uk',
-  currentLawId: number
-): Simulation | null {
-  const policyId = simState.policy?.id;
-  if (!policyId) {
-    return null;
-  }
-
-  let populationId: string | undefined;
-  let populationType: 'household' | 'geography' | undefined;
-
-  if (simState.population?.household?.id) {
-    populationId = simState.population.household.id;
-    populationType = 'household';
-  } else if (simState.population?.geography?.geographyId) {
-    populationId = simState.population.geography.geographyId;
-    populationType = 'geography';
-  }
-
-  if (!populationId || !populationType) {
-    return null;
-  }
-
-  return {
-    id: simulationId,
-    countryId,
-    apiVersion: undefined,
-    policyId: toApiPolicyId(policyId, currentLawId),
-    populationId,
-    populationType,
-    label: simState.label,
-    isCreated: true,
-    output: null,
-    status: 'pending',
-  };
-}
-
 export function useReportSubmission({
   reportState,
   countryId,
@@ -97,10 +53,7 @@ export function useReportSubmission({
   const currentLawId = useSelector((state: RootState) => state.metadata.currentLawId);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { createReport } = useCreateReport(reportState.label || undefined);
-
-  const isReportConfigured = reportState.simulations.every(
-    (sim) => !!sim.policy.id && !!(sim.population.household?.id || sim.population.geography?.id)
-  );
+  const { isReportConfigured } = useReportIngredientAvailability(reportState);
 
   const handleSubmit = useCallback(async () => {
     if (!isReportConfigured || isSubmitting) {
@@ -113,69 +66,14 @@ export function useReportSubmission({
     journeyProfiler?.markStart?.('report-submit', 'user-interaction');
 
     try {
-      const simulationIds: string[] = [];
-      const simulations: (Simulation | null)[] = [];
       journeyProfiler?.markStart?.('report-submit-simulations', 'api-call');
-
-      for (const simState of reportState.simulations) {
-        const policyId = simState.policy?.id
-          ? toApiPolicyId(simState.policy.id, currentLawId)
-          : undefined;
-
-        if (!policyId) {
-          console.error('[useReportSubmission] Simulation missing policy ID');
-          continue;
-        }
-
-        let populationId: string | undefined;
-        let populationType: 'household' | 'geography' | undefined;
-
-        if (simState.population?.household?.id) {
-          populationId = simState.population.household.id;
-          populationType = 'household';
-        } else if (simState.population?.geography?.geographyId) {
-          populationId = simState.population.geography.geographyId;
-          populationType = 'geography';
-        }
-
-        if (!populationId || !populationType) {
-          console.error('[useReportSubmission] Simulation missing population');
-          continue;
-        }
-
-        const simulationData: Partial<Simulation> = {
-          populationId,
-          policyId,
-          populationType,
-        };
-
-        const payload = SimulationAdapter.toCreationPayload(simulationData);
-        const result = await createSimulation(countryId, payload);
-        const simulationId = result.result.simulation_id;
-        simulationIds.push(simulationId);
-
-        // Create UserSimulation association in localStorage so sharing works
-        const simulationStore = new LocalStorageSimulationStore();
-        await simulationStore.create({
-          userId: MOCK_USER_ID,
-          simulationId,
-          countryId,
-          label: simState.label ?? undefined,
-          isCreated: true,
-        });
-
-        const simulation = convertToSimulation(simState, simulationId, countryId, currentLawId);
-        simulations.push(simulation);
-      }
+      const { simulationIds, simulations } = await createReportSimulations({
+        simulationStates: reportState.simulations,
+        countryId,
+        currentLawId,
+      });
 
       journeyProfiler?.markEnd?.('report-submit-simulations', 'api-call');
-
-      if (simulationIds.length === 0) {
-        console.error('[useReportSubmission] No simulations created');
-        setIsSubmitting(false);
-        journeyProfiler?.markEnd?.('report-submit', 'user-interaction');
-        return;
-      }
 
       const reportData: Partial<Report> = {
         countryId,

--- a/app/src/pages/reportBuilder/hooks/useSimulationCanvas.ts
+++ b/app/src/pages/reportBuilder/hooks/useSimulationCanvas.ts
@@ -21,6 +21,13 @@ import { Geography } from '@/types/ingredients/Geography';
 import { PolicyStateProps, PopulationStateProps } from '@/types/pathwayState';
 import { countPolicyModifications } from '@/utils/countParameterChanges';
 import { generateGeographyLabel } from '@/utils/geographyUtils';
+import {
+  getHouseholdLoadErrorMessage,
+  getPolicyLoadErrorMessage,
+  getUserHouseholdAvailability,
+  getUserPolicyAvailability,
+  isUserHouseholdSelectable,
+} from '@/utils/ingredientAvailability';
 import { initializePolicyState } from '@/utils/pathwayState/initializePolicyState';
 import { initializePopulationState } from '@/utils/pathwayState/initializePopulationState';
 import { initializeSimulationState } from '@/utils/pathwayState/initializeSimulationState';
@@ -62,12 +69,49 @@ export function useSimulationCanvas({
 }: UseSimulationCanvasArgs) {
   const countryId = useCurrentCountry() as 'us' | 'uk';
   const userId = MOCK_USER_ID.toString();
-  const { data: policies, isLoading: policiesLoading } = useUserPolicies(userId);
-  const { data: households, isLoading: householdsLoading } = useUserHouseholds(userId);
+  const {
+    data: policies,
+    isLoading: policiesLoading,
+    error: policiesError,
+    refetchAssociations: refetchPolicyAssociations,
+  } = useUserPolicies(userId);
+  const {
+    data: households,
+    isLoading: householdsLoading,
+    error: householdsError,
+    refetchAssociations: refetchHouseholdAssociations,
+  } = useUserHouseholds(userId);
   const { data: regions, isLoading: regionsLoading } = useRegions(countryId);
   const regionRecords = regions ?? [];
   const isGeographySelected = !!reportState.simulations[0]?.population?.geography?.id;
   const [hasRegionLoadTimedOut, setHasRegionLoadTimedOut] = useState(false);
+  const [isRetryingCatalogs, setIsRetryingCatalogs] = useState(false);
+
+  const catalogError = policiesError || householdsError || null;
+  const catalogErrorMessage =
+    policiesError && householdsError
+      ? "We couldn't load your saved policies and households."
+      : policiesError
+        ? "We couldn't load your saved policies."
+        : householdsError
+          ? "We couldn't load your saved households."
+          : undefined;
+
+  const retryCatalogs = useCallback(async () => {
+    setIsRetryingCatalogs(true);
+    try {
+      const retries: Promise<unknown>[] = [];
+      if (policiesError) {
+        retries.push(refetchPolicyAssociations());
+      }
+      if (householdsError) {
+        retries.push(refetchHouseholdAssociations());
+      }
+      await Promise.all(retries);
+    } finally {
+      setIsRetryingCatalogs(false);
+    }
+  }, [householdsError, policiesError, refetchHouseholdAssociations, refetchPolicyAssociations]);
 
   const isWaitingForRegions = regionsLoading || regionRecords.length === 0;
 
@@ -91,11 +135,12 @@ export function useSimulationCanvas({
   // best-effort here; if they never arrive, stop blocking the builder after a
   // short timeout instead of rendering a permanent skeleton.
   const isInitialLoading =
-    policiesLoading ||
-    householdsLoading ||
-    policies === undefined ||
-    households === undefined ||
-    (!hasRegionLoadTimedOut && isWaitingForRegions);
+    !catalogError &&
+    (policiesLoading ||
+      householdsLoading ||
+      policies === undefined ||
+      households === undefined ||
+      (!hasRegionLoadTimedOut && isWaitingForRegions));
 
   // ---------------------------------------------------------------------------
   // Modal visibility state
@@ -134,6 +179,7 @@ export function useSimulationCanvas({
           paramCount: countPolicyModifications(p.policy),
           createdAt: p.association.createdAt,
           updatedAt: p.association.updatedAt,
+          ...getUserPolicyAvailability(p),
         };
       })
       .sort((a, b) => {
@@ -194,13 +240,27 @@ export function useSimulationCanvas({
       const householdData = households?.find(
         (h) => String(h.association.householdId) === householdId
       );
-      if (!householdData?.household) {
+      if (!householdData) {
+        continue;
+      }
+
+      const label = householdData.association.label || `Household #${householdId}`;
+      const availability = getUserHouseholdAvailability(householdData);
+      if (!isUserHouseholdSelectable(householdData)) {
+        if (availability.errorMessage) {
+          results.push({
+            id: householdId,
+            label,
+            type: 'household',
+            ...availability,
+            timestamp: householdUsageStore.getLastUsed(householdId) || '',
+          });
+        }
         continue;
       }
 
       const household = householdData.household;
       const resolvedId = household.id || householdId;
-      const label = householdData.association.label || `Household #${householdId}`;
       results.push({
         id: resolvedId,
         label,
@@ -224,6 +284,16 @@ export function useSimulationCanvas({
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
+
+  const getPolicyErrorMessage = useCallback(
+    (policyId?: string | null) => getPolicyLoadErrorMessage(policies, policyId),
+    [policies]
+  );
+
+  const getPopulationErrorMessage = useCallback(
+    (householdId?: string | null) => getHouseholdLoadErrorMessage(households, householdId),
+    [households]
+  );
 
   /**
    * Update a simulation's population at `index`, and if it's the baseline (0)
@@ -611,11 +681,17 @@ export function useSimulationCanvas({
   return {
     countryId,
     isInitialLoading,
+    catalogError,
+    catalogErrorMessage,
+    isRetryingCatalogs,
+    retryCatalogs,
     isGeographySelected,
 
     // Computed data
     savedPolicies,
     recentPopulations,
+    getPolicyErrorMessage,
+    getPopulationErrorMessage,
 
     // Simulation actions
     handleAddSimulation,

--- a/app/src/pages/reportBuilder/modals/IngredientPickerModal.tsx
+++ b/app/src/pages/reportBuilder/modals/IngredientPickerModal.tsx
@@ -10,6 +10,7 @@ import {
   IconUsers,
 } from '@tabler/icons-react';
 import { useSelector } from 'react-redux';
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Group } from '@/components/ui/Group';
@@ -29,6 +30,10 @@ import { RootState } from '@/store';
 import { PolicyStateProps, PopulationStateProps } from '@/types/pathwayState';
 import { countPolicyModifications } from '@/utils/countParameterChanges';
 import { formatPeriod } from '@/utils/dateUtils';
+import {
+  getUserHouseholdAvailability,
+  getUserPolicyAvailability,
+} from '@/utils/ingredientAvailability';
 import { formatLabelParts, getHierarchicalLabels } from '@/utils/parameterLabels';
 import { formatParameterValue } from '@/utils/policyTableHelpers';
 import { CountryMapIcon } from '../components/shared/CountryMapIcon';
@@ -216,6 +221,7 @@ export function IngredientPickerModal({
                         const paramCount = countPolicyModifications(p.policy); // Handles undefined gracefully
                         const policyParams = p.policy?.parameters || [];
                         const isExpanded = expandedPolicyId === policyId;
+                        const { isDisabled, errorMessage } = getUserPolicyAvailability(p);
 
                         return (
                           <div
@@ -225,28 +231,34 @@ export function IngredientPickerModal({
                               border: `1px solid ${isExpanded ? colorConfig.border : colors.border.light}`,
                               overflow: 'hidden',
                               transition: 'all 0.2s ease',
+                              opacity: isDisabled ? 0.6 : 1,
                             }}
                           >
                             {/* Main clickable row */}
                             <div
                               role="button"
-                              tabIndex={0}
+                              tabIndex={isDisabled ? -1 : 0}
+                              aria-disabled={isDisabled || undefined}
                               style={{
                                 display: 'flex',
                                 alignItems: 'center',
                                 padding: spacing.sm,
-                                cursor: 'pointer',
+                                cursor: isDisabled ? 'not-allowed' : 'pointer',
                                 transition: 'background 0.15s ease',
                               }}
-                              onClick={() => handleSelectPolicy(policyId, label, paramCount)}
+                              onClick={() =>
+                                !isDisabled && handleSelectPolicy(policyId, label, paramCount)
+                              }
                               onKeyDown={(e) => {
-                                if (e.key === 'Enter' || e.key === ' ') {
+                                if (!isDisabled && (e.key === 'Enter' || e.key === ' ')) {
                                   e.preventDefault();
                                   handleSelectPolicy(policyId, label, paramCount);
                                 }
                               }}
                               onMouseEnter={(e) => {
-                                e.currentTarget.style.background = colors.gray[50];
+                                if (!isDisabled) {
+                                  e.currentTarget.style.background = colors.gray[50];
+                                }
                               }}
                               onMouseLeave={(e) => {
                                 e.currentTarget.style.background = 'transparent';
@@ -258,7 +270,9 @@ export function IngredientPickerModal({
                                   {label}
                                 </Text>
                                 <Text c="dimmed" style={{ fontSize: FONT_SIZES.small }}>
-                                  {paramCount} param{paramCount !== 1 ? 's' : ''} changed
+                                  {isDisabled
+                                    ? 'Failed to load'
+                                    : `${paramCount} param${paramCount !== 1 ? 's' : ''} changed`}
                                 </Text>
                               </Stack>
 
@@ -266,6 +280,7 @@ export function IngredientPickerModal({
                               <Button
                                 variant="ghost"
                                 size="icon-sm"
+                                disabled={isDisabled}
                                 onClick={(e) => {
                                   e.stopPropagation(); // Prevent selection
                                   setExpandedPolicyId(isExpanded ? null : policyId);
@@ -279,17 +294,24 @@ export function IngredientPickerModal({
                               </Button>
 
                               {/* Select indicator */}
-                              <IconChevronRight size={16} color={colors.gray[400]} />
+                              {errorMessage ? (
+                                <IngredientErrorIcon message={errorMessage} />
+                              ) : (
+                                <IconChevronRight size={16} color={colors.gray[400]} />
+                              )}
                             </div>
 
                             {/* Expandable parameter details - table-like display */}
                             <div
                               style={{
-                                maxHeight: isExpanded ? '400px' : '0px',
-                                opacity: isExpanded ? 1 : 0,
-                                overflow: isExpanded ? 'auto' : 'hidden',
+                                maxHeight: isExpanded && !isDisabled ? '400px' : '0px',
+                                opacity: isExpanded && !isDisabled ? 1 : 0,
+                                overflow: isExpanded && !isDisabled ? 'auto' : 'hidden',
                                 transition: 'all 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
-                                borderTop: isExpanded ? `1px solid ${colors.gray[200]}` : 'none',
+                                borderTop:
+                                  isExpanded && !isDisabled
+                                    ? `1px solid ${colors.gray[200]}`
+                                    : 'none',
                               }}
                             >
                               {/* Unified grid for header and data rows */}
@@ -615,20 +637,27 @@ export function IngredientPickerModal({
                         // Use association data for display (like Populations page)
                         const householdId = h.association.householdId.toString();
                         const label = h.association.label || `Household #${householdId}`;
+                        const { isDisabled, errorMessage } = getUserHouseholdAvailability(h);
                         return (
                           <div
                             key={householdId}
                             role="button"
-                            tabIndex={0}
+                            tabIndex={isDisabled ? -1 : 0}
+                            aria-disabled={isDisabled || undefined}
                             style={{
                               padding: spacing.sm,
                               borderRadius: spacing.radius.container,
                               border: `1px solid ${colors.border.light}`,
-                              cursor: 'pointer',
+                              cursor: isDisabled ? 'not-allowed' : 'pointer',
+                              opacity: isDisabled ? 0.6 : 1,
                             }}
-                            onClick={() => h.household && handleSelectHousehold(h.household, label)}
+                            onClick={() =>
+                              !isDisabled &&
+                              h.household &&
+                              handleSelectHousehold(h.household, label)
+                            }
                             onKeyDown={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
+                              if (!isDisabled && (e.key === 'Enter' || e.key === ' ')) {
                                 e.preventDefault();
                                 if (h.household) {
                                   handleSelectHousehold(h.household, label);
@@ -640,7 +669,11 @@ export function IngredientPickerModal({
                               <Text fw={500} style={{ fontSize: FONT_SIZES.normal }}>
                                 {label}
                               </Text>
-                              <IconChevronRight size={16} color={colors.gray[400]} />
+                              {errorMessage ? (
+                                <IngredientErrorIcon message={errorMessage} />
+                              ) : (
+                                <IconChevronRight size={16} color={colors.gray[400]} />
+                              )}
                             </Group>
                           </div>
                         );

--- a/app/src/pages/reportBuilder/modals/PolicyBrowseModal.tsx
+++ b/app/src/pages/reportBuilder/modals/PolicyBrowseModal.tsx
@@ -16,6 +16,7 @@ import { useUpdatePolicyAssociation, useUserPolicies } from '@/hooks/useUserPoli
 import { RootState } from '@/store';
 import { PolicyStateProps } from '@/types/pathwayState';
 import { countPolicyModifications } from '@/utils/countParameterChanges';
+import { getUserPolicyAvailability } from '@/utils/ingredientAvailability';
 import { formatLabelParts, getHierarchicalLabelsFromTree } from '@/utils/parameterLabels';
 import { FONT_SIZES, INGREDIENT_COLORS } from '../constants';
 import { createCurrentLawPolicy } from '../currentLaw';
@@ -72,6 +73,7 @@ export function PolicyBrowseModal({
           parameters: p.policy?.parameters || [],
           createdAt: p.association.createdAt,
           updatedAt: p.association.updatedAt,
+          ...getUserPolicyAvailability(p),
         };
       })
       .sort((a, b) => {
@@ -119,7 +121,11 @@ export function PolicyBrowseModal({
     label: string;
     paramCount: number;
     userPolicyAssociationId?: string;
+    isDisabled?: boolean;
   }) => {
+    if (policy.isDisabled) {
+      return;
+    }
     if (policy.userPolicyAssociationId) {
       updatePolicyAssociation.mutate({
         userPolicyId: policy.userPolicyAssociationId,
@@ -253,13 +259,15 @@ export function PolicyBrowseModal({
           parameterTree={parameterTree}
           onClose={() => setDrawerPolicyId(null)}
           onSelect={() => {
-            if (drawerPolicy) {
-              handleSelectPolicy(drawerPolicy);
-              setDrawerPolicyId(null);
+            if (!drawerPolicy || drawerPolicy.isDisabled) {
+              return;
             }
+
+            handleSelectPolicy(drawerPolicy);
+            setDrawerPolicyId(null);
           }}
           onEdit={() => {
-            if (!drawerPolicy) {
+            if (!drawerPolicy || drawerPolicy.isDisabled) {
               return;
             }
 

--- a/app/src/pages/reportBuilder/modals/PopulationBrowseModal.tsx
+++ b/app/src/pages/reportBuilder/modals/PopulationBrowseModal.tsx
@@ -25,6 +25,7 @@ import { useUserHouseholds } from '@/hooks/useUserHousehold';
 import { Geography } from '@/types/ingredients/Geography';
 import { PopulationStateProps } from '@/types/pathwayState';
 import { generateGeographyLabel } from '@/utils/geographyUtils';
+import { getUserHouseholdAvailability } from '@/utils/ingredientAvailability';
 import {
   getUKConstituencies,
   getUKCountries,
@@ -139,7 +140,8 @@ export function PopulationBrowseModal({
         const usageTimestamp = householdUsageStore.getLastUsed(householdIdStr);
         const sortTimestamp =
           usageTimestamp || h.association.updatedAt || h.association.createdAt || '';
-        const isSelectable = Boolean(h.household);
+        const availability = getUserHouseholdAvailability(h);
+        const isSelectable = !availability.isDisabled;
         return {
           id: householdIdStr,
           label: h.association.label || `Household #${householdIdStr}`,
@@ -154,6 +156,7 @@ export function PopulationBrowseModal({
               : h.isLoading
                 ? 'Loading...'
                 : 'Failed to load',
+          errorMessage: availability.errorMessage,
         };
       })
       .sort((a, b) => b.sortTimestamp.localeCompare(a.sortTimestamp));
@@ -366,6 +369,7 @@ export function PopulationBrowseModal({
           memberCount: h.memberCount,
           disabled: !h.isSelectable,
           statusMessage: h.statusMessage,
+          errorMessage: h.errorMessage,
         }))}
         householdsLoading={householdsLoading}
         getSectionTitle={getSectionTitle}

--- a/app/src/pages/reportBuilder/modals/policy/PolicyBrowseContent.tsx
+++ b/app/src/pages/reportBuilder/modals/policy/PolicyBrowseContent.tsx
@@ -9,6 +9,7 @@ import {
   IconSearch,
   IconUsers,
 } from '@tabler/icons-react';
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Button } from '@/components/ui/button';
 import { Group } from '@/components/ui/Group';
 import { Input } from '@/components/ui/input';
@@ -26,6 +27,8 @@ interface PolicyItem {
   paramCount: number;
   createdAt?: string;
   updatedAt?: string;
+  isDisabled?: boolean;
+  errorMessage?: string;
 }
 
 type ActiveSection = 'my-policies' | 'public';
@@ -216,12 +219,15 @@ export function PolicyBrowseContent({
                     ...modalStyles.policyCard,
                     background: colors.white,
                     borderColor: isSelected ? colorConfig.border : colors.gray[200],
+                    cursor: policy.isDisabled ? 'not-allowed' : 'pointer',
+                    opacity: policy.isDisabled ? 0.6 : 1,
                   }}
                   role="button"
-                  tabIndex={0}
-                  onClick={() => onSelectPolicy(policy)}
+                  tabIndex={policy.isDisabled ? -1 : 0}
+                  aria-disabled={policy.isDisabled || undefined}
+                  onClick={() => !policy.isDisabled && onSelectPolicy(policy)}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
+                    if (!policy.isDisabled && (e.key === 'Enter' || e.key === ' ')) {
                       e.preventDefault();
                       onSelectPolicy(policy);
                     }
@@ -249,13 +255,16 @@ export function PolicyBrowseContent({
                         {policy.label}
                       </Text>
                       <Text c="dimmed" style={{ fontSize: FONT_SIZES.small }}>
-                        {policy.paramCount} param{policy.paramCount !== 1 ? 's' : ''} changed
+                        {policy.isDisabled
+                          ? 'Failed to load'
+                          : `${policy.paramCount} param${policy.paramCount !== 1 ? 's' : ''} changed`}
                       </Text>
                     </Stack>
                     <Group gap="xs" style={{ flexShrink: 0 }}>
                       <Button
                         variant="ghost"
                         size="icon-sm"
+                        disabled={policy.isDisabled}
                         onClick={(e) => {
                           e.stopPropagation();
                           onPolicyInfoClick(policy.id);
@@ -263,7 +272,11 @@ export function PolicyBrowseContent({
                       >
                         <IconInfoCircle size={18} />
                       </Button>
-                      <IconChevronRight size={16} color={colors.gray[400]} />
+                      {policy.errorMessage ? (
+                        <IngredientErrorIcon message={policy.errorMessage} />
+                      ) : (
+                        <IconChevronRight size={16} color={colors.gray[400]} />
+                      )}
                     </Group>
                   </Group>
                 </div>

--- a/app/src/pages/reportBuilder/modals/policy/PolicyDetailsDrawer.tsx
+++ b/app/src/pages/reportBuilder/modals/policy/PolicyDetailsDrawer.tsx
@@ -3,6 +3,7 @@
  */
 import { useMemo, useState } from 'react';
 import { IconChevronRight, IconPencil, IconX } from '@tabler/icons-react';
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Button } from '@/components/ui/button';
 import { Group } from '@/components/ui/Group';
 import { Stack } from '@/components/ui/Stack';
@@ -12,6 +13,7 @@ import { ParameterTreeNode } from '@/libs/buildParameterTree';
 import { ParameterMetadata } from '@/types/metadata/parameterMetadata';
 import { Parameter } from '@/types/subIngredients/parameter';
 import { formatPeriod } from '@/utils/dateUtils';
+import { POLICY_LOAD_ERROR_MESSAGE } from '@/utils/ingredientAvailability';
 import { formatLabelParts, getHierarchicalLabelsFromTree } from '@/utils/parameterLabels';
 import { formatParameterValue } from '@/utils/policyTableHelpers';
 import { FONT_SIZES } from '../../constants';
@@ -23,6 +25,8 @@ interface PolicyDetailsDrawerProps {
     label: string;
     paramCount: number;
     parameters: Parameter[];
+    isDisabled?: boolean;
+    errorMessage?: string;
   } | null;
   parameters: Record<string, ParameterMetadata>;
   parameterTree: ParameterTreeNode | null | undefined;
@@ -113,9 +117,12 @@ export function PolicyDetailsDrawer({
         >
           <div style={{ padding: spacing.lg, borderBottom: `1px solid ${colors.gray[200]}` }}>
             <Group justify="space-between" align="center">
-              <Text fw={600} style={{ fontSize: FONT_SIZES.normal, color: colors.gray[900] }}>
-                {policy.label || 'Untitled policy'}
-              </Text>
+              <Group gap="xs" wrap="nowrap">
+                <Text fw={600} style={{ fontSize: FONT_SIZES.normal, color: colors.gray[900] }}>
+                  {policy.label || 'Untitled policy'}
+                </Text>
+                {policy.errorMessage && <IngredientErrorIcon message={policy.errorMessage} />}
+              </Group>
               <Button variant="ghost" size="icon-sm" onClick={onClose}>
                 <IconX size={18} />
               </Button>
@@ -129,26 +136,43 @@ export function PolicyDetailsDrawer({
               background: colors.gray[50],
             }}
           >
-            <PolicyOverviewContent
-              policyLabel={policy.label}
-              onLabelChange={() => {}}
-              isReadOnly
-              showNamingCard={false}
-              modificationCount={policy.paramCount}
-              modifiedParams={modifiedParams}
-              hoveredParamName={hoveredParamName}
-              onHoverParam={setHoveredParamName}
-              onClickParam={() => {}}
-            />
+            {policy.isDisabled ? (
+              <Stack align="center" gap="sm" style={{ padding: spacing.xl }}>
+                <IngredientErrorIcon
+                  message={policy.errorMessage || POLICY_LOAD_ERROR_MESSAGE}
+                  size={20}
+                />
+                <Text c="dimmed" style={{ fontSize: FONT_SIZES.small }}>
+                  Failed to load this policy
+                </Text>
+              </Stack>
+            ) : (
+              <PolicyOverviewContent
+                policyLabel={policy.label}
+                onLabelChange={() => {}}
+                isReadOnly
+                showNamingCard={false}
+                modificationCount={policy.paramCount}
+                modifiedParams={modifiedParams}
+                hoveredParamName={hoveredParamName}
+                onHoverParam={setHoveredParamName}
+                onClickParam={() => {}}
+              />
+            )}
           </div>
           <div style={{ padding: spacing.lg, borderTop: `1px solid ${colors.gray[200]}` }}>
             <Stack gap="sm">
-              <Button className="tw:w-full" onClick={onSelect}>
+              <Button className="tw:w-full" onClick={onSelect} disabled={policy.isDisabled}>
                 Select this policy
                 <IconChevronRight size={16} />
               </Button>
               {onEdit && (
-                <Button variant="outline" className="tw:w-full" onClick={onEdit}>
+                <Button
+                  variant="outline"
+                  className="tw:w-full"
+                  onClick={onEdit}
+                  disabled={policy.isDisabled}
+                >
                   <IconPencil size={16} />
                   Edit policy
                 </Button>

--- a/app/src/pages/reportBuilder/modals/population/PopulationBrowseContent.tsx
+++ b/app/src/pages/reportBuilder/modals/population/PopulationBrowseContent.tsx
@@ -7,6 +7,7 @@
  * - Household list
  */
 import { IconChevronRight, IconHome, IconSearch } from '@tabler/icons-react';
+import { IngredientErrorIcon } from '@/components/common/IngredientErrorIcon';
 import { Group } from '@/components/ui/Group';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -26,6 +27,7 @@ interface HouseholdItem {
   memberCount: number;
   disabled?: boolean;
   statusMessage?: string;
+  errorMessage?: string;
 }
 
 interface PopulationBrowseContentProps {
@@ -192,7 +194,7 @@ export function PopulationBrowseContent({
                     cursor: household.disabled ? 'not-allowed' : 'pointer',
                     opacity: household.disabled ? 0.6 : 1,
                   }}
-                  role={household.disabled ? undefined : 'button'}
+                  role="button"
                   tabIndex={household.disabled ? -1 : 0}
                   aria-disabled={household.disabled || undefined}
                   onClick={() => {
@@ -238,7 +240,11 @@ export function PopulationBrowseContent({
                         )}
                       </Stack>
                     </Group>
-                    {!household.disabled && <IconChevronRight size={16} color={colors.gray[400]} />}
+                    {household.errorMessage ? (
+                      <IngredientErrorIcon message={household.errorMessage} />
+                    ) : (
+                      !household.disabled && <IconChevronRight size={16} color={colors.gray[400]} />
+                    )}
                   </Group>
                 </div>
               ))}

--- a/app/src/pages/reportBuilder/types.ts
+++ b/app/src/pages/reportBuilder/types.ts
@@ -44,13 +44,17 @@ export interface SavedPolicy {
   paramCount: number;
   createdAt?: string;
   updatedAt?: string;
+  isDisabled?: boolean;
+  errorMessage?: string;
 }
 
 export interface RecentPopulation {
   id: string;
   label: string;
   type: 'geography' | 'household';
-  population: PopulationStateProps;
+  population?: PopulationStateProps;
+  isDisabled?: boolean;
+  errorMessage?: string;
 }
 
 // ============================================================================
@@ -125,6 +129,8 @@ export interface OptionChipSquareProps {
   isSelected: boolean;
   onClick: () => void;
   colorConfig: IngredientColorConfig;
+  isDisabled?: boolean;
+  errorMessage?: string;
 }
 
 export interface OptionChipRowProps {
@@ -134,6 +140,8 @@ export interface OptionChipRowProps {
   isSelected: boolean;
   onClick: () => void;
   colorConfig: IngredientColorConfig;
+  isDisabled?: boolean;
+  errorMessage?: string;
 }
 
 export interface CreateCustomChipProps {
@@ -175,6 +183,7 @@ export interface IngredientSectionProps {
   savedPolicies?: SavedPolicy[];
   recentPopulations?: RecentPopulation[];
   currentLabel?: string;
+  selectedErrorMessage?: string;
   isReadOnly?: boolean;
   onViewPolicy?: () => void;
   onViewPopulation?: () => void;
@@ -204,6 +213,8 @@ export interface SimulationBlockProps {
   inheritedPopulation?: PopulationStateProps;
   savedPolicies: SavedPolicy[];
   recentPopulations: RecentPopulation[];
+  policyErrorMessage?: string;
+  populationErrorMessage?: string;
   isReadOnly?: boolean;
 }
 

--- a/app/src/pages/reportBuilder/utils/createReportSimulations.ts
+++ b/app/src/pages/reportBuilder/utils/createReportSimulations.ts
@@ -1,0 +1,86 @@
+import { SimulationAdapter } from '@/adapters';
+import { createSimulation } from '@/api/simulation';
+import { LocalStorageSimulationStore } from '@/api/simulationAssociation';
+import { MOCK_USER_ID } from '@/constants';
+import { Simulation } from '@/types/ingredients/Simulation';
+import { SimulationStateProps } from '@/types/pathwayState';
+import { hasRequiredSimulationIngredients } from '@/utils/ingredientAvailability';
+import { toApiPolicyId } from '../currentLaw';
+
+interface CreateReportSimulationsArgs {
+  simulationStates: SimulationStateProps[];
+  countryId: 'us' | 'uk';
+  currentLawId: number;
+}
+
+interface CreatedReportSimulations {
+  simulationIds: string[];
+  simulations: Simulation[];
+}
+
+export async function createReportSimulations({
+  simulationStates,
+  countryId,
+  currentLawId,
+}: CreateReportSimulationsArgs): Promise<CreatedReportSimulations> {
+  if (!hasRequiredSimulationIngredients(simulationStates)) {
+    throw new Error('Report has incomplete simulations');
+  }
+
+  const simulationStore = new LocalStorageSimulationStore();
+  const simulationIds: string[] = [];
+  const simulations: Simulation[] = [];
+
+  for (const simulationState of simulationStates) {
+    const localPolicyId = simulationState.policy.id;
+    if (!localPolicyId) {
+      throw new Error('Simulation missing policy ID');
+    }
+
+    const policyId = toApiPolicyId(localPolicyId, currentLawId);
+    const householdId = simulationState.population.household?.id;
+    const geographyId = simulationState.population.geography?.geographyId;
+    const populationId = householdId || geographyId;
+    const populationType = householdId ? 'household' : 'geography';
+
+    if (!populationId) {
+      throw new Error('Simulation missing population');
+    }
+
+    const payload = SimulationAdapter.toCreationPayload({
+      populationId,
+      policyId,
+      populationType,
+    });
+    const result = await createSimulation(countryId, payload);
+    const simulationId = result.result.simulation_id;
+
+    if (!simulationId) {
+      throw new Error('Simulation creation returned no ID');
+    }
+
+    await simulationStore.create({
+      userId: MOCK_USER_ID,
+      simulationId,
+      countryId,
+      label: simulationState.label ?? undefined,
+      isCreated: true,
+    });
+
+    simulationIds.push(simulationId);
+    simulations.push({
+      id: simulationId,
+      countryId,
+      apiVersion: undefined,
+      policyId,
+      populationId,
+      populationType,
+      label: simulationState.label,
+      isCreated: true,
+      output: null,
+      status: 'pending',
+    });
+  }
+
+  return { simulationIds, simulations };
+}

--- a/app/src/pathways/report/views/policy/PolicyExistingView.tsx
+++ b/app/src/pathways/report/views/policy/PolicyExistingView.tsx
@@ -13,11 +13,16 @@ import {
   useUserPolicies,
 } from '@/hooks/useUserPolicy';
 import { Parameter } from '@/types/subIngredients/parameter';
+import { getUserPolicyAvailability, isUserPolicySelectable } from '@/utils/ingredientAvailability';
 
 interface PolicyExistingViewProps {
   onSelectPolicy: (policyId: string, label: string, parameters: Parameter[]) => void;
   onBack?: () => void;
   onCancel?: () => void;
+}
+
+function getPolicyAssociationKey(association: UserPolicyWithAssociation): string {
+  return association.association.id?.toString() || association.association.policyId.toString();
 }
 
 export default function PolicyExistingView({
@@ -28,55 +33,42 @@ export default function PolicyExistingView({
   const userId = MOCK_USER_ID.toString();
 
   const { data, isLoading, isError, error } = useUserPolicies(userId);
-  const [localPolicy, setLocalPolicy] = useState<UserPolicyWithAssociation | null>(null);
+  const userPolicies = data || [];
+  const [selectedPolicyKey, setSelectedPolicyKey] = useState<string | null>(null);
+  const localPolicy =
+    userPolicies.find(
+      (association) => getPolicyAssociationKey(association) === selectedPolicyKey
+    ) ?? null;
 
   function canProceed() {
-    if (!localPolicy) {
-      return false;
-    }
-    if (isPolicyWithAssociation(localPolicy)) {
-      return localPolicy.policy?.id !== null && localPolicy.policy?.id !== undefined;
-    }
-    return false;
+    return (
+      !!localPolicy &&
+      isUserPolicySelectable(localPolicy) &&
+      localPolicy.policy.id !== null &&
+      localPolicy.policy.id !== undefined
+    );
   }
 
   function handlePolicySelect(association: UserPolicyWithAssociation) {
-    if (!association) {
-      console.warn(
-        '[PolicyExistingView] handlePolicySelect called with null/undefined association'
-      );
+    if (!association || !isUserPolicySelectable(association)) {
+      console.warn('[PolicyExistingView] handlePolicySelect called with unavailable association');
       return;
     }
 
-    setLocalPolicy(association);
+    setSelectedPolicyKey(getPolicyAssociationKey(association));
   }
 
   function handleSubmit() {
-    if (!localPolicy) {
-      console.warn('[PolicyExistingView] handleSubmit called with no policy selected');
+    if (!localPolicy || !isUserPolicySelectable(localPolicy)) {
+      console.warn('[PolicyExistingView] handleSubmit called with no available policy selected');
       return;
     }
 
-    if (isPolicyWithAssociation(localPolicy)) {
-      handleSubmitPolicy();
-    } else {
-      console.warn(
-        '[PolicyExistingView] handleSubmit: localPolicy is not a valid PolicyWithAssociation'
-      );
-    }
-  }
-
-  function handleSubmitPolicy() {
-    if (!localPolicy || !isPolicyWithAssociation(localPolicy)) {
-      console.warn('[PolicyExistingView] handleSubmitPolicy called with invalid localPolicy state');
-      return;
-    }
-
-    const policyId = localPolicy.policy?.id?.toString();
+    const policyId = localPolicy.policy.id?.toString();
     const label = localPolicy.association?.label || '';
 
     // Policy now has parameters directly (already transformed from policy_json)
-    const parameters = localPolicy.policy?.parameters || [];
+    const parameters = localPolicy.policy.parameters || [];
 
     // Call parent callback instead of dispatching to Redux
     if (policyId) {
@@ -87,8 +79,6 @@ export default function PolicyExistingView({
       );
     }
   }
-
-  const userPolicies = data || [];
 
   if (isLoading) {
     return (
@@ -143,18 +133,22 @@ export default function PolicyExistingView({
     let subtitle = '';
     if ('label' in association.association && association.association.label) {
       title = association.association.label;
-      subtitle = `Policy #${policyId}`;
+      subtitle = association.error ? 'Failed to load' : `Policy #${policyId}`;
     } else {
       title = `Policy #${policyId}`;
     }
 
+    const associationKey = getPolicyAssociationKey(association);
+    const isSelectable = isUserPolicySelectable(association);
+    const availability = getUserPolicyAvailability(association);
+
     return {
-      id: association.association.id?.toString() || policyId.toString(), // Use association ID for unique key
+      id: associationKey,
       title,
       subtitle,
       onClick: () => handlePolicySelect(association),
-      isSelected:
-        isPolicyWithAssociation(localPolicy) && localPolicy.policy?.id === association.policy?.id,
+      ...availability,
+      isSelected: isSelectable && selectedPolicyKey === associationKey,
     };
   });
 

--- a/app/src/pathways/report/views/population/PopulationExistingView.tsx
+++ b/app/src/pathways/report/views/population/PopulationExistingView.tsx
@@ -21,6 +21,12 @@ import { getCountryDisplayName } from '@/models/geography';
 import { Household as HouseholdModel } from '@/models/Household';
 import { Geography } from '@/types/ingredients/Geography';
 import {
+  getLoadErrorAvailability,
+  getUserHouseholdAvailability,
+  isUserHouseholdSelectable,
+  POPULATION_LOAD_ERROR_MESSAGE,
+} from '@/utils/ingredientAvailability';
+import {
   isGeographicAssociationReady,
   isHouseholdAssociationReady,
 } from '@/utils/validation/ingredientValidation';
@@ -30,6 +36,18 @@ interface PopulationExistingViewProps {
   onSelectGeography: (geographyId: string, geography: Geography, label: string) => void;
   onBack?: () => void;
   onCancel?: () => void;
+}
+
+type ExistingPopulation =
+  | UserHouseholdMetadataWithAssociation
+  | UserGeographicMetadataWithAssociation;
+
+function getPopulationAssociationKey(association: ExistingPopulation): string {
+  if (isHouseholdMetadataWithAssociation(association)) {
+    return `household:${association.association.id || association.association.householdId}`;
+  }
+
+  return `geography:${association.association.id || association.association.geographyId}`;
 }
 
 export default function PopulationExistingView({
@@ -56,9 +74,17 @@ export default function PopulationExistingView({
     error: geographicError,
   } = useUserGeographics(userId);
 
-  const [localPopulation, setLocalPopulation] = useState<
-    UserHouseholdMetadataWithAssociation | UserGeographicMetadataWithAssociation | null
-  >(null);
+  const householdPopulations = householdData || [];
+  const geographicPopulations = geographicData || [];
+  const filteredHouseholds = householdPopulations.filter((association) =>
+    isHouseholdMetadataWithAssociation(association)
+  );
+  const allPopulations: ExistingPopulation[] = [...filteredHouseholds, ...geographicPopulations];
+  const [selectedPopulationKey, setSelectedPopulationKey] = useState<string | null>(null);
+  const localPopulation =
+    allPopulations.find(
+      (association) => getPopulationAssociationKey(association) === selectedPopulationKey
+    ) ?? null;
 
   // Combined loading and error states
   const isLoading = isHouseholdLoading || isGeographicLoading;
@@ -71,30 +97,32 @@ export default function PopulationExistingView({
     }
 
     if (isHouseholdMetadataWithAssociation(localPopulation)) {
-      return isHouseholdAssociationReady(localPopulation);
+      return (
+        isUserHouseholdSelectable(localPopulation) && isHouseholdAssociationReady(localPopulation)
+      );
     }
 
     if (isGeographicMetadataWithAssociation(localPopulation)) {
-      return isGeographicAssociationReady(localPopulation);
+      return !localPopulation.error && isGeographicAssociationReady(localPopulation);
     }
 
     return false;
   }
 
   function handleHouseholdPopulationSelect(association: UserHouseholdMetadataWithAssociation) {
-    if (!association) {
+    if (!association || !isUserHouseholdSelectable(association)) {
       return;
     }
 
-    setLocalPopulation(association);
+    setSelectedPopulationKey(getPopulationAssociationKey(association));
   }
 
   function handleGeographicPopulationSelect(association: UserGeographicMetadataWithAssociation) {
-    if (!association) {
+    if (!association || association.error || !isGeographicAssociationReady(association)) {
       return;
     }
 
-    setLocalPopulation(association);
+    setSelectedPopulationKey(getPopulationAssociationKey(association));
   }
 
   function handleSubmit() {
@@ -110,13 +138,11 @@ export default function PopulationExistingView({
   }
 
   function handleSubmitHouseholdPopulation() {
-    if (!localPopulation || !isHouseholdMetadataWithAssociation(localPopulation)) {
-      return;
-    }
-
-    // Guard: ensure household data is fully loaded before continuing
-    if (!localPopulation.household) {
-      console.error('[PopulationExistingView] Household model is undefined');
+    if (
+      !localPopulation ||
+      !isHouseholdMetadataWithAssociation(localPopulation) ||
+      !isUserHouseholdSelectable(localPopulation)
+    ) {
       return;
     }
 
@@ -129,7 +155,12 @@ export default function PopulationExistingView({
   }
 
   function handleSubmitGeographicPopulation() {
-    if (!localPopulation || !isGeographicMetadataWithAssociation(localPopulation)) {
+    if (
+      !localPopulation ||
+      !isGeographicMetadataWithAssociation(localPopulation) ||
+      localPopulation.error ||
+      !isGeographicAssociationReady(localPopulation)
+    ) {
       return;
     }
 
@@ -140,9 +171,6 @@ export default function PopulationExistingView({
     // Call parent callback instead of dispatching to Redux
     onSelectGeography(geographyId, geography, label);
   }
-
-  const householdPopulations = householdData || [];
-  const geographicPopulations = geographicData || [];
 
   if (isLoading) {
     return (
@@ -188,24 +216,23 @@ export default function PopulationExistingView({
     );
   }
 
-  // Filter household populations
-  const filteredHouseholds = householdPopulations.filter((association) =>
-    isHouseholdMetadataWithAssociation(association)
-  );
-
-  // Combine all populations (pagination handled by PathwayView)
-  const allPopulations = [...filteredHouseholds, ...geographicPopulations];
-
   // Build card list items from ALL household populations
   const householdCardItems = allPopulations
     .filter((association) => isHouseholdMetadataWithAssociation(association))
     .map((association) => {
       const isReady = isHouseholdAssociationReady(association);
+      const associationKey = getPopulationAssociationKey(association);
+      const isSelectable = isUserHouseholdSelectable(association);
+      const availability = getUserHouseholdAvailability(association);
 
       let title = '';
       let subtitle = '';
 
-      if (!isReady) {
+      if (association.error) {
+        title =
+          association.association.label || `Household #${association.association.householdId}`;
+        subtitle = 'Failed to load';
+      } else if (!isReady) {
         // NOT LOADED YET - show loading indicator
         title = '⏳ Loading...';
         subtitle = 'Household data not loaded yet';
@@ -218,13 +245,12 @@ export default function PopulationExistingView({
       }
 
       return {
-        id: association.association.id?.toString() || association.household?.id?.toString(), // Use association ID for unique key
+        id: associationKey,
         title,
         subtitle,
         onClick: () => handleHouseholdPopulationSelect(association!),
-        isSelected:
-          isHouseholdMetadataWithAssociation(localPopulation) &&
-          localPopulation.household?.id === association.household?.id,
+        ...availability,
+        isSelected: isSelectable && selectedPopulationKey === associationKey,
       };
     });
 
@@ -245,6 +271,12 @@ export default function PopulationExistingView({
   const geographicCardItems = allPopulations
     .filter((association) => isGeographicMetadataWithAssociation(association))
     .map((association) => {
+      const associationKey = getPopulationAssociationKey(association);
+      const isSelectable = !association.error && isGeographicAssociationReady(association);
+      const availability = getLoadErrorAvailability(
+        association.error,
+        POPULATION_LOAD_ERROR_MESSAGE
+      );
       let title = '';
       let subtitle = '';
 
@@ -264,13 +296,13 @@ export default function PopulationExistingView({
       }
 
       return {
-        id: association.association.id?.toString() || association.geography?.id?.toString(), // Use association ID for unique key
+        id: associationKey,
         title,
         subtitle,
         onClick: () => handleGeographicPopulationSelect(association!),
-        isSelected:
-          isGeographicMetadataWithAssociation(localPopulation) &&
-          localPopulation.geography?.id === association.geography!.id,
+        ...availability,
+        isDisabled: !isSelectable,
+        isSelected: isSelectable && selectedPopulationKey === associationKey,
       };
     });
 

--- a/app/src/pathways/report/views/simulation/SimulationSetupView.tsx
+++ b/app/src/pathways/report/views/simulation/SimulationSetupView.tsx
@@ -21,6 +21,10 @@ interface SimulationSetupViewProps {
   onNavigateToPolicy: () => void;
   onNavigateToPopulation: () => void;
   onNext: () => void;
+  isPolicyUnavailable?: boolean;
+  isPopulationUnavailable?: boolean;
+  policyErrorMessage?: string;
+  populationErrorMessage?: string;
   onBack?: () => void;
   onCancel?: () => void;
 }
@@ -32,6 +36,10 @@ export default function SimulationSetupView({
   onNavigateToPolicy,
   onNavigateToPopulation,
   onNext,
+  isPolicyUnavailable = false,
+  isPopulationUnavailable = false,
+  policyErrorMessage,
+  populationErrorMessage,
   onBack,
   onCancel,
 }: SimulationSetupViewProps) {
@@ -39,6 +47,8 @@ export default function SimulationSetupView({
 
   const policy = simulation.policy;
   const population = simulation.population;
+  const isPolicyReady = isPolicyConfigured(policy) && !isPolicyUnavailable;
+  const isPopulationReady = isPopulationConfigured(population) && !isPopulationUnavailable;
 
   // Detect if we're in report mode for simulation 2 (population will be inherited)
   const isSimulation2InReport = isReportMode && simulationIndex === 1;
@@ -52,17 +62,17 @@ export default function SimulationSetupView({
   };
 
   const handleNext = () => {
-    if (selectedCard === 'population' && !isPopulationConfigured(population)) {
+    if (selectedCard === 'population' && !isPopulationReady) {
       onNavigateToPopulation();
-    } else if (selectedCard === 'policy' && !isPolicyConfigured(policy)) {
+    } else if (selectedCard === 'policy' && !isPolicyReady) {
       onNavigateToPolicy();
-    } else if (isPolicyConfigured(policy) && isPopulationConfigured(population)) {
+    } else if (isPolicyReady && isPopulationReady) {
       // Both are fulfilled, proceed to next step
       onNext();
     }
   };
 
-  const canProceed: boolean = isPolicyConfigured(policy) && isPopulationConfigured(population);
+  const canProceed = isPolicyReady && isPopulationReady;
 
   function generatePopulationCardTitle() {
     if (!isPopulationConfigured(population)) {
@@ -87,6 +97,10 @@ export default function SimulationSetupView({
   }
 
   function generatePopulationCardDescription() {
+    if (isPopulationUnavailable) {
+      return populationErrorMessage ? 'Failed to load' : 'Population unavailable';
+    }
+
     if (!isPopulationConfigured(population)) {
       return 'Select a household collection or custom household';
     }
@@ -121,6 +135,10 @@ export default function SimulationSetupView({
   }
 
   function generatePolicyCardDescription() {
+    if (isPolicyUnavailable) {
+      return policyErrorMessage ? 'Failed to load' : 'Policy unavailable';
+    }
+
     if (!isPolicyConfigured(policy)) {
       return 'Select a policy to apply to the simulation';
     }
@@ -136,7 +154,8 @@ export default function SimulationSetupView({
       description: generatePopulationCardDescription(),
       onClick: handlePopulationSelect,
       isSelected: selectedCard === 'population',
-      isFulfilled: isPopulationConfigured(population),
+      isFulfilled: isPopulationReady,
+      errorMessage: populationErrorMessage,
       isDisabled: false,
     },
     {
@@ -144,20 +163,21 @@ export default function SimulationSetupView({
       description: generatePolicyCardDescription(),
       onClick: handlePolicySelect,
       isSelected: selectedCard === 'policy',
-      isFulfilled: isPolicyConfigured(policy),
+      isFulfilled: isPolicyReady,
+      errorMessage: policyErrorMessage,
       isDisabled: false,
     },
   ];
 
   // Determine the primary action label and state
   const getPrimaryAction = () => {
-    if (selectedCard === 'population' && !isPopulationConfigured(population)) {
+    if (selectedCard === 'population' && !isPopulationReady) {
       return {
         label: 'Configure household(s)',
         onClick: handleNext,
         isDisabled: false,
       };
-    } else if (selectedCard === 'policy' && !isPolicyConfigured(policy)) {
+    } else if (selectedCard === 'policy' && !isPolicyReady) {
       return {
         label: 'Configure policy',
         onClick: handleNext,

--- a/app/src/pathways/report/views/simulation/SimulationSubmitView.tsx
+++ b/app/src/pathways/report/views/simulation/SimulationSubmitView.tsx
@@ -14,6 +14,10 @@ import { SimulationCreationPayload } from '@/types/payloads';
 interface SimulationSubmitViewProps {
   simulation: SimulationStateProps;
   onSubmitSuccess: (simulationId: string) => void;
+  isPolicyUnavailable?: boolean;
+  isPopulationUnavailable?: boolean;
+  policyErrorMessage?: string;
+  populationErrorMessage?: string;
   onBack?: () => void;
   onCancel?: () => void;
 }
@@ -21,12 +25,26 @@ interface SimulationSubmitViewProps {
 export default function SimulationSubmitView({
   simulation,
   onSubmitSuccess,
+  isPolicyUnavailable = false,
+  isPopulationUnavailable = false,
+  policyErrorMessage,
+  populationErrorMessage,
   onBack,
   onCancel,
 }: SimulationSubmitViewProps) {
   const { createSimulation, isPending } = useCreateSimulation(simulation?.label || undefined);
+  const hasPolicy = !!simulation.policy.id;
+  const hasPopulation = !!(
+    simulation.population.household?.id || simulation.population.geography?.id
+  );
+  const isSubmissionBlocked =
+    !hasPolicy || !hasPopulation || isPolicyUnavailable || isPopulationUnavailable;
 
   function handleSubmit() {
+    if (isSubmissionBlocked) {
+      return;
+    }
+
     // Determine population ID and type based on what's set
     let populationId: string | undefined;
     let populationType: 'household' | 'geography' | undefined;
@@ -61,18 +79,30 @@ export default function SimulationSubmitView({
     {
       title: 'Population added',
       description:
-        simulation.population.label ||
-        `Household #${simulation.population.household?.id || simulation.population.geography?.id}`,
-      isFulfilled: !!(simulation.population.household?.id || simulation.population.geography?.id),
-      badge:
-        simulation.population.label ||
-        `Household #${simulation.population.household?.id || simulation.population.geography?.id}`,
+        isPopulationUnavailable && populationErrorMessage
+          ? 'Failed to load'
+          : simulation.population.label ||
+            `Household #${simulation.population.household?.id || simulation.population.geography?.id}`,
+      isFulfilled: hasPopulation && !isPopulationUnavailable,
+      isDisabled: isPopulationUnavailable,
+      errorMessage: populationErrorMessage,
+      badge: isPopulationUnavailable
+        ? undefined
+        : simulation.population.label ||
+          `Household #${simulation.population.household?.id || simulation.population.geography?.id}`,
     },
     {
       title: 'Policy reform added',
-      description: simulation.policy.label || `Policy #${simulation.policy.id}`,
-      isFulfilled: !!simulation.policy.id,
-      badge: simulation.policy.label || `Policy #${simulation.policy.id}`,
+      description:
+        isPolicyUnavailable && policyErrorMessage
+          ? 'Failed to load'
+          : simulation.policy.label || `Policy #${simulation.policy.id}`,
+      isFulfilled: hasPolicy && !isPolicyUnavailable,
+      isDisabled: isPolicyUnavailable,
+      errorMessage: policyErrorMessage,
+      badge: isPolicyUnavailable
+        ? undefined
+        : simulation.policy.label || `Policy #${simulation.policy.id}`,
     },
   ];
 
@@ -84,6 +114,7 @@ export default function SimulationSubmitView({
       submitButtonText="Create simulation"
       submissionHandler={handleSubmit}
       submitButtonLoading={isPending}
+      submitButtonDisabled={isSubmissionBlocked}
       onBack={onBack}
       onCancel={onCancel}
     />

--- a/app/src/pathways/simulation/SimulationPathwayWrapper.tsx
+++ b/app/src/pathways/simulation/SimulationPathwayWrapper.tsx
@@ -16,9 +16,16 @@ import { useRegions } from '@/hooks/useRegions';
 import { useUserGeographics } from '@/hooks/useUserGeographic';
 import { useUserHouseholds } from '@/hooks/useUserHousehold';
 import { useUserPolicies } from '@/hooks/useUserPolicy';
+import { CURRENT_LAW_LABEL } from '@/pages/reportBuilder/currentLaw';
 import { RootState } from '@/store';
 import { SimulationViewMode } from '@/types/pathwayModes/SimulationViewMode';
 import { SimulationStateProps } from '@/types/pathwayState';
+import {
+  findUserHouseholdByHouseholdId,
+  findUserPolicyByPolicyId,
+  getUserHouseholdAvailability,
+  getUserPolicyAvailability,
+} from '@/utils/ingredientAvailability';
 import {
   createPolicyCallbacks,
   createPopulationCallbacks,
@@ -81,6 +88,22 @@ export default function SimulationPathwayWrapper({ onComplete }: SimulationPathw
 
   const hasExistingPolicies = (userPolicies?.length ?? 0) > 0;
   const hasExistingPopulations = (userHouseholds?.length ?? 0) + (userGeographics?.length ?? 0) > 0;
+  const isCurrentLawSelected =
+    simulationState.policy.id === currentLawId.toString() &&
+    simulationState.policy.label === CURRENT_LAW_LABEL;
+  const selectedPolicy = isCurrentLawSelected
+    ? undefined
+    : findUserPolicyByPolicyId(userPolicies, simulationState.policy.id);
+  const selectedHousehold = findUserHouseholdByHouseholdId(
+    userHouseholds,
+    simulationState.population.household?.id
+  );
+  const policyAvailability = selectedPolicy
+    ? getUserPolicyAvailability(selectedPolicy)
+    : { isDisabled: false, errorMessage: undefined };
+  const populationAvailability = selectedHousehold
+    ? getUserHouseholdAvailability(selectedHousehold)
+    : { isDisabled: false, errorMessage: undefined };
 
   // ========== CONDITIONAL NAVIGATION HANDLERS ==========
   // Skip selection view if user has no existing items
@@ -149,7 +172,7 @@ export default function SimulationPathwayWrapper({ onComplete }: SimulationPathw
       policy: {
         ...prev.policy,
         id: currentLawId.toString(),
-        label: 'Current law',
+        label: CURRENT_LAW_LABEL,
         parameters: [],
       },
     }));
@@ -193,6 +216,10 @@ export default function SimulationPathwayWrapper({ onComplete }: SimulationPathw
           onNavigateToPolicy={handleNavigateToPolicy}
           onNavigateToPopulation={handleNavigateToPopulation}
           onNext={() => navigateToMode(SimulationViewMode.SUBMIT)}
+          isPolicyUnavailable={policyAvailability.isDisabled}
+          isPopulationUnavailable={populationAvailability.isDisabled}
+          policyErrorMessage={policyAvailability.errorMessage}
+          populationErrorMessage={populationAvailability.errorMessage}
           onBack={canGoBack ? goBack : undefined}
           onCancel={handleCancel}
         />
@@ -204,6 +231,10 @@ export default function SimulationPathwayWrapper({ onComplete }: SimulationPathw
         <SimulationSubmitView
           simulation={simulationState}
           onSubmitSuccess={simulationCallbacks.handleSubmitSuccess}
+          isPolicyUnavailable={policyAvailability.isDisabled}
+          isPopulationUnavailable={populationAvailability.isDisabled}
+          policyErrorMessage={policyAvailability.errorMessage}
+          populationErrorMessage={populationAvailability.errorMessage}
           onBack={canGoBack ? goBack : undefined}
           onCancel={handleCancel}
         />

--- a/app/src/tests/unit/components/IngredientReadView.test.tsx
+++ b/app/src/tests/unit/components/IngredientReadView.test.tsx
@@ -125,4 +125,51 @@ describe('IngredientReadView', () => {
     // Then
     expect(onBuild).toHaveBeenCalled();
   });
+
+  test('given disabled row then displays warning and blocks row action', async () => {
+    // Given
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+
+    // When
+    render(
+      <IngredientReadView
+        ingredient={MOCK_INGREDIENT.NAME.toLowerCase()}
+        title={MOCK_INGREDIENT.TITLE}
+        isLoading={false}
+        isError={false}
+        data={[
+          {
+            id: 'broken-policy',
+            isDisabled: true,
+            errorMessage: 'Error loading this policy',
+            name: { text: 'Broken Policy' },
+            actions: null,
+          },
+        ]}
+        columns={[
+          {
+            key: 'name',
+            header: 'Name',
+            type: 'text',
+          },
+          {
+            key: 'actions',
+            header: '',
+            type: 'actions',
+            actions: [{ action: 'edit', tooltip: 'Edit policy', icon: <span>Edit</span> }],
+            onAction,
+          },
+        ]}
+      />
+    );
+
+    // Then
+    expect(screen.getByLabelText('Error loading this policy')).toBeInTheDocument();
+    const actionButton = screen.getByRole('button', { name: 'Edit policy' });
+    expect(actionButton).toBeDisabled();
+
+    await user.click(actionButton);
+    expect(onAction).not.toHaveBeenCalled();
+  });
 });

--- a/app/src/tests/unit/hooks/useUserHousehold.test.tsx
+++ b/app/src/tests/unit/hooks/useUserHousehold.test.tsx
@@ -373,10 +373,12 @@ describe('useUserHousehold hooks', () => {
 
       // Then
       await waitFor(() => {
-        expect(result.current.isError).toBe(true);
+        expect(result.current.isLoading).toBe(false);
       });
 
       expect(result.current.data).toBeDefined();
+      expect(result.current.isError).toBe(false);
+      expect(result.current.error).toBeNull();
 
       // First household should have data
       expect(result.current.data![0].household).toBeInstanceOf(HouseholdModel);

--- a/app/src/tests/unit/hooks/useUserReports.test.tsx
+++ b/app/src/tests/unit/hooks/useUserReports.test.tsx
@@ -400,14 +400,16 @@ describe('useUserReports', () => {
       expect(result.current.data.length).toBeGreaterThan(0);
       // Some simulations might still be cached, so we just verify the structure
       expect(result.current.data[0]).toHaveProperty('simulations');
+      expect(result.current.isError).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.data.some((report) => report.error)).toBe(true);
     });
 
-    test('given policy fetch fails then continues with partial data', async () => {
+    test('given policy fetch fails then marks affected reports without page-level error', async () => {
       // Given
       const userId = TEST_USER_ID;
-      vi.spyOn(policyApi, 'fetchPolicyById').mockRejectedValue(
-        new Error(ERROR_MESSAGES.POLICY_FETCH_FAILED)
-      );
+      const error = new Error('Policy fetch failed');
+      vi.spyOn(policyApi, 'fetchPolicyById').mockRejectedValue(error);
 
       // When
       const { result } = renderHook(() => useUserReports(userId), { wrapper });
@@ -417,12 +419,11 @@ describe('useUserReports', () => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      // Should still return reports but policies will be undefined or partial
-      // The hook doesn't guarantee empty arrays when fetches fail
       expect(result.current.data).toBeDefined();
       expect(result.current.data.length).toBeGreaterThan(0);
-      // Some policies might still be cached, so we just verify the structure
-      expect(result.current.data[0]).toHaveProperty('policies');
+      expect(result.current.isError).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.data.some((report) => report.error === error)).toBe(true);
     });
   });
 

--- a/app/src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/ModifyReportPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@test-utils';
+import { act, render, screen } from '@test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ReportIngredientsInput } from '@/hooks/utils/useFetchReportIngredients';
 import ModifyReportPage from '@/pages/reportBuilder/ModifyReportPage';
@@ -7,6 +7,9 @@ import type { ReportBuilderState } from '@/pages/reportBuilder/types';
 const mockUseAppLocation = vi.fn();
 const mockUseReportBuilderState = vi.fn();
 const mockReportBuilderShell = vi.fn();
+const { mockUseModifyReportSubmission } = vi.hoisted(() => ({
+  mockUseModifyReportSubmission: vi.fn(),
+}));
 
 const baseReportState: ReportBuilderState = {
   id: 'sur-123',
@@ -46,12 +49,7 @@ vi.mock('@/pages/reportBuilder/hooks/useReportBuilderState', () => ({
 }));
 
 vi.mock('@/pages/reportBuilder/hooks/useModifyReportSubmission', () => ({
-  useModifyReportSubmission: () => ({
-    handleSaveAsNew: vi.fn(),
-    handleReplace: vi.fn(),
-    isSavingNew: false,
-    isReplacing: false,
-  }),
+  useModifyReportSubmission: () => mockUseModifyReportSubmission(),
 }));
 
 vi.mock('@/pages/reportBuilder/components', () => ({
@@ -75,6 +73,13 @@ describe('ModifyReportPage', () => {
       originalState: baseReportState,
       isLoading: false,
       error: null,
+    });
+    mockUseModifyReportSubmission.mockReturnValue({
+      handleSaveAsNew: vi.fn(),
+      handleReplace: vi.fn(),
+      isSavingNew: false,
+      isReplacing: false,
+      isReportSubmissionBlocked: false,
     });
   });
 
@@ -137,5 +142,27 @@ describe('ModifyReportPage', () => {
 
     const shellProps = mockReportBuilderShell.mock.calls[0]?.[0];
     expect(shellProps.backLabel).toBe('sur-123');
+  });
+
+  test('given report submission is blocked then update and save actions are disabled', () => {
+    mockUseModifyReportSubmission.mockReturnValue({
+      handleSaveAsNew: vi.fn(),
+      handleReplace: vi.fn(),
+      isSavingNew: false,
+      isReplacing: false,
+      isReportSubmissionBlocked: true,
+    });
+    render(<ModifyReportPage userReportId="sur-123" />);
+
+    const initialShellProps = mockReportBuilderShell.mock.calls[0]?.[0];
+    act(() => initialShellProps.actions[0].onClick());
+
+    const editShellProps = mockReportBuilderShell.mock.lastCall?.[0];
+    expect(editShellProps.actions.find((action: any) => action.key === 'replace')).toMatchObject({
+      disabled: true,
+    });
+    expect(editShellProps.actions.find((action: any) => action.key === 'save-new')).toMatchObject({
+      disabled: true,
+    });
   });
 });

--- a/app/src/tests/unit/pages/reportBuilder/components/IngredientSectionFull.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/components/IngredientSectionFull.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { IngredientSectionFull } from '@/pages/reportBuilder/components/IngredientSectionFull';
+
+describe('IngredientSectionFull', () => {
+  test('given the selected policy has errored then displays the shared error state', () => {
+    render(
+      <IngredientSectionFull
+        type="policy"
+        currentId="policy-123"
+        currentLabel="Broken policy"
+        selectedErrorMessage="Error loading this policy"
+        onCreateCustom={vi.fn()}
+        onBrowseMore={vi.fn()}
+        onDeselectPolicy={vi.fn()}
+        onViewPolicy={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Broken policy')).toBeInTheDocument();
+    expect(screen.getByText('Failed to load')).toBeInTheDocument();
+    expect(screen.getByLabelText('Error loading this policy')).toBeInTheDocument();
+    expect(screen.getByText('Broken policy').closest('[aria-disabled]')).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+});

--- a/app/src/tests/unit/pages/reportBuilder/components/SimulationCanvas.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/components/SimulationCanvas.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, userEvent } from '@test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { SimulationCanvas } from '@/pages/reportBuilder/components/SimulationCanvas';
+import type { IngredientPickerState, ReportBuilderState } from '@/pages/reportBuilder/types';
+import { initializeSimulationState } from '@/utils/pathwayState/initializeSimulationState';
+
+const { mockRetryCatalogs, mockUseSimulationCanvas } = vi.hoisted(() => ({
+  mockRetryCatalogs: vi.fn(),
+  mockUseSimulationCanvas: vi.fn(),
+}));
+
+vi.mock('@/pages/reportBuilder/hooks/useSimulationCanvas', () => ({
+  useSimulationCanvas: (...args: unknown[]) => mockUseSimulationCanvas(...args),
+}));
+
+describe('SimulationCanvas', () => {
+  const reportState: ReportBuilderState = {
+    label: null,
+    year: '2026',
+    simulations: [initializeSimulationState()],
+  };
+  const pickerState: IngredientPickerState = {
+    isOpen: false,
+    simulationIndex: 0,
+    ingredientType: 'policy',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSimulationCanvas.mockReturnValue({
+      isInitialLoading: false,
+      catalogError: new Error('Policy associations failed'),
+      catalogErrorMessage: "We couldn't load your saved policies.",
+      isRetryingCatalogs: false,
+      retryCatalogs: mockRetryCatalogs,
+      householdEditorState: { returnToBrowseOnBack: false },
+      policyCreationState: { returnToBrowseOnBack: false },
+      closeHouseholdEditor: vi.fn(),
+      returnToPopulationBrowse: vi.fn(),
+      closePolicyCreation: vi.fn(),
+      returnToPolicyBrowse: vi.fn(),
+    });
+  });
+
+  test('given a catalog failure then shows an actionable error instead of the loading skeleton', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SimulationCanvas
+        reportYear="2026"
+        reportState={reportState}
+        setReportState={vi.fn()}
+        pickerState={pickerState}
+        setPickerState={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Saved ingredients unavailable');
+    expect(screen.getByText("We couldn't load your saved policies.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(mockRetryCatalogs).toHaveBeenCalledOnce();
+  });
+});

--- a/app/src/tests/unit/pages/reportBuilder/components/chips/OptionChips.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/components/chips/OptionChips.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, userEvent } from '@test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { OptionChipRow } from '@/pages/reportBuilder/components/chips/OptionChipRow';
+import { OptionChipSquare } from '@/pages/reportBuilder/components/chips/OptionChipSquare';
+import { INGREDIENT_COLORS } from '@/pages/reportBuilder/constants';
+
+describe.each([
+  { variant: 'square', OptionChip: OptionChipSquare },
+  { variant: 'row', OptionChip: OptionChipRow },
+])('$variant option chip', ({ OptionChip }) => {
+  test('given an ingredient error then displays the warning icon and blocks selection', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+
+    render(
+      <OptionChip
+        icon={<span>Policy</span>}
+        label="Broken policy"
+        description="Failed to load"
+        isSelected={false}
+        onClick={onClick}
+        colorConfig={INGREDIENT_COLORS.policy}
+        isDisabled
+        errorMessage="Error loading this policy"
+      />
+    );
+
+    const chip = screen.getByText('Broken policy').closest('[role="button"]');
+    expect(chip).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByLabelText('Error loading this policy')).toBeInTheDocument();
+
+    await user.click(chip!);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/tests/unit/pages/reportBuilder/hooks/useModifyReportSubmission.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/hooks/useModifyReportSubmission.test.tsx
@@ -17,6 +17,10 @@ import {
   TEST_SIMULATION_IDS,
 } from '@/tests/fixtures/pages/reportBuilder/useReportSubmissionMocks';
 
+const { mockIngredientAvailability } = vi.hoisted(() => ({
+  mockIngredientAvailability: vi.fn(),
+}));
+
 // Mock modules
 vi.mock('@/api/simulation', () => ({
   createSimulation: (...args: any[]) => mockCreateSimulationFn(...args),
@@ -74,6 +78,10 @@ vi.mock('@/constants', () => ({
   CURRENT_YEAR: '2026',
 }));
 
+vi.mock('@/pages/reportBuilder/hooks/useReportIngredientAvailability', () => ({
+  useReportIngredientAvailability: () => mockIngredientAvailability(),
+}));
+
 const mockMutateAsync = vi.fn().mockResolvedValue({});
 
 vi.mock('@/hooks/useUserReportAssociations', () => ({
@@ -103,6 +111,11 @@ describe('useModifyReportSubmission', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupDefaultMocks();
+    mockIngredientAvailability.mockReturnValue({
+      hasUnavailableIngredients: false,
+      isCheckingIngredientAvailability: false,
+      isReportConfigured: true,
+    });
 
     queryClient = new QueryClient({
       defaultOptions: {
@@ -231,5 +244,71 @@ describe('useModifyReportSubmission', () => {
         expect(mockOnSuccess).toHaveBeenCalledWith(EXISTING_USER_REPORT_ID);
       });
     });
+  });
+
+  test('given a selected ingredient has errored then save and replace are blocked', async () => {
+    // Given
+    mockIngredientAvailability.mockReturnValue({
+      hasUnavailableIngredients: true,
+      isCheckingIngredientAvailability: false,
+      isReportConfigured: false,
+    });
+    const { result } = renderHook(
+      () =>
+        useModifyReportSubmission({
+          reportState: mockTwoSimReportState,
+          countryId: 'us',
+          existingUserReportId: EXISTING_USER_REPORT_ID,
+          onSuccess: mockOnSuccess,
+        }),
+      { wrapper }
+    );
+
+    // When
+    await result.current.handleSaveAsNew('Blocked report');
+    await result.current.handleReplace();
+
+    // Then
+    expect(result.current.isReportSubmissionBlocked).toBe(true);
+    expect(mockCreateSimulationFn).not.toHaveBeenCalled();
+    expect(mockLocalStorageCreateFn).not.toHaveBeenCalled();
+  });
+
+  test('given an incomplete simulation then save and replace are blocked', async () => {
+    // Given
+    mockIngredientAvailability.mockReturnValue({
+      hasUnavailableIngredients: false,
+      isCheckingIngredientAvailability: false,
+      isReportConfigured: false,
+    });
+    const incompleteState = {
+      ...mockTwoSimReportState,
+      simulations: [
+        {
+          ...mockTwoSimReportState.simulations[0],
+          policy: { id: undefined, label: null, parameters: [] },
+        },
+        mockTwoSimReportState.simulations[1],
+      ],
+    };
+    const { result } = renderHook(
+      () =>
+        useModifyReportSubmission({
+          reportState: incompleteState as any,
+          countryId: 'us',
+          existingUserReportId: EXISTING_USER_REPORT_ID,
+          onSuccess: mockOnSuccess,
+        }),
+      { wrapper }
+    );
+
+    // When
+    await result.current.handleSaveAsNew('Incomplete report');
+    await result.current.handleReplace();
+
+    // Then
+    expect(result.current.isReportSubmissionBlocked).toBe(true);
+    expect(mockCreateSimulationFn).not.toHaveBeenCalled();
+    expect(mockLocalStorageCreateFn).not.toHaveBeenCalled();
   });
 });

--- a/app/src/tests/unit/pages/reportBuilder/hooks/useReportSubmission.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/hooks/useReportSubmission.test.tsx
@@ -20,6 +20,10 @@ import {
   TEST_SIMULATION_IDS,
 } from '@/tests/fixtures/pages/reportBuilder/useReportSubmissionMocks';
 
+const { mockIngredientAvailability } = vi.hoisted(() => ({
+  mockIngredientAvailability: vi.fn(),
+}));
+
 // Mock modules
 vi.mock('@/api/simulation', () => ({
   createSimulation: (...args: any[]) => mockCreateSimulationFn(...args),
@@ -59,6 +63,10 @@ vi.mock('@/constants', () => ({
   CURRENT_YEAR: '2026',
 }));
 
+vi.mock('@/pages/reportBuilder/hooks/useReportIngredientAvailability', () => ({
+  useReportIngredientAvailability: () => mockIngredientAvailability(),
+}));
+
 describe('useReportSubmission', () => {
   let queryClient: QueryClient;
   let mockStore: ReturnType<typeof createTestStore>;
@@ -67,6 +75,11 @@ describe('useReportSubmission', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupDefaultMocks();
+    mockIngredientAvailability.mockReturnValue({
+      hasUnavailableIngredients: false,
+      isCheckingIngredientAvailability: false,
+      isReportConfigured: true,
+    });
 
     queryClient = new QueryClient({
       defaultOptions: {
@@ -240,6 +253,11 @@ describe('useReportSubmission', () => {
 
     test('given simulation without policy then isReportConfigured is false', () => {
       // Given
+      mockIngredientAvailability.mockReturnValue({
+        hasUnavailableIngredients: false,
+        isCheckingIngredientAvailability: false,
+        isReportConfigured: false,
+      });
       const incompleteState = {
         ...mockSingleSimReportState,
         simulations: [
@@ -263,6 +281,31 @@ describe('useReportSubmission', () => {
 
       // Then
       expect(result.current.isReportConfigured).toBe(false);
+    });
+
+    test('given a selected ingredient has errored then submission is blocked', async () => {
+      // Given
+      mockIngredientAvailability.mockReturnValue({
+        hasUnavailableIngredients: true,
+        isCheckingIngredientAvailability: false,
+        isReportConfigured: false,
+      });
+      const { result } = renderHook(
+        () =>
+          useReportSubmission({
+            reportState: mockSingleSimReportState,
+            countryId: 'us',
+            onSuccess: mockOnSuccess,
+          }),
+        { wrapper }
+      );
+
+      // When
+      await result.current.handleSubmit();
+
+      // Then
+      expect(result.current.isReportConfigured).toBe(false);
+      expect(mockCreateSimulationFn).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/src/tests/unit/pages/reportBuilder/hooks/useSimulationCanvas.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/hooks/useSimulationCanvas.test.tsx
@@ -8,6 +8,10 @@ const mockUseCurrentCountry = vi.fn();
 const mockUseUserPolicies = vi.fn();
 const mockUseUserHouseholds = vi.fn();
 const mockUseRegions = vi.fn();
+const mockGeographyRecentIds = vi.fn();
+const mockHouseholdRecentIds = vi.fn();
+const mockRefetchPolicyAssociations = vi.fn();
+const mockRefetchHouseholdAssociations = vi.fn();
 
 vi.mock('@/hooks/useCurrentCountry', () => ({
   useCurrentCountry: () => mockUseCurrentCountry(),
@@ -27,11 +31,11 @@ vi.mock('@/hooks/useRegions', () => ({
 
 vi.mock('@/api/usageTracking', () => ({
   geographyUsageStore: {
-    getRecentIds: () => [],
+    getRecentIds: (...args: unknown[]) => mockGeographyRecentIds(...args),
     getLastUsed: () => null,
   },
   householdUsageStore: {
-    getRecentIds: () => [],
+    getRecentIds: (...args: unknown[]) => mockHouseholdRecentIds(...args),
     getLastUsed: () => null,
   },
 }));
@@ -55,9 +59,21 @@ describe('useSimulationCanvas', () => {
     vi.useFakeTimers();
 
     mockUseCurrentCountry.mockReturnValue('us');
-    mockUseUserPolicies.mockReturnValue({ data: [], isLoading: false });
-    mockUseUserHouseholds.mockReturnValue({ data: [], isLoading: false });
+    mockUseUserPolicies.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetchAssociations: mockRefetchPolicyAssociations,
+    });
+    mockUseUserHouseholds.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetchAssociations: mockRefetchHouseholdAssociations,
+    });
     mockUseRegions.mockReturnValue({ data: [], isLoading: false });
+    mockGeographyRecentIds.mockReturnValue([]);
+    mockHouseholdRecentIds.mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -87,6 +103,58 @@ describe('useSimulationCanvas', () => {
     expect(result.current.isInitialLoading).toBe(false);
   });
 
+  test('given policy associations fail then it exposes an error instead of permanent loading', async () => {
+    const error = new Error('Policy associations failed');
+    mockUseUserPolicies.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error,
+      refetchAssociations: mockRefetchPolicyAssociations,
+    });
+
+    const { result } = renderHook(() =>
+      useSimulationCanvas({
+        reportState,
+        setReportState,
+        pickerState,
+        setPickerState,
+      })
+    );
+
+    expect(result.current.isInitialLoading).toBe(false);
+    expect(result.current.catalogError).toBe(error);
+    expect(result.current.catalogErrorMessage).toBe("We couldn't load your saved policies.");
+
+    await act(async () => {
+      await result.current.retryCatalogs();
+    });
+    expect(mockRefetchPolicyAssociations).toHaveBeenCalledOnce();
+    expect(mockRefetchHouseholdAssociations).not.toHaveBeenCalled();
+  });
+
+  test('given household associations fail then it exposes a household catalog error', () => {
+    const error = new Error('Household associations failed');
+    mockUseUserHouseholds.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error,
+      refetchAssociations: mockRefetchHouseholdAssociations,
+    });
+
+    const { result } = renderHook(() =>
+      useSimulationCanvas({
+        reportState,
+        setReportState,
+        pickerState,
+        setPickerState,
+      })
+    );
+
+    expect(result.current.isInitialLoading).toBe(false);
+    expect(result.current.catalogError).toBe(error);
+    expect(result.current.catalogErrorMessage).toBe("We couldn't load your saved households.");
+  });
+
   test('given a selected policy then edit mode opens from policy state without association metadata', () => {
     const reportStateWithPolicy: ReportBuilderState = {
       ...reportState,
@@ -107,7 +175,12 @@ describe('useSimulationCanvas', () => {
       ],
     };
 
-    mockUseUserPolicies.mockReturnValue({ data: [], isLoading: false });
+    mockUseUserPolicies.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetchAssociations: mockRefetchPolicyAssociations,
+    });
 
     const { result } = renderHook(() =>
       useSimulationCanvas({
@@ -129,5 +202,87 @@ describe('useSimulationCanvas', () => {
         id: 'policy-replacement',
       },
     });
+  });
+
+  test('given a saved policy detail error then exposes it as disabled with the shared error message', () => {
+    mockUseUserPolicies.mockReturnValue({
+      data: [
+        {
+          association: {
+            id: 'broken-association',
+            policyId: 'broken-policy',
+            label: 'Broken policy',
+            countryId: 'us',
+          },
+          policy: undefined,
+          isLoading: false,
+          isError: true,
+          error: new Error('Policy request failed'),
+        },
+      ],
+      isLoading: false,
+      error: null,
+      refetchAssociations: mockRefetchPolicyAssociations,
+    });
+
+    const { result } = renderHook(() =>
+      useSimulationCanvas({
+        reportState,
+        setReportState,
+        pickerState,
+        setPickerState,
+      })
+    );
+
+    expect(result.current.savedPolicies).toEqual([
+      expect.objectContaining({
+        id: 'broken-policy',
+        label: 'Broken policy',
+        isDisabled: true,
+        errorMessage: 'Error loading this policy',
+      }),
+    ]);
+  });
+
+  test('given a recent household detail error then exposes it as a disabled recent', () => {
+    mockHouseholdRecentIds.mockReturnValue(['broken-household']);
+    mockUseUserHouseholds.mockReturnValue({
+      data: [
+        {
+          association: {
+            id: 'broken-association',
+            householdId: 'broken-household',
+            label: 'Broken household',
+            countryId: 'us',
+          },
+          household: undefined,
+          isLoading: false,
+          isError: true,
+          error: new Error('Household request failed'),
+        },
+      ],
+      isLoading: false,
+      error: null,
+      refetchAssociations: mockRefetchHouseholdAssociations,
+    });
+
+    const { result } = renderHook(() =>
+      useSimulationCanvas({
+        reportState,
+        setReportState,
+        pickerState,
+        setPickerState,
+      })
+    );
+
+    expect(result.current.recentPopulations).toEqual([
+      {
+        id: 'broken-household',
+        label: 'Broken household',
+        type: 'household',
+        isDisabled: true,
+        errorMessage: 'Error loading this population',
+      },
+    ]);
   });
 });

--- a/app/src/tests/unit/pages/reportBuilder/modals/policy/PolicyDetailsDrawer.test.tsx
+++ b/app/src/tests/unit/pages/reportBuilder/modals/policy/PolicyDetailsDrawer.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, userEvent } from '@test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { PolicyDetailsDrawer } from '@/pages/reportBuilder/modals/policy/PolicyDetailsDrawer';
+
+describe('PolicyDetailsDrawer', () => {
+  test('given an errored policy then select and edit are disabled', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const onEdit = vi.fn();
+
+    render(
+      <PolicyDetailsDrawer
+        policy={{
+          id: 'policy-123',
+          label: 'Broken policy',
+          paramCount: 0,
+          parameters: [],
+          isDisabled: true,
+          errorMessage: 'Error loading this policy',
+        }}
+        parameters={{}}
+        parameterTree={null}
+        onClose={vi.fn()}
+        onSelect={onSelect}
+        onEdit={onEdit}
+      />
+    );
+
+    expect(screen.getAllByLabelText('Error loading this policy')).toHaveLength(2);
+    expect(screen.getByText('Failed to load this policy')).toBeInTheDocument();
+
+    const selectButton = screen.getByRole('button', { name: /select this policy/i });
+    const editButton = screen.getByRole('button', { name: /edit policy/i });
+    expect(selectButton).toBeDisabled();
+    expect(editButton).toBeDisabled();
+
+    await user.click(selectButton);
+    await user.click(editButton);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/tests/unit/pages/reportBuilder/utils/createReportSimulations.test.ts
+++ b/app/src/tests/unit/pages/reportBuilder/utils/createReportSimulations.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createReportSimulations } from '@/pages/reportBuilder/utils/createReportSimulations';
+import {
+  CURRENT_LAW_ID,
+  mockCreateSimulationFn,
+  mockLocalStorageCreateFn,
+  mockTwoSimReportState,
+  setupDefaultMocks,
+  TEST_LABELS,
+  TEST_POLICY_IDS,
+  TEST_POPULATION,
+  TEST_SIMULATION_IDS,
+} from '@/tests/fixtures/pages/reportBuilder/useReportSubmissionMocks';
+
+vi.mock('@/api/simulation', () => ({
+  createSimulation: (...args: any[]) => mockCreateSimulationFn(...args),
+}));
+
+vi.mock('@/api/simulationAssociation', () => ({
+  LocalStorageSimulationStore: vi.fn().mockImplementation(() => ({
+    create: mockLocalStorageCreateFn,
+  })),
+}));
+
+vi.mock('@/adapters', () => ({
+  SimulationAdapter: {
+    toCreationPayload: (data: any) => ({
+      population_id: data.populationId,
+      policy_id: data.policyId,
+      population_type: data.populationType,
+    }),
+  },
+}));
+
+vi.mock('@/constants', () => ({
+  MOCK_USER_ID: 'anonymous',
+  CURRENT_YEAR: '2026',
+}));
+
+describe('createReportSimulations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  test('creates API simulations, local associations, and domain simulations', async () => {
+    const result = await createReportSimulations({
+      simulationStates: mockTwoSimReportState.simulations,
+      countryId: 'us',
+      currentLawId: CURRENT_LAW_ID,
+    });
+
+    expect(result.simulationIds).toEqual([
+      TEST_SIMULATION_IDS.SIM_NEW_1,
+      TEST_SIMULATION_IDS.SIM_NEW_2,
+    ]);
+    expect(result.simulations).toEqual([
+      expect.objectContaining({
+        id: TEST_SIMULATION_IDS.SIM_NEW_1,
+        policyId: CURRENT_LAW_ID.toString(),
+        populationId: TEST_POPULATION.GEOGRAPHY_ID,
+        populationType: 'geography',
+        label: TEST_LABELS.BASELINE,
+      }),
+      expect.objectContaining({
+        id: TEST_SIMULATION_IDS.SIM_NEW_2,
+        policyId: TEST_POLICY_IDS.REFORM_POLICY,
+        populationId: TEST_POPULATION.GEOGRAPHY_ID,
+        populationType: 'geography',
+        label: TEST_LABELS.REFORM,
+      }),
+    ]);
+    expect(mockCreateSimulationFn).toHaveBeenCalledTimes(2);
+    expect(mockLocalStorageCreateFn).toHaveBeenCalledTimes(2);
+  });
+
+  test('creates a household simulation with the household population type', async () => {
+    const householdSimulation = {
+      ...mockTwoSimReportState.simulations[0],
+      population: {
+        label: 'Test household',
+        type: 'household',
+        household: { id: TEST_POPULATION.HOUSEHOLD_ID },
+        geography: null,
+      },
+    };
+
+    const result = await createReportSimulations({
+      simulationStates: [householdSimulation] as any,
+      countryId: 'us',
+      currentLawId: CURRENT_LAW_ID,
+    });
+
+    expect(mockCreateSimulationFn).toHaveBeenCalledWith(
+      'us',
+      expect.objectContaining({
+        population_id: TEST_POPULATION.HOUSEHOLD_ID,
+        population_type: 'household',
+      })
+    );
+    expect(result.simulations[0]).toEqual(
+      expect.objectContaining({
+        populationId: TEST_POPULATION.HOUSEHOLD_ID,
+        populationType: 'household',
+      })
+    );
+  });
+
+  test('validates every simulation before creating any of them', async () => {
+    const incompleteSimulations = [
+      mockTwoSimReportState.simulations[0],
+      {
+        ...mockTwoSimReportState.simulations[1],
+        population: {
+          ...mockTwoSimReportState.simulations[1].population,
+          geography: {
+            ...mockTwoSimReportState.simulations[1].population.geography!,
+            geographyId: '',
+          },
+        },
+      },
+    ];
+
+    await expect(
+      createReportSimulations({
+        simulationStates: incompleteSimulations as any,
+        countryId: 'us',
+        currentLawId: CURRENT_LAW_ID,
+      })
+    ).rejects.toThrow('Report has incomplete simulations');
+    expect(mockCreateSimulationFn).not.toHaveBeenCalled();
+    expect(mockLocalStorageCreateFn).not.toHaveBeenCalled();
+  });
+
+  test('does not persist an association when simulation creation returns no ID', async () => {
+    mockCreateSimulationFn.mockResolvedValue({ result: { simulation_id: '' } });
+
+    await expect(
+      createReportSimulations({
+        simulationStates: [mockTwoSimReportState.simulations[0]],
+        countryId: 'us',
+        currentLawId: CURRENT_LAW_ID,
+      })
+    ).rejects.toThrow('Simulation creation returned no ID');
+    expect(mockLocalStorageCreateFn).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/tests/unit/pathways/report/views/policy/PolicyExistingView.test.tsx
+++ b/app/src/tests/unit/pathways/report/views/policy/PolicyExistingView.test.tsx
@@ -17,7 +17,10 @@ import {
 
 vi.mock('@/hooks/useUserPolicy', () => ({
   useUserPolicies: vi.fn(),
-  isPolicyWithAssociation: vi.fn((val) => val && val.policy && val.association),
+  isPolicyWithAssociation: vi.fn(
+    (value: unknown) =>
+      !!value && typeof value === 'object' && 'association' in value && 'policy' in value
+  ),
 }));
 
 describe('PolicyExistingView', () => {
@@ -126,6 +129,44 @@ describe('PolicyExistingView', () => {
       // The subtitle should show "Policy #unknown" when ID is missing
       expect(screen.getByText(/policy #unknown/i)).toBeInTheDocument();
     });
+
+    test('given a policy detail error then displays an unselectable card with a warning icon', async () => {
+      // Given
+      const user = userEvent.setup();
+      vi.mocked(useUserPolicies).mockReturnValue({
+        data: [
+          {
+            association: {
+              id: 'broken-association',
+              userId: '1',
+              policyId: 'broken-policy',
+              label: 'Broken policy',
+              countryId: 'us',
+            },
+            policy: undefined,
+            isLoading: false,
+            isError: true,
+            error: new Error('Policy request failed'),
+          },
+        ],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any);
+
+      // When
+      render(<PolicyExistingView onSelectPolicy={mockOnSelectPolicy} />);
+      const policyCard = screen.getByText('Broken policy').closest('button');
+
+      // Then
+      expect(policyCard).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByText('Failed to load')).toBeInTheDocument();
+      expect(screen.getByLabelText('Error loading this policy')).toBeInTheDocument();
+
+      await user.click(policyCard!);
+      expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+      expect(mockOnSelectPolicy).not.toHaveBeenCalled();
+    });
   });
 
   describe('User interactions', () => {
@@ -156,6 +197,38 @@ describe('PolicyExistingView', () => {
 
       // Then
       expect(mockOnSelectPolicy).toHaveBeenCalled();
+    });
+
+    test('given a selected policy later errors then disables submission', async () => {
+      // Given
+      const user = userEvent.setup();
+      let queryResult = mockUseUserPoliciesWithData as any;
+      vi.mocked(useUserPolicies).mockImplementation(() => queryResult);
+      const { rerender } = render(<PolicyExistingView onSelectPolicy={mockOnSelectPolicy} />);
+
+      await user.click(screen.getByText(/my policy/i).closest('button')!);
+      expect(screen.getByRole('button', { name: /next/i })).toBeEnabled();
+
+      // When
+      queryResult = {
+        ...queryResult,
+        data: queryResult.data.map((item: any, index: number) =>
+          index === 0
+            ? {
+                ...item,
+                policy: undefined,
+                isError: true,
+                error: new Error('Policy request failed'),
+              }
+            : item
+        ),
+      };
+      rerender(<PolicyExistingView onSelectPolicy={mockOnSelectPolicy} />);
+
+      // Then
+      expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      expect(mockOnSelectPolicy).not.toHaveBeenCalled();
     });
   });
 

--- a/app/src/tests/unit/pathways/report/views/population/PopulationExistingView.test.tsx
+++ b/app/src/tests/unit/pathways/report/views/population/PopulationExistingView.test.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import { configureStore } from '@reduxjs/toolkit';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { Provider } from 'react-redux';
+import { render, screen, userEvent } from '@test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { UserHouseholdMetadataWithAssociation } from '@/hooks/useUserHousehold';
 import { Household as HouseholdModel } from '@/models/Household';
@@ -33,41 +30,6 @@ vi.mock('@/hooks/useUserGeographic', () => ({
 vi.mock('@/utils/validation/ingredientValidation', () => ({
   isHouseholdAssociationReady: () => true,
   isGeographicAssociationReady: () => false,
-}));
-
-vi.mock('@/components/common/PathwayView', () => ({
-  default: ({
-    title,
-    cardListItems = [],
-    primaryAction,
-  }: {
-    title: string;
-    cardListItems?: Array<{
-      id: string;
-      title: string;
-      subtitle?: string;
-      onClick: () => void;
-    }>;
-    primaryAction?: {
-      label: string;
-      onClick: () => void;
-      isDisabled?: boolean;
-    };
-  }) => (
-    <div>
-      <h1>{title}</h1>
-      {cardListItems.map((item) => (
-        <button key={item.id} type="button" onClick={item.onClick}>
-          {item.title}
-        </button>
-      ))}
-      {primaryAction ? (
-        <button type="button" onClick={primaryAction.onClick} disabled={primaryAction.isDisabled}>
-          {primaryAction.label}
-        </button>
-      ) : null}
-    </div>
-  ),
 }));
 
 const selectedHousehold = HouseholdModel.fromDraft({
@@ -104,22 +66,9 @@ const mockHouseholdAssociation: UserHouseholdMetadataWithAssociation = {
   isError: false,
 };
 
-function createStore() {
-  return configureStore({
-    reducer: {
-      metadata: () => ({
-        currentCountry: 'us',
-        economyOptions: { region: [] },
-      }),
-    },
-  });
-}
-
 function renderView(props?: Partial<React.ComponentProps<typeof PopulationExistingView>>) {
   return render(
-    <Provider store={createStore()}>
-      <PopulationExistingView onSelectHousehold={vi.fn()} onSelectGeography={vi.fn()} {...props} />
-    </Provider>
+    <PopulationExistingView onSelectHousehold={vi.fn()} onSelectGeography={vi.fn()} {...props} />
   );
 }
 
@@ -146,7 +95,11 @@ describe('PopulationExistingView', () => {
 
     renderView({ onSelectHousehold });
 
-    await user.click(screen.getByRole('button', { name: 'Selected household' }));
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Selected household Household #household-123',
+      })
+    );
     await user.click(screen.getByRole('button', { name: 'Next' }));
 
     expect(onSelectHousehold).toHaveBeenCalledWith(
@@ -154,5 +107,79 @@ describe('PopulationExistingView', () => {
       selectedHousehold,
       'Selected household'
     );
+  });
+
+  test('given a household detail error then displays an unselectable card with a warning icon', async () => {
+    const user = userEvent.setup();
+    const onSelectHousehold = vi.fn();
+    mockUseUserHouseholds.mockReturnValue({
+      data: [
+        {
+          ...mockHouseholdAssociation,
+          association: {
+            ...mockHouseholdAssociation.association,
+            id: 'broken-association',
+            householdId: 'broken-household',
+            label: 'Broken household',
+          },
+          household: undefined,
+          isError: true,
+          error: new Error('Household request failed'),
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderView({ onSelectHousehold });
+    const householdCard = screen.getByText('Broken household').closest('button');
+
+    expect(householdCard).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByText('Failed to load')).toBeInTheDocument();
+    expect(screen.getByLabelText('Error loading this population')).toBeInTheDocument();
+
+    await user.click(householdCard!);
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+    expect(onSelectHousehold).not.toHaveBeenCalled();
+  });
+
+  test('given a selected household later errors then disables submission', async () => {
+    const user = userEvent.setup();
+    const onSelectHousehold = vi.fn();
+    let queryResult = {
+      data: [mockHouseholdAssociation],
+      isLoading: false,
+      isError: false,
+      error: null,
+    };
+    mockUseUserHouseholds.mockImplementation(() => queryResult);
+    const { rerender } = renderView({ onSelectHousehold });
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Selected household Household #household-123',
+      })
+    );
+    expect(screen.getByRole('button', { name: /next/i })).toBeEnabled();
+
+    queryResult = {
+      ...queryResult,
+      data: [
+        {
+          ...mockHouseholdAssociation,
+          household: undefined,
+          isError: true,
+          error: new Error('Household request failed'),
+        },
+      ],
+    } as any;
+    rerender(
+      <PopulationExistingView onSelectHousehold={onSelectHousehold} onSelectGeography={vi.fn()} />
+    );
+
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(onSelectHousehold).not.toHaveBeenCalled();
   });
 });

--- a/app/src/tests/unit/pathways/report/views/simulation/SimulationSetupView.test.tsx
+++ b/app/src/tests/unit/pathways/report/views/simulation/SimulationSetupView.test.tsx
@@ -124,6 +124,32 @@ describe('SimulationSetupView', () => {
       // Then
       expect(screen.getByRole('button', { name: /next/i })).not.toBeDisabled();
     });
+
+    test('given a selected policy later errors then shows the error and requires reconfiguration', async () => {
+      const user = userEvent.setup();
+      render(
+        <SimulationSetupView
+          simulation={mockSimulationStateConfigured}
+          simulationIndex={0}
+          isReportMode={false}
+          onNavigateToPolicy={mockOnNavigateToPolicy}
+          onNavigateToPopulation={mockOnNavigateToPopulation}
+          onNext={mockOnNext}
+          isPolicyUnavailable
+          policyErrorMessage="Error loading this policy"
+        />
+      );
+
+      expect(screen.getByLabelText('Error loading this policy')).toBeInTheDocument();
+      expect(screen.getByText('Failed to load')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /configure household/i })).toBeDisabled();
+
+      await user.click(screen.getByRole('button', { name: /current law failed to load/i }));
+      await user.click(screen.getByRole('button', { name: /configure policy/i }));
+
+      expect(mockOnNavigateToPolicy).toHaveBeenCalledOnce();
+      expect(mockOnNext).not.toHaveBeenCalled();
+    });
   });
 
   describe('Partial configuration', () => {

--- a/app/src/tests/unit/pathways/report/views/simulation/SimulationSubmitView.test.tsx
+++ b/app/src/tests/unit/pathways/report/views/simulation/SimulationSubmitView.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, userEvent } from '@test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { useCreateSimulation } from '@/hooks/useCreateSimulation';
+import SimulationSubmitView from '@/pathways/report/views/simulation/SimulationSubmitView';
+import { mockSimulationStateConfigured } from '@/tests/fixtures/pathways/report/views/SimulationViewMocks';
+
+vi.mock('@/hooks/useCreateSimulation', () => ({
+  useCreateSimulation: vi.fn(),
+}));
+
+describe('SimulationSubmitView', () => {
+  const createSimulation = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCreateSimulation).mockReturnValue({
+      createSimulation,
+      isPending: false,
+      error: null,
+    });
+  });
+
+  test('given a selected household later errors then disables and guards submission', async () => {
+    const user = userEvent.setup();
+    render(
+      <SimulationSubmitView
+        simulation={mockSimulationStateConfigured}
+        onSubmitSuccess={vi.fn()}
+        isPopulationUnavailable
+        populationErrorMessage="Error loading this population"
+      />
+    );
+
+    expect(screen.getByLabelText('Error loading this population')).toBeInTheDocument();
+    expect(screen.getByText('Failed to load')).toBeInTheDocument();
+
+    const submitButton = screen.getByRole('button', { name: /create simulation/i });
+    expect(submitButton).toBeDisabled();
+    await user.click(submitButton);
+    expect(createSimulation).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/tests/unit/pathways/simulation/SimulationPathwayWrapper.test.tsx
+++ b/app/src/tests/unit/pathways/simulation/SimulationPathwayWrapper.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@test-utils';
 import { useParams } from 'react-router-dom';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { useCreateSimulation } from '@/hooks/useCreateSimulation';
 import { useCurrentCountry } from '@/hooks/useCurrentCountry';
 import { useRegions } from '@/hooks/useRegions';
@@ -21,6 +21,12 @@ import {
   TEST_COUNTRY_ID,
 } from '@/tests/fixtures/pathways/simulation/SimulationPathwayWrapperMocks';
 import { mockUSRegionRecords } from '@/tests/fixtures/utils/regionStrategiesMocks';
+import { SimulationViewMode } from '@/types/pathwayModes/SimulationViewMode';
+import * as simulationStateInitializer from '@/utils/pathwayState/initializeSimulationState';
+
+const { mockUsePathwayNavigation } = vi.hoisted(() => ({
+  mockUsePathwayNavigation: vi.fn(),
+}));
 
 // Mock dependencies
 vi.mock('react-router-dom', async () => {
@@ -62,12 +68,7 @@ vi.mock('@/hooks/useUserGeographic', () => ({
 }));
 
 vi.mock('@/hooks/usePathwayNavigation', () => ({
-  usePathwayNavigation: vi.fn(() => ({
-    mode: 'LABEL',
-    navigateToMode: vi.fn(),
-    goBack: vi.fn(),
-    getBackMode: vi.fn(),
-  })),
+  usePathwayNavigation: (...args: unknown[]) => mockUsePathwayNavigation(...args),
 }));
 
 vi.mock('@/hooks/useCurrentCountry', () => ({
@@ -95,6 +96,17 @@ describe('SimulationPathwayWrapper', () => {
       isError: false,
       error: null,
     } as ReturnType<typeof useRegions>);
+    mockUsePathwayNavigation.mockReturnValue({
+      currentMode: SimulationViewMode.LABEL,
+      navigateToMode: vi.fn(),
+      goBack: vi.fn(),
+      canGoBack: false,
+      getBackMode: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe('Error handling', () => {
@@ -151,5 +163,63 @@ describe('SimulationPathwayWrapper', () => {
       // Then
       expect(container).toBeInTheDocument();
     });
+  });
+
+  test('given a selected policy later errors then blocks submission with the shared error icon', () => {
+    vi.spyOn(simulationStateInitializer, 'initializeSimulationState').mockReturnValue({
+      id: undefined,
+      label: 'Saved simulation',
+      countryId: TEST_COUNTRY_ID,
+      policy: {
+        id: 'broken-policy',
+        label: 'Broken policy',
+        parameters: [],
+      },
+      population: {
+        label: 'Nationwide',
+        type: 'geography',
+        household: null,
+        geography: {
+          id: 'us',
+          geographyId: 'us',
+          countryId: 'us',
+          scope: 'national',
+          name: 'United States',
+        },
+      },
+    });
+    vi.mocked(useUserPolicies).mockReturnValue({
+      data: [
+        {
+          association: {
+            id: 'broken-association',
+            userId: 'anonymous',
+            policyId: 'broken-policy',
+            countryId: 'us',
+            label: 'Broken policy',
+          },
+          policy: undefined,
+          isLoading: false,
+          isError: true,
+          error: new Error('Policy request failed'),
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as ReturnType<typeof useUserPolicies>);
+    mockUsePathwayNavigation.mockReturnValue({
+      currentMode: SimulationViewMode.SUBMIT,
+      navigateToMode: vi.fn(),
+      goBack: vi.fn(),
+      canGoBack: true,
+      getBackMode: vi.fn(),
+    });
+
+    render(<SimulationPathwayWrapper />);
+
+    expect(screen.getByLabelText('Error loading this policy')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create simulation/i })).toBeDisabled();
+    expect(mockUseCreateSimulation.createSimulation).not.toHaveBeenCalled();
   });
 });

--- a/app/src/tests/unit/utils/ingredientAvailability.test.ts
+++ b/app/src/tests/unit/utils/ingredientAvailability.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+import {
+  getHouseholdLoadErrorMessage,
+  getPolicyLoadErrorMessage,
+  getUserHouseholdAvailability,
+  getUserPolicyAvailability,
+  hasRequiredSimulationIngredients,
+  hasUnavailableSimulationIngredients,
+} from '@/utils/ingredientAvailability';
+
+const simulation = {
+  policy: { id: 'selected-policy', label: 'Selected policy', parameters: [] },
+  population: {
+    household: { id: 'selected-household' },
+    geography: null,
+    label: 'Selected household',
+    type: 'household',
+  },
+};
+
+function policyItem(policyId: string, error: Error | null) {
+  return {
+    association: { policyId },
+    policy: error ? undefined : { id: policyId, parameters: [] },
+    isLoading: false,
+    error,
+  };
+}
+
+function householdItem(householdId: string, error: Error | null) {
+  return {
+    association: { householdId },
+    household: error ? undefined : { id: householdId },
+    isLoading: false,
+    error,
+  };
+}
+
+describe('ingredientAvailability', () => {
+  test('blocks a simulation when its selected policy has errored', () => {
+    const policies = [policyItem('selected-policy', new Error('Request failed'))];
+    const households = [householdItem('selected-household', null)];
+
+    expect(
+      hasUnavailableSimulationIngredients([simulation] as any, policies as any, households as any)
+    ).toBe(true);
+    expect(getPolicyLoadErrorMessage(policies as any, 'selected-policy')).toBe(
+      'Error loading this policy'
+    );
+  });
+
+  test('blocks a simulation when its selected household has errored', () => {
+    const policies = [policyItem('selected-policy', null)];
+    const households = [householdItem('selected-household', new Error('Request failed'))];
+
+    expect(
+      hasUnavailableSimulationIngredients([simulation] as any, policies as any, households as any)
+    ).toBe(true);
+    expect(getHouseholdLoadErrorMessage(households as any, 'selected-household')).toBe(
+      'Error loading this population'
+    );
+  });
+
+  test('does not block a simulation for an unrelated catalog error', () => {
+    const policies = [policyItem('other-policy', new Error('Request failed'))];
+    const households = [householdItem('selected-household', null)];
+
+    expect(
+      hasUnavailableSimulationIngredients([simulation] as any, policies as any, households as any)
+    ).toBe(false);
+  });
+
+  test('returns one shared presentation for policy and household errors', () => {
+    const policy = policyItem('selected-policy', new Error('Request failed'));
+    const household = householdItem('selected-household', new Error('Request failed'));
+
+    expect(getUserPolicyAvailability(policy as any)).toEqual({
+      isDisabled: true,
+      errorMessage: 'Error loading this policy',
+    });
+    expect(getUserHouseholdAvailability(household as any)).toEqual({
+      isDisabled: true,
+      errorMessage: 'Error loading this population',
+    });
+  });
+
+  test('requires at least one fully configured simulation', () => {
+    expect(hasRequiredSimulationIngredients([])).toBe(false);
+    expect(hasRequiredSimulationIngredients([simulation] as any)).toBe(true);
+    expect(
+      hasRequiredSimulationIngredients([
+        {
+          ...simulation,
+          policy: { ...simulation.policy, id: undefined },
+        },
+      ] as any)
+    ).toBe(false);
+    expect(
+      hasRequiredSimulationIngredients([
+        {
+          ...simulation,
+          population: {
+            ...simulation.population,
+            household: null,
+            geography: { id: 'us', geographyId: '' },
+            type: 'geography',
+          },
+        },
+      ] as any)
+    ).toBe(false);
+  });
+});

--- a/app/src/utils/ingredientAvailability.ts
+++ b/app/src/utils/ingredientAvailability.ts
@@ -1,0 +1,127 @@
+import type { UserHouseholdMetadataWithAssociation } from '@/hooks/useUserHousehold';
+import type { UserPolicyWithAssociation } from '@/hooks/useUserPolicy';
+import type { SimulationStateProps } from '@/types/pathwayState';
+
+export const POLICY_LOAD_ERROR_MESSAGE = 'Error loading this policy';
+export const POPULATION_LOAD_ERROR_MESSAGE = 'Error loading this population';
+
+export interface IngredientAvailabilityPresentation {
+  isDisabled: boolean;
+  errorMessage?: string;
+}
+
+type SelectableUserPolicy = UserPolicyWithAssociation & {
+  policy: NonNullable<UserPolicyWithAssociation['policy']>;
+};
+
+type SelectableUserHousehold = UserHouseholdMetadataWithAssociation & {
+  household: NonNullable<UserHouseholdMetadataWithAssociation['household']>;
+};
+
+export function isUserPolicySelectable(
+  item: UserPolicyWithAssociation
+): item is SelectableUserPolicy {
+  return !item.isLoading && !item.error && !!item.policy;
+}
+
+export function isUserHouseholdSelectable(
+  item: UserHouseholdMetadataWithAssociation
+): item is SelectableUserHousehold {
+  return !item.isLoading && !item.error && !!item.household;
+}
+
+export function getUserPolicyAvailability(
+  item: UserPolicyWithAssociation
+): IngredientAvailabilityPresentation {
+  return {
+    isDisabled: !isUserPolicySelectable(item),
+    errorMessage: item.error ? POLICY_LOAD_ERROR_MESSAGE : undefined,
+  };
+}
+
+export function getUserHouseholdAvailability(
+  item: UserHouseholdMetadataWithAssociation
+): IngredientAvailabilityPresentation {
+  return {
+    isDisabled: !isUserHouseholdSelectable(item),
+    errorMessage: item.error ? POPULATION_LOAD_ERROR_MESSAGE : undefined,
+  };
+}
+
+export function getLoadErrorAvailability(
+  error: unknown,
+  errorMessage: string
+): IngredientAvailabilityPresentation {
+  return {
+    isDisabled: !!error,
+    errorMessage: error ? errorMessage : undefined,
+  };
+}
+
+export function findUserPolicyByPolicyId(
+  policies: UserPolicyWithAssociation[] | undefined,
+  policyId: string | null | undefined
+): UserPolicyWithAssociation | undefined {
+  if (!policyId) {
+    return undefined;
+  }
+
+  return policies?.find((item) => item.association.policyId.toString() === policyId);
+}
+
+export function findUserHouseholdByHouseholdId(
+  households: UserHouseholdMetadataWithAssociation[] | undefined,
+  householdId: string | null | undefined
+): UserHouseholdMetadataWithAssociation | undefined {
+  if (!householdId) {
+    return undefined;
+  }
+
+  return households?.find((item) => item.association.householdId.toString() === householdId);
+}
+
+export function getPolicyLoadErrorMessage(
+  policies: UserPolicyWithAssociation[] | undefined,
+  policyId: string | null | undefined
+): string | undefined {
+  const policy = findUserPolicyByPolicyId(policies, policyId);
+  return policy ? getUserPolicyAvailability(policy).errorMessage : undefined;
+}
+
+export function getHouseholdLoadErrorMessage(
+  households: UserHouseholdMetadataWithAssociation[] | undefined,
+  householdId: string | null | undefined
+): string | undefined {
+  const household = findUserHouseholdByHouseholdId(households, householdId);
+  return household ? getUserHouseholdAvailability(household).errorMessage : undefined;
+}
+
+export function hasUnavailableSimulationIngredients(
+  simulations: SimulationStateProps[],
+  policies: UserPolicyWithAssociation[] | undefined,
+  households: UserHouseholdMetadataWithAssociation[] | undefined
+): boolean {
+  return simulations.some((simulation) => {
+    const selectedPolicy = findUserPolicyByPolicyId(policies, simulation.policy.id);
+    const selectedHousehold = findUserHouseholdByHouseholdId(
+      households,
+      simulation.population.household?.id
+    );
+
+    return (
+      (!!selectedPolicy && !isUserPolicySelectable(selectedPolicy)) ||
+      (!!selectedHousehold && !isUserHouseholdSelectable(selectedHousehold))
+    );
+  });
+}
+
+export function hasRequiredSimulationIngredients(simulations: SimulationStateProps[]): boolean {
+  return (
+    simulations.length > 0 &&
+    simulations.every(
+      (simulation) =>
+        !!simulation.policy.id &&
+        !!(simulation.population.household?.id || simulation.population.geography?.geographyId)
+    )
+  );
+}


### PR DESCRIPTION
Fixes #1127

## Summary
- keep association-list failures as page-level errors while treating detail-query failures as row-level errors
- disable affected saved ingredient rows and show a warning tooltip instead of hiding successfully loaded rows
- guard disabled-row links, menus, and action handlers

## Validation
- `/Users/administrator/Documents/PolicyEngine/policyengine-app-v2/node_modules/.bin/vitest run src/tests/unit/hooks/useUserReports.test.tsx src/tests/unit/hooks/useUserHousehold.test.tsx src/tests/unit/hooks/useUserSimulations.test.tsx src/tests/unit/components/IngredientReadView.test.tsx src/tests/unit/pages/Reports.page.test.tsx src/tests/unit/pages/Policies.page.test.tsx src/tests/unit/pages/Populations.page.test.tsx src/tests/unit/pages/Simulations.page.test.tsx`
- `/Users/administrator/Documents/PolicyEngine/policyengine-app-v2/node_modules/.bin/tsc --noEmit`