### PR TITLE
Move the /uk/cec redirect into next.config.ts so it takes effect

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -69,6 +69,13 @@ const nextConfig: NextConfig = {
         destination: "/:countryId/ai-agents",
         permanent: true,
       },
+      // Retired Citizens' Economic Council simulator, still embedded by
+      // citizensecon.org.uk/policymodelling → main UK simulator
+      {
+        source: "/uk/cec",
+        destination: "/uk",
+        permanent: false,
+      },
       // Legacy /blog → /research
       {
         source: "/:countryId/blog/:slug",


### PR DESCRIPTION
Follow-up to #1146, which put the `/uk/cec` → `/uk` redirect in `website/vercel.json` — but after it deployed, production still returns 404 (checked https://www.policyengine.org/uk/cec after the deploy succeeded). The redirects that demonstrably work in production (e.g. `/uk/blog` → 308 `/uk/research`) come from `next.config.ts` `redirects()`, which the framework reads; the legacy blog rules exist in both files, matching that pattern.

This adds the same redirect to `website/next.config.ts`. Non-permanent, same as #1146, so the route can be repurposed if the CEC simulator is restored.

Context: https://citizensecon.org.uk/policymodelling iframes `policyengine.org/uk/cec` and currently shows our 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)