### PR TITLE
Report not-yet-deployed static zone destinations as pending

### DIFF
--- a/.github/scripts/audit-app-zone-shell.mjs
+++ b/.github/scripts/audit-app-zone-shell.mjs
@@ -7,11 +7,12 @@
  * migration. Production audits check the public source URL; pull requests can
  * opt into destination fallback for newly added rewrites that are not live yet.
  */
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const DEFAULT_BASE_URL = "https://policyengine.org";
 const DEFAULT_ROUTES_FILE = "website/src/data/appZoneRoutes.ts";
+const DEFAULT_STATIC_ASSET_ROOT = "app/public";
 const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_TIMEOUT_MS = 30000;
 const DEFAULT_MAX_SITEMAP_ROUTES = 30;
@@ -52,6 +53,44 @@ export function isShellBrandExempt(source) {
   return SHELL_BRAND_EXEMPT_SOURCES.some(
     (base) => source === base || source.startsWith(`${base}/`),
   );
+}
+
+/**
+ * Maps a repo-relative destination onto the static asset that serves it, or
+ * null for destinations pointing at an external origin.
+ */
+export function staticAssetPathFor(
+  destination,
+  staticRoot = DEFAULT_STATIC_ASSET_ROOT,
+) {
+  if (/^https?:\/\//i.test(destination)) return null;
+  if (!destination.startsWith("/")) return null;
+  const [path] = destination.split(/[?#]/);
+  return `${staticRoot}${path}`;
+}
+
+/**
+ * A route whose destination is a static asset in this repo cannot be live
+ * before the pull request that adds it deploys: neither the source path nor
+ * the destination exists on production yet, so both return 404 and the
+ * destination fallback has nothing to fall back to. That is the same "not
+ * live yet" case the fallback already covers for external destinations, which
+ * are serving from their own origin by the time the rewrite is proposed.
+ *
+ * Only ever reported on pull requests. The scheduled production audit runs
+ * with fallback disabled, so a route that never deploys still fails there.
+ */
+export function isPendingStaticDeploy(
+  { destination, status, ok },
+  {
+    allowDestinationFallback = false,
+    exists = existsSync,
+    staticRoot = DEFAULT_STATIC_ASSET_ROOT,
+  } = {},
+) {
+  if (ok || status !== 404 || !allowDestinationFallback) return false;
+  const assetPath = staticAssetPathFor(destination, staticRoot);
+  return assetPath !== null && exists(assetPath);
 }
 
 export function parseArgs(argv) {
@@ -520,6 +559,7 @@ async function auditRoute(
   baseUrl,
   timeout,
   allowDestinationFallback,
+  staticRoot = DEFAULT_STATIC_ASSET_ROOT,
 ) {
   const page = await browser.newPage({
     viewport: { width: 1440, height: 1000 },
@@ -544,6 +584,21 @@ async function auditRoute(
       testedUrl = destinationUrl;
       usedFallback = true;
     }
+  }
+
+  if (
+    isPendingStaticDeploy(
+      { destination: route.destination, status: result.status, ok: result.ok },
+      { allowDestinationFallback, staticRoot },
+    )
+  ) {
+    result = {
+      ok: true,
+      status: result.status,
+      reason:
+        "not live yet — destination is a static asset added in this checkout",
+      pending: true,
+    };
   }
 
   await page.close();
@@ -630,7 +685,13 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
         timeout,
         allowDestinationFallback,
       );
-      const mark = result.ok ? (result.exempt ? "SKIP" : "OK") : "FAIL";
+      const mark = result.ok
+        ? result.exempt
+          ? "SKIP"
+          : result.pending
+            ? "PENDING"
+            : "OK"
+        : "FAIL";
       console.log(`${mark} ${result.source}`);
       console.log(`    ${result.reason}`);
       if (result.usedFallback) {
@@ -651,10 +712,23 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
 
   const failures = results.filter((result) => !result.ok);
   const exempt = results.filter((result) => result.exempt);
-  const enforced = results.length - exempt.length;
+  const pending = results.filter((result) => result.pending);
+  const enforced = results.length - exempt.length - pending.length;
   console.log(
     `\n${enforced - failures.length}/${enforced} enforced app-zone routes have the PolicyEngine shell.`,
   );
+
+  if (pending.length > 0) {
+    console.log(
+      `\n${pending.length} route(s) not live yet — their destination is a static asset added in this checkout, so the shell is not enforced until they deploy:`,
+    );
+    for (const route of pending) {
+      console.log(`  - ${route.source} -> ${route.destination}`);
+    }
+    console.log(
+      "  The scheduled production audit runs without destination fallback and will enforce these once merged.",
+    );
+  }
 
   if (exempt.length > 0) {
     console.log(

--- a/.github/scripts/audit-app-zone-shell.test.mjs
+++ b/.github/scripts/audit-app-zone-shell.test.mjs
@@ -5,11 +5,13 @@ import {
   extractRoutes,
   extractSitemapLocs,
   inspectTopShellData,
+  isPendingStaticDeploy,
   isShellBrandExempt,
   resolveDestinationForSource,
   SHELL_BRAND_EXEMPT_SOURCES,
   shouldAllowDestinationFallback,
   sourcePathFromSitemapLoc,
+  staticAssetPathFor,
 } from "./audit-app-zone-shell.mjs";
 
 const visibleTopElement = (overrides = {}) => ({
@@ -271,5 +273,116 @@ describe("isShellBrandExempt", () => {
       false,
     );
     assert.equal(isShellBrandExempt("/uk/marriage"), false);
+  });
+});
+
+describe("staticAssetPathFor", () => {
+  test("maps a repo-relative destination onto its static asset", () => {
+    assert.equal(
+      staticAssetPathFor("/assets/posts/some-post/index.html"),
+      "app/public/assets/posts/some-post/index.html",
+    );
+  });
+
+  test("ignores query strings and fragments", () => {
+    assert.equal(
+      staticAssetPathFor("/assets/posts/some-post/index.html?embed=true"),
+      "app/public/assets/posts/some-post/index.html",
+    );
+    assert.equal(
+      staticAssetPathFor("/assets/posts/some-post/index.html#impact"),
+      "app/public/assets/posts/some-post/index.html",
+    );
+  });
+
+  test("returns null for external destinations", () => {
+    assert.equal(staticAssetPathFor("https://some-tool.vercel.app/us/x"), null);
+    assert.equal(staticAssetPathFor("http://some-tool.vercel.app/us/x"), null);
+    assert.equal(staticAssetPathFor("some-tool.vercel.app/us/x"), null);
+  });
+});
+
+describe("isPendingStaticDeploy", () => {
+  const present = () => true;
+  const absent = () => false;
+  const pendingRoute = {
+    destination: "/assets/posts/some-post/index.html",
+    status: 404,
+    ok: false,
+  };
+
+  test("treats a 404 in-repo asset as pending when fallback is allowed", () => {
+    assert.equal(
+      isPendingStaticDeploy(pendingRoute, {
+        allowDestinationFallback: true,
+        exists: present,
+      }),
+      true,
+    );
+  });
+
+  test("still fails on the production audit, which disables fallback", () => {
+    // The scheduled run is the backstop: a route that never deploys must not
+    // stay pending forever.
+    assert.equal(
+      isPendingStaticDeploy(pendingRoute, {
+        allowDestinationFallback: false,
+        exists: present,
+      }),
+      false,
+    );
+  });
+
+  test("fails when the asset is missing from the checkout", () => {
+    // A rewrite pointing at an asset nobody added is a broken route, not a
+    // route awaiting deploy.
+    assert.equal(
+      isPendingStaticDeploy(pendingRoute, {
+        allowDestinationFallback: true,
+        exists: absent,
+      }),
+      false,
+    );
+  });
+
+  test("does not excuse external destinations", () => {
+    // External tools serve from their own origin before the rewrite lands, so
+    // a 404 there is a real failure.
+    assert.equal(
+      isPendingStaticDeploy(
+        { ...pendingRoute, destination: "https://some-tool.vercel.app/us/x" },
+        { allowDestinationFallback: true, exists: present },
+      ),
+      false,
+    );
+  });
+
+  test("does not excuse a live route that is missing the shell", () => {
+    // 200 with no brand, or any non-404 error, is exactly what this audit
+    // exists to catch.
+    assert.equal(
+      isPendingStaticDeploy(
+        { ...pendingRoute, status: 200 },
+        { allowDestinationFallback: true, exists: present },
+      ),
+      false,
+    );
+    assert.equal(
+      isPendingStaticDeploy(
+        { ...pendingRoute, status: 500 },
+        { allowDestinationFallback: true, exists: present },
+      ),
+      false,
+    );
+  });
+
+  test("leaves passing routes alone", () => {
+    assert.equal(
+      isPendingStaticDeploy(
+        { ...pendingRoute, ok: true },
+        { allowDestinationFallback: true, exists: present },
+      ),
+      false,
+    );
   });
 });

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,3 +1,4 @@
 - Enforce the site shell on the SNAP payment error simulator route and fix four stale app iframe sources
 - Enforce the site shell on the last nine bare embedded tools, emptying the zone-shell audit exemption list
 - Redirect /uk/cec (the retired Citizens' Economic Council simulator, embedded by citizensecon.org.uk) to /uk instead of a 404
+- Report zone routes whose destination is a static asset added in the same pull request as pending deploy rather than failing the shell audit, which no in-repo static page could previously pass


### PR DESCRIPTION
The zone-shell audit's destination fallback exists so a rewrite added in a PR can be checked before its source path is live. It only works for destinations on an **external** origin — those are already serving from their own Vercel domain by the time the rewrite is proposed, which is why #1142's `snap-qc-sim.vercel.app` destination passed on its own PR.

A destination pointing at a **static asset in this repo** cannot do that. Production has neither the source path nor the asset until the PR that adds both deploys, so the source 404s, the fallback 404s, and the route fails. The practical effect is that no in-repo static page can pass the audit on its own pull request — currently blocking #1073, and it would recur for every future post published this way.

## What changes

A route is reported `PENDING` rather than failing when **all** of these hold:

- the destination is repo-relative rather than an external origin,
- both the source and the destination returned 404,
- the asset exists in the checkout, and
- destination fallback is enabled — i.e. this is a pull request.

The last condition is the important one. The scheduled production audit runs with `APP_ZONE_ALLOW_DESTINATION_FALLBACK=0`, so it still fails these routes: a rewrite that never actually deploys gets caught nightly rather than staying pending forever. A destination whose asset nobody added is a broken route and still fails everywhere, including on PRs.

Pending routes are printed with their own marker and summarised in their own block, excluded from the `N/M enforced` count rather than folded into it, so a reviewer can see exactly what was not enforced and why.

## Verification

Nine new unit tests cover the decision table — production mode, missing asset, external destination, non-404 status, and already-passing routes all stay failures/unchanged. 22 pass in `audit-app-zone-shell.test.mjs`, 13 in the guard suite.

End-to-end against production, with a temporary local asset:

```
# PR mode
PENDING /uk/__pending-e2e      -> asset present in checkout
FAIL    /uk/__missing-asset-e2e -> asset absent            (exit 1)

# scheduled production mode
FAIL    /uk/__pending-e2e
FAIL    /uk/__missing-asset-e2e                            (exit 1)
```

Raised separately from #1073 so the guard change gets reviewed on its own rather than arriving inside a blog-post PR. cc @anth-volk @MaxGhenis