### PR TITLE
Sort research author names by last name

### DIFF
--- a/website/src/__tests__/lib/authorFilterOptions.test.ts
+++ b/website/src/__tests__/lib/authorFilterOptions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+import { buildAuthorFilterOptions } from "@/lib/authorFilterOptions";
+
+describe("buildAuthorFilterOptions", () => {
+  test("formats and sorts author labels by last name", () => {
+    const authors = {
+      "nikhil-woodruff": { name: "Nikhil Woodruff" },
+      "max-ghenis": { name: "Max Ghenis" },
+      "ana-maria-lopez": { name: "Ana Maria Lopez" },
+      "jason-debacker": { name: "Jason DeBacker" },
+    };
+
+    expect(buildAuthorFilterOptions(authors)).toEqual([
+      { key: "jason-debacker", name: "DeBacker, Jason" },
+      { key: "max-ghenis", name: "Ghenis, Max" },
+      { key: "ana-maria-lopez", name: "Lopez, Ana Maria" },
+      { key: "nikhil-woodruff", name: "Woodruff, Nikhil" },
+    ]);
+  });
+
+  test("keeps a single-token author name unchanged", () => {
+    expect(
+      buildAuthorFilterOptions({ "chat-gpt": { name: "ChatGPT" } }),
+    ).toEqual([{ key: "chat-gpt", name: "ChatGPT" }]);
+  });
+});

--- a/website/src/app/[countryId]/research/ResearchClient.tsx
+++ b/website/src/app/[countryId]/research/ResearchClient.tsx
@@ -53,17 +53,16 @@ import {
 } from "@/data/posts/postTransformers";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import authorsData from "@/data/posts/authors.json";
+import { buildAuthorFilterOptions } from "@/lib/authorFilterOptions";
 
 /* ─── Constants ─── */
 
-// All authors from authors.json, sorted alphabetically by display name. The
+// All authors from authors.json, formatted and sorted by last name. The
 // dropdown previously hardcoded a 5-name subset; pulling from authors.json
 // keeps it in sync as authors are added without a code edit.
-const allAuthors = Object.entries(
+const allAuthors = buildAuthorFilterOptions(
   authorsData as Record<string, { name: string }>,
-)
-  .map(([key, value]) => ({ key, name: value.name }))
-  .sort((a, b) => a.name.localeCompare(b.name));
+);
 
 const typeOptions = [
   { value: "article", label: "Article" },

--- a/website/src/lib/authorFilterOptions.ts
+++ b/website/src/lib/authorFilterOptions.ts
@@ -1,0 +1,26 @@
+export interface AuthorFilterOption {
+  key: string;
+  name: string;
+}
+
+function formatLastFirst(name: string): string {
+  const nameParts = name.trim().split(/\s+/);
+
+  if (nameParts.length === 1) {
+    return nameParts[0];
+  }
+
+  const lastName = nameParts.pop();
+  return `${lastName}, ${nameParts.join(" ")}`;
+}
+
+export function buildAuthorFilterOptions(
+  authors: Record<string, { name: string }>,
+): AuthorFilterOption[] {
+  return Object.entries(authors)
+    .map(([key, author]) => ({
+      key,
+      name: formatLastFirst(author.name),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
Fixes #1153

## Summary

- Format research author filter labels as Last, First.
- Sort the filter options by the surname-first labels.
- Preserve author keys used by selection state and URL parameters.
- Keep single-token author names unchanged.

## Tests

- bun --cwd website test --run src/__tests__/lib/authorFilterOptions.test.ts src/__tests__/components/research-filters.test.tsx
- bun --cwd website test
- bun --cwd website typecheck
- bun --cwd website lint