### PR TITLE
File an issue when the scheduled zone-shell audit fails

### DIFF
--- a/.github/workflows/app-zone-shell-audit.yml
+++ b/.github/workflows/app-zone-shell-audit.yml
@@ -15,6 +15,9 @@ jobs:
   audit:
     name: Audit PolicyEngine shell on app-zone routes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
 
@@ -35,3 +38,21 @@ jobs:
         env:
           APP_ZONE_ALLOW_DESTINATION_FALLBACK: ${{ github.event_name == 'pull_request' && '1' || '0' }}
         run: node .github/scripts/audit-app-zone-shell.mjs
+
+      - name: File or bump an issue when the scheduled audit fails
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Production zone-shell audit is failing"
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "in:title \"$title\"" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Still failing: $run_url"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "The scheduled app-zone shell audit failed: $run_url
+
+          A zone child stopped rendering the PolicyEngine site shell, or a route is down or erroring. Every embedded tool renders the shell itself (CLAUDE.md → Embedded sites → The shell rule); the child repo's own CI shell guard should catch this at PR time — fix the child and check why its guard did not."
+          fi


### PR DESCRIPTION
Follow-up to #1148. The daily scheduled `app-zone-shell-audit` run previously failed silently in the Actions tab; now a failure on a scheduled run opens a tracking issue (or comments on the existing one), so a zone child that stops rendering the site shell — or a route that goes down — gets noticed the same day. Each child repo also now guards its own shell in CI (scotland-income-tax-reform#12, uc-rebalancing#5, nics-exemption-inactive-employees#12, young-worker-nics#6, electricity-vat-cut#2, bus-fare-cap#10, student-loan-visualisation#5, cancelling-fuel-duty-rise#7, obbba-household-by-household#246), so this issue is the backstop, not the first line of defense.

PR-run behavior is unchanged (`if: failure() && github.event_name == 'schedule'`); the job gains an explicit minimal permissions block (`contents: read`, `issues: write`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)