### PR TITLE
Add /scorecard rewrite to website/vercel.json (the file serving www)

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -159,6 +159,14 @@
     {
       "source": "/us/api/:path*",
       "destination": "https://household-api-docs-policy-engine.vercel.app/us/api/:path*"
+    },
+    {
+      "source": "/scorecard",
+      "destination": "https://policyengine-scorecard.vercel.app/scorecard"
+    },
+    {
+      "source": "/scorecard/:path*",
+      "destination": "https://policyengine-scorecard.vercel.app/scorecard/:path*"
     }
   ]
 }


### PR DESCRIPTION
Completes #1134: that PR added the `/scorecard` proxy to the repo-root `vercel.json`, which routes the **policyengine-app-v2** project (beta). The live site — `www.policyengine.org` — is the **policyengine-website** project rooted at `website/`, so the entries belong in `website/vercel.json` too, exactly as the `/slides`, `/tutorial`, and `/us/taxsim` proxies appear in both files.

Verified serving at the destination:
- https://policyengine-scorecard.vercel.app/scorecard
- https://policyengine-scorecard.vercel.app/scorecard/data/index.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)