### PR TITLE
Keep research filter panels within the viewport

### DIFF
--- a/website/src/__tests__/components/research-filters.test.tsx
+++ b/website/src/__tests__/components/research-filters.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ResearchFilters } from "@/app/[countryId]/research/ResearchClient";
+
+const noop = () => {};
+
+const authors = Array.from({ length: 20 }, (_, index) => ({
+  key: `author-${index}`,
+  name: `Author ${index}`,
+}));
+
+function renderFilters() {
+  return render(
+    <ResearchFilters
+      searchQuery=""
+      onSearchChange={noop}
+      onSearchSubmit={noop}
+      selectedTopics={[]}
+      onTopicsChange={noop}
+      selectedLocations={[]}
+      onLocationsChange={noop}
+      selectedAuthors={[]}
+      onAuthorsChange={noop}
+      selectedTypes={[]}
+      onTypesChange={noop}
+      availableAuthors={authors}
+      countryId="us"
+    />,
+  );
+}
+
+describe("ResearchFilters", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 700,
+      writable: true,
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 100,
+      width: 0,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("bounds a long expanded section and scrolls its contents", async () => {
+    renderFilters();
+
+    const authorHeader = screen.getByRole("button", { name: "Author" });
+    fireEvent.click(authorHeader);
+
+    const authorSection = authorHeader.parentElement;
+    const filterStack = authorSection?.parentElement;
+    const authorContent = authorHeader.nextElementSibling;
+
+    expect(authorSection).toHaveStyle({
+      display: "flex",
+      flexDirection: "column",
+      flexShrink: "1",
+      minHeight: "0",
+    });
+    expect(authorContent).toHaveStyle({
+      flex: "1 1 auto",
+      minHeight: "0",
+      overflowY: "auto",
+    });
+    await waitFor(() =>
+      expect(filterStack).toHaveStyle({ maxHeight: "580px" }),
+    );
+
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 600,
+      writable: true,
+    });
+    fireEvent(window, new Event("resize"));
+
+    await waitFor(() =>
+      expect(filterStack).toHaveStyle({ maxHeight: "480px" }),
+    );
+  });
+
+  test("keeps collapsed section headers from shrinking", () => {
+    renderFilters();
+
+    fireEvent.click(screen.getByRole("button", { name: "Author" }));
+
+    const typeSection = screen.getByRole("button", {
+      name: "Type",
+    }).parentElement;
+    expect(typeSection).toHaveStyle({ flexShrink: "0" });
+  });
+});

--- a/website/src/app/[countryId]/research/ResearchClient.tsx
+++ b/website/src/app/[countryId]/research/ResearchClient.tsx
@@ -371,13 +371,13 @@ function BlogPostGrid({
     </>
   );
 }
-
 /* ─── FilterSection ─── */
 
 const sectionHeaderStyle: React.CSSProperties = {
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
+  flexShrink: 0,
   padding: "10px 12px",
   borderRadius: "10px",
   cursor: "pointer",
@@ -414,18 +414,18 @@ function FilterSection({
   return (
     <div
       style={{
+        display: "flex",
+        flexDirection: "column",
         borderRadius: "12px",
         border: `1px solid ${isExpanded ? colors.primary[200] : colors.border.light}`,
         backgroundColor: isExpanded ? "rgba(230, 255, 250, 0.3)" : colors.white,
         transition: "border-color 0.2s ease, background-color 0.2s ease",
         overflow: "hidden",
-        // Collapsed sections must keep their full header height when a sibling
-        // section expands — the parent flex column has `maxHeight: availableHeight;
-        // overflow: hidden`, and the default `flex-shrink: 1` would otherwise
-        // squish the headers down (visible bug: clicking "Author" shrinks the
-        // "Type" / "Topic" / "Location" headers because the expanded Author panel
-        // takes most of the available column height).
-        flexShrink: 0,
+        // Collapsed sections keep their full header height. The expanded section
+        // is the only shrinkable item, so its content takes the remaining viewport
+        // space and scrolls instead of pushing the filter stack below the page.
+        flexShrink: isExpanded ? 1 : 0,
+        minHeight: 0,
       }}
     >
       <button
@@ -488,13 +488,16 @@ function FilterSection({
 
       <div
         style={{
+          flex: isExpanded ? "1 1 auto" : "0 1 auto",
+          minHeight: 0,
           maxHeight: isExpanded
             ? `${Math.min(height, maxHeight)}px`
             : "0px",
           opacity: isExpanded ? 1 : 0,
           transition:
             "max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease",
-          overflow: isExpanded ? "auto" : "hidden",
+          overflowX: "hidden",
+          overflowY: isExpanded ? "auto" : "hidden",
         }}
       >
         <div ref={contentRef} style={{ padding: "4px 12px 12px" }}>
@@ -590,7 +593,7 @@ interface ResearchFiltersProps {
   countryId?: string;
 }
 
-function ResearchFilters({
+export function ResearchFilters({
   searchQuery,
   onSearchChange,
   onSearchSubmit,


### PR DESCRIPTION
Fixes #1151

## Summary

- preserve the full height of collapsed research filter headers
- make the expanded section shrink into the remaining viewport budget
- keep long filter contents reachable through internal vertical scrolling
- add regression coverage for long lists, viewport resizing, and sibling header sizing

## Tests

- bun run test src/__tests__/components/research-filters.test.tsx
- bun run test
- bun run typecheck
- bun run lint
- bun run build
- git diff --check

## Visual verification

Automated browser and screenshot checks were intentionally not used. Review the research filter expansion and internal scrolling in the local preview.