### PR TITLE
Add /scorecard rewrite to the PolicyEngine scorecard app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -192,6 +192,14 @@
       "source": "/uk/api/:path*",
       "destination": "https://household-api-docs-policy-engine.vercel.app/uk/api/:path*"
     },
+    {
+      "source": "/scorecard",
+      "destination": "https://policyengine-scorecard.vercel.app/scorecard"
+    },
+    {
+      "source": "/scorecard/:path*",
+      "destination": "https://policyengine-scorecard.vercel.app/scorecard/:path*"
+    },
     { "source": "/(.*)", "destination": "/website.html" }
   ],
   "headers": [


### PR DESCRIPTION
Proxies **policyengine.org/scorecard** to the `policyengine-scorecard` Vercel project, following the prefix-preserving rewrite pattern used for `/slides`, `/us/taxsim`, and `/us/watca`.

The scorecard is a repository of every external score we can find — 42,270 claims from 8 models (Urban SotSN, JCT, CBO, TPC, Tax Foundation, PWBM, Budget Lab, CPSP) — with PolicyEngine counterparts where the model can produce them, full provenance on every claim, and explanations of material divergences. It wears the standard PE header/footer (`PolicyEngineShell` from @policyengine/ui-kit), so it reads as part of the site.

Already serving at the destination:
- https://policyengine-scorecard.vercel.app/scorecard
- https://policyengine-scorecard.vercel.app/scorecard/data/index.json

Two vercel.json rewrite entries, placed with the other tool proxies before the website catch-all; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)