### PR TITLE
Redirect /uk/cec to /uk so the citizensecon.org.uk embed stops 404ing

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,1 +1,2 @@
 - Enforce the site shell on the SNAP payment error simulator route and fix four stale app iframe sources
+- Redirect /uk/cec (the retired Citizens' Economic Council simulator, embedded by citizensecon.org.uk) to /uk instead of a 404

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -5,6 +5,11 @@
   "outputDirectory": ".next",
   "redirects": [
     {
+      "source": "/uk/cec",
+      "destination": "/uk",
+      "permanent": false
+    },
+    {
       "source": "/:countryId/blog/:slug",
       "destination": "/:countryId/research/:slug",
       "permanent": true


### PR DESCRIPTION
(see above)
