### PR TITLE
Include article text in research search results

### DIFF
--- a/website/src/__tests__/components/research-search-card.test.tsx
+++ b/website/src/__tests__/components/research-search-card.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { BlogPostCard } from "@/app/[countryId]/research/ResearchClient";
+import { colors } from "@/designTokens";
+import type { ResearchSearchResult } from "@/lib/researchSearch";
+
+const baseItem: ResearchSearchResult = {
+  title: "Estimating the constituency distribution of a mansion tax",
+  description:
+    "Three central London constituencies account for a fifth of property sales above £2 million.",
+  date: "2025-11-24",
+  authors: ["max-ghenis"],
+  tags: ["uk", "policy", "tax"],
+  image: "",
+  slug: "uk-mansion-tax-autumn-budget",
+  isApp: false,
+  countryId: "uk",
+};
+
+describe("BlogPostCard search excerpts", () => {
+  test("replaces the description with a quoted italic highlighted body excerpt", () => {
+    const text =
+      "Outside London, Runnymede and Weybridge had 183 high-value sales.";
+    const highlightedText = "Runnymede and Weybridge";
+    const highlightStart = text.indexOf(highlightedText);
+
+    render(
+      <BlogPostCard
+        item={{
+          ...baseItem,
+          searchExcerpt: {
+            text,
+            highlightedText,
+            highlightStart,
+            highlightEnd: highlightStart + highlightedText.length,
+          },
+        }}
+        countryId="uk"
+      />,
+    );
+
+    const highlight = screen.getByText(highlightedText);
+    expect(highlight.tagName).toBe("MARK");
+    expect(highlight).toHaveStyle({ backgroundColor: colors.primary[100] });
+    expect(highlight.parentElement).toHaveStyle({ fontStyle: "italic" });
+    expect(highlight.parentElement?.textContent).toBe(`“${text}”`);
+    expect(screen.queryByText(baseItem.description)).not.toBeInTheDocument();
+  });
+
+  test("renders the original description when there is no body-only match", () => {
+    render(<BlogPostCard item={baseItem} countryId="uk" />);
+
+    expect(screen.getByText(baseItem.description)).toBeInTheDocument();
+    expect(screen.queryByRole("mark")).not.toBeInTheDocument();
+  });
+});

--- a/website/src/__tests__/lib/researchSearch.test.ts
+++ b/website/src/__tests__/lib/researchSearch.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  searchResearchItems,
+  type ResearchSearchIndexEntry,
+} from "@/lib/researchSearch";
+import type { ResearchItem } from "@/data/posts/postTransformers";
+
+const mansionTaxArticle: ResearchItem = {
+  title: "Estimating the constituency distribution of a mansion tax",
+  description:
+    "Three central London constituencies account for a fifth of property sales above £2 million.",
+  date: "2025-11-24",
+  authors: ["max-ghenis"],
+  tags: ["uk", "policy", "tax"],
+  image: "",
+  slug: "uk-mansion-tax-autumn-budget",
+  isApp: false,
+  countryId: "uk",
+};
+
+const searchIndex: ResearchSearchIndexEntry[] = [
+  {
+    slug: mansionTaxArticle.slug,
+    content:
+      "London constituencies account for 45-46% of all affected properties. Outside London, the constituencies with the most high-value sales are Runnymede and Weybridge (183), Queen's Park and Maida Vale (166).",
+  },
+];
+
+describe("searchResearchItems", () => {
+  test("returns an article for a phrase found only in its body", () => {
+    const results = searchResearchItems(
+      [mansionTaxArticle],
+      searchIndex,
+      "Runnymede and Weybridge",
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].slug).toBe(mansionTaxArticle.slug);
+    expect(results[0].searchExcerpt?.text).toContain("Runnymede and Weybridge");
+    expect(results[0].searchExcerpt?.highlightedText).toBe(
+      "Runnymede and Weybridge",
+    );
+  });
+
+  test("keeps the normal description when the query matches metadata", () => {
+    const results = searchResearchItems(
+      [mansionTaxArticle],
+      searchIndex,
+      "central London constituencies",
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].searchExcerpt).toBeUndefined();
+    expect(results[0].description).toBe(mansionTaxArticle.description);
+  });
+
+  test("matches body phrases case-insensitively and keeps them inside a bounded excerpt", () => {
+    const results = searchResearchItems(
+      [mansionTaxArticle],
+      searchIndex,
+      "RUNNYMEDE AND WEYBRIDGE",
+    );
+
+    const excerpt = results[0].searchExcerpt;
+    expect(excerpt).toBeDefined();
+    expect(excerpt!.text.length).toBeLessThanOrEqual(183);
+    expect(excerpt!.highlightStart).toBeGreaterThanOrEqual(0);
+    expect(
+      excerpt!.text.slice(excerpt!.highlightStart, excerpt!.highlightEnd),
+    ).toBe("Runnymede and Weybridge");
+  });
+
+  test("highlights the visible phrase for a fuzzy punctuation match", () => {
+    const results = searchResearchItems(
+      [mansionTaxArticle],
+      searchIndex,
+      "Runnymede & Weybridge",
+    );
+
+    expect(results[0].searchExcerpt?.highlightedText).toBe(
+      "Runnymede and Weybridge",
+    );
+  });
+});

--- a/website/src/__tests__/lib/researchSearchCorpus.test.ts
+++ b/website/src/__tests__/lib/researchSearchCorpus.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+
+import { getResearchItems } from "@/data/posts/postTransformers";
+import { searchResearchItems } from "@/lib/researchSearch";
+import {
+  buildResearchSearchIndex,
+  getSearchableArticleText,
+} from "@/lib/researchSearchCorpus";
+
+describe("getSearchableArticleText", () => {
+  test("keeps reader-visible markdown text while removing presentation syntax", () => {
+    const markdown = [
+      "## Key findings",
+      "The [constituency lookup](https://example.com) includes **Runnymede and Weybridge**.",
+      "```plotly",
+      '{ "internal": "chart configuration" }',
+      "```",
+    ].join("\n");
+
+    const text = getSearchableArticleText("example.md", markdown);
+
+    expect(text).toContain("Key findings");
+    expect(text).toContain("constituency lookup");
+    expect(text).toContain("Runnymede and Weybridge");
+    expect(text).not.toContain("https://example.com");
+    expect(text).not.toContain("chart configuration");
+  });
+
+  test("indexes notebook markdown cells but not code cells", () => {
+    const notebook = JSON.stringify({
+      cells: [
+        {
+          cell_type: "markdown",
+          source: ["A reader-visible finding about household incomes."],
+        },
+        {
+          cell_type: "code",
+          source: ["private_internal_variable = 42"],
+        },
+      ],
+    });
+
+    const text = getSearchableArticleText("example.ipynb", notebook);
+
+    expect(text).toContain("reader-visible finding");
+    expect(text).not.toContain("private_internal_variable");
+  });
+});
+
+describe("buildResearchSearchIndex", () => {
+  test("includes text from the real mansion-tax article body", () => {
+    const searchIndex = buildResearchSearchIndex();
+    const entry = searchIndex.find(
+      (item) => item.slug === "uk-mansion-tax-autumn-budget",
+    );
+
+    expect(entry?.content).toContain("Runnymede and Weybridge");
+
+    const results = searchResearchItems(
+      getResearchItems(),
+      searchIndex,
+      "Runnymede and Weybridge",
+    );
+    expect(results[0].slug).toBe("uk-mansion-tax-autumn-budget");
+    expect(results[0].searchExcerpt?.highlightedText).toBe(
+      "Runnymede and Weybridge",
+    );
+  });
+});

--- a/website/src/app/[countryId]/research/ResearchClient.tsx
+++ b/website/src/app/[countryId]/research/ResearchClient.tsx
@@ -16,10 +16,16 @@
  *   - Uses OptimisedImage for blog post images
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import Fuse from "fuse.js";
 import {
   IconArrowRight,
   IconChevronDown,
@@ -49,11 +55,15 @@ import {
   getTopicTags,
   locationLabels,
   topicLabels,
-  type ResearchItem,
 } from "@/data/posts/postTransformers";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import authorsData from "@/data/posts/authors.json";
 import { buildAuthorFilterOptions } from "@/lib/authorFilterOptions";
+import {
+  searchResearchItems,
+  type ResearchSearchIndexEntry,
+  type ResearchSearchResult,
+} from "@/lib/researchSearch";
 
 /* ─── Constants ─── */
 
@@ -116,11 +126,11 @@ function buildFilterParams(
 
 /* ─── BlogPostCard ─── */
 
-function BlogPostCard({
+export function BlogPostCard({
   item,
   countryId,
 }: {
-  item: ResearchItem;
+  item: ResearchSearchResult;
   countryId: string;
 }) {
   const link = item.isApp
@@ -241,7 +251,7 @@ function BlogPostCard({
             {item.title}
           </p>
 
-          {/* Description */}
+          {/* Description or body-search excerpt */}
           <Text
             size="sm"
             style={{
@@ -252,9 +262,29 @@ function BlogPostCard({
               WebkitBoxOrient: "vertical",
               overflow: "hidden",
               lineHeight: "1.6",
+              fontStyle: item.searchExcerpt ? "italic" : undefined,
             }}
           >
-            {item.description}
+            {item.searchExcerpt ? (
+              <>
+                “
+                {item.searchExcerpt.text.slice(
+                  0,
+                  item.searchExcerpt.highlightStart,
+                )}
+                <mark
+                  style={{
+                    backgroundColor: colors.primary[100],
+                    color: "inherit",
+                  }}
+                >
+                  {item.searchExcerpt.highlightedText}
+                </mark>
+                {item.searchExcerpt.text.slice(item.searchExcerpt.highlightEnd)}”
+              </>
+            ) : (
+              item.description
+            )}
           </Text>
 
           {/* CTA */}
@@ -290,7 +320,7 @@ function BlogPostCard({
 
 /* ─── BlogPostGrid ─── */
 
-function itemKey(item: ResearchItem) {
+function itemKey(item: ResearchSearchResult) {
   return `${item.isApp ? "app" : "post"}-${item.slug}`;
 }
 
@@ -298,7 +328,7 @@ function BlogPostGrid({
   items,
   countryId,
 }: {
-  items: ResearchItem[];
+  items: ResearchSearchResult[];
   countryId: string;
 }) {
   const prevKeysRef = useRef<Set<string>>(new Set());
@@ -892,6 +922,43 @@ export default function ResearchClient({
   const [selectedAuthors, setSelectedAuthors] = useState<string[]>(() =>
     parseArrayParam(searchParams.get("authors")),
   );
+  const [searchIndex, setSearchIndex] = useState<
+    ResearchSearchIndexEntry[] | null
+  >(null);
+  const [searchIndexFailed, setSearchIndexFailed] = useState(false);
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+
+  const shouldLoadSearchIndex =
+    searchQuery.trim().length > 0 && searchIndex === null && !searchIndexFailed;
+
+  useEffect(() => {
+    if (!shouldLoadSearchIndex) {
+      return;
+    }
+
+    let active = true;
+    fetch("/api/research-search-index")
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to load the article search index");
+        }
+        return response.json() as Promise<ResearchSearchIndexEntry[]>;
+      })
+      .then((index) => {
+        if (active) {
+          setSearchIndex(index);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setSearchIndexFailed(true);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [shouldLoadSearchIndex]);
 
   // Sync URL params when filters change
   useEffect(() => {
@@ -920,7 +987,7 @@ export default function ResearchClient({
 
   // Filter items
   const filteredItems = useMemo(() => {
-    let items = allItems;
+    let items: ResearchSearchResult[] = allItems;
 
     // Filter by type
     if (selectedTypes.length > 0) {
@@ -952,12 +1019,12 @@ export default function ResearchClient({
     }
 
     // Apply search
-    if (searchQuery.trim()) {
-      const fuse = new Fuse(items, {
-        keys: ["title", "description"],
-        threshold: 0.3,
-      });
-      items = fuse.search(searchQuery).map((result) => result.item);
+    if (deferredSearchQuery.trim()) {
+      items = searchResearchItems(
+        items,
+        searchIndex || [],
+        deferredSearchQuery,
+      );
     }
 
     return items;
@@ -967,8 +1034,12 @@ export default function ResearchClient({
     selectedTopics,
     selectedLocations,
     selectedAuthors,
-    searchQuery,
+    deferredSearchQuery,
+    searchIndex,
   ]);
+
+  const isSearchIndexLoading =
+    searchQuery.trim().length > 0 && searchIndex === null && !searchIndexFailed;
 
   // Infinite scroll - show 8 items initially, load 8 more as user scrolls
   const { visibleCount, sentinelRef, hasMore, reset } = useInfiniteScroll({
@@ -1057,11 +1128,21 @@ export default function ResearchClient({
               className="tw:mb-md"
               style={{ color: colors.gray[500] }}
             >
-              {filteredItems.length}{" "}
-              {filteredItems.length === 1 ? "result" : "results"}
+              {isSearchIndexLoading
+                ? "Searching article text…"
+                : `${filteredItems.length} ${
+                    filteredItems.length === 1 ? "result" : "results"
+                  }`}
             </Text>
 
-            {filteredItems.length > 0 ? (
+            {isSearchIndexLoading ? (
+              <div
+                className="tw:flex tw:justify-center"
+                style={{ padding: spacing["3xl"] }}
+              >
+                <Spinner size="sm" />
+              </div>
+            ) : filteredItems.length > 0 ? (
               <>
                 <BlogPostGrid
                   items={visibleItems}

--- a/website/src/app/api/research-search-index/route.ts
+++ b/website/src/app/api/research-search-index/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { buildResearchSearchIndex } from "@/lib/researchSearchCorpus";
+
+export const dynamic = "force-static";
+
+export function GET(): NextResponse {
+  return NextResponse.json(buildResearchSearchIndex(), {
+    headers: {
+      "Cache-Control":
+        "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/website/src/lib/researchSearch.ts
+++ b/website/src/lib/researchSearch.ts
@@ -1,0 +1,243 @@
+import Fuse, { type FuseResultMatch } from "fuse.js";
+
+import type { ResearchItem } from "@/data/posts/postTransformers";
+
+const MAX_EXCERPT_CONTENT_LENGTH = 180;
+const TOKEN_MATCH_RADIUS = 120;
+const IGNORED_QUERY_TOKENS = new Set(["and", "for", "from", "the", "with"]);
+
+export interface ResearchSearchIndexEntry {
+  slug: string;
+  content: string;
+}
+
+export interface SearchExcerpt {
+  text: string;
+  highlightedText: string;
+  highlightStart: number;
+  highlightEnd: number;
+}
+
+export interface ResearchSearchResult extends ResearchItem {
+  searchExcerpt?: SearchExcerpt;
+}
+
+interface SearchDocument {
+  item: ResearchItem;
+  title: string;
+  description: string;
+  content: string;
+}
+
+function getFallbackMatchRange(
+  match: FuseResultMatch,
+): [number, number] | null {
+  const longestRange = match.indices.reduce<[number, number] | null>(
+    (longest, [start, end]) => {
+      if (!longest || end - start > longest[1] - longest[0]) {
+        return [start, end];
+      }
+      return longest;
+    },
+    null,
+  );
+
+  return longestRange;
+}
+
+function getTokenMatchRange(
+  content: string,
+  query: string,
+): [number, number] | null {
+  const normalizedContent = content.toLocaleLowerCase();
+  const tokens = [
+    ...new Set(
+      query
+        .toLocaleLowerCase()
+        .match(/[\p{L}\p{N}]+/gu)
+        ?.filter(
+          (token) => token.length >= 2 && !IGNORED_QUERY_TOKENS.has(token),
+        ) || [],
+    ),
+  ];
+  const tokenOccurrences = tokens.map((token) => {
+    const occurrences: Array<[number, number]> = [];
+    let start = normalizedContent.indexOf(token);
+
+    while (start >= 0) {
+      occurrences.push([start, start + token.length - 1]);
+      start = normalizedContent.indexOf(token, start + token.length);
+    }
+
+    return occurrences;
+  });
+  const anchors = tokenOccurrences.flat();
+
+  return anchors.reduce<[number, number] | null>((bestRange, anchor) => {
+    const nearbyMatches = tokenOccurrences
+      .map((occurrences) =>
+        occurrences.reduce<[number, number] | null>((nearest, occurrence) => {
+          const distance = Math.abs(occurrence[0] - anchor[0]);
+          if (distance > TOKEN_MATCH_RADIUS) {
+            return nearest;
+          }
+          if (!nearest || distance < Math.abs(nearest[0] - anchor[0])) {
+            return occurrence;
+          }
+          return nearest;
+        }, null),
+      )
+      .filter((occurrence): occurrence is [number, number] =>
+        Boolean(occurrence),
+      );
+
+    if (nearbyMatches.length === 0) {
+      return bestRange;
+    }
+
+    const candidate: [number, number] = [
+      Math.min(...nearbyMatches.map(([start]) => start)),
+      Math.max(...nearbyMatches.map(([, end]) => end)),
+    ];
+    if (!bestRange) {
+      return candidate;
+    }
+
+    const bestTokenCount = tokenOccurrences.filter((occurrences) =>
+      occurrences.some(
+        ([start]) => start >= bestRange[0] && start <= bestRange[1],
+      ),
+    ).length;
+    if (nearbyMatches.length > bestTokenCount) {
+      return candidate;
+    }
+    if (
+      nearbyMatches.length === bestTokenCount &&
+      candidate[1] - candidate[0] < bestRange[1] - bestRange[0]
+    ) {
+      return candidate;
+    }
+    return bestRange;
+  }, null);
+}
+
+function getBodyMatchRange(
+  content: string,
+  query: string,
+  match: FuseResultMatch,
+): [number, number] | null {
+  const normalizedQuery = query.trim();
+  const exactStart = content
+    .toLocaleLowerCase()
+    .indexOf(normalizedQuery.toLocaleLowerCase());
+
+  if (exactStart >= 0) {
+    return [exactStart, exactStart + normalizedQuery.length - 1];
+  }
+
+  return (
+    getTokenMatchRange(content, normalizedQuery) || getFallbackMatchRange(match)
+  );
+}
+
+function createSearchExcerpt(
+  content: string,
+  query: string,
+  match: FuseResultMatch,
+): SearchExcerpt | undefined {
+  const range = getBodyMatchRange(content, query, match);
+  if (!range) {
+    return undefined;
+  }
+
+  const [matchStart, inclusiveMatchEnd] = range;
+  const matchEnd = inclusiveMatchEnd + 1;
+  const matchLength = matchEnd - matchStart;
+  const excerptContentLength = Math.max(
+    MAX_EXCERPT_CONTENT_LENGTH,
+    matchLength,
+  );
+  const surroundingLength = Math.max(0, excerptContentLength - matchLength);
+
+  let excerptStart = Math.max(
+    0,
+    matchStart - Math.floor(surroundingLength / 2),
+  );
+  let excerptEnd = Math.min(
+    content.length,
+    excerptStart + excerptContentLength,
+  );
+  excerptStart = Math.max(0, excerptEnd - excerptContentLength);
+
+  if (excerptStart > 0) {
+    const nextSpace = content.indexOf(" ", excerptStart);
+    if (nextSpace >= 0 && nextSpace < matchStart) {
+      excerptStart = nextSpace + 1;
+    }
+  }
+
+  if (excerptEnd < content.length) {
+    const previousSpace = content.lastIndexOf(" ", excerptEnd);
+    if (previousSpace > matchEnd) {
+      excerptEnd = previousSpace;
+    }
+  }
+
+  const excerptContent = content.slice(excerptStart, excerptEnd).trim();
+  const contentStart = content.indexOf(excerptContent, excerptStart);
+  const prefix = contentStart > 0 ? "…" : "";
+  const suffix =
+    contentStart + excerptContent.length < content.length ? "…" : "";
+  const text = `${prefix}${excerptContent}${suffix}`;
+  const highlightStart = prefix.length + matchStart - contentStart;
+  const highlightEnd = highlightStart + matchLength;
+
+  return {
+    text,
+    highlightedText: text.slice(highlightStart, highlightEnd),
+    highlightStart,
+    highlightEnd,
+  };
+}
+
+export function searchResearchItems(
+  items: ResearchItem[],
+  searchIndex: ResearchSearchIndexEntry[],
+  query: string,
+): ResearchSearchResult[] {
+  const contentBySlug = new Map(
+    searchIndex.map((entry) => [entry.slug, entry.content]),
+  );
+  const documents: SearchDocument[] = items.map((item) => ({
+    item,
+    title: item.title,
+    description: item.description,
+    content: item.isApp ? "" : contentBySlug.get(item.slug) || "",
+  }));
+  const fuse = new Fuse(documents, {
+    keys: [
+      { name: "title", weight: 0.5 },
+      { name: "description", weight: 0.3 },
+      { name: "content", weight: 0.2 },
+    ],
+    threshold: 0.3,
+    includeMatches: true,
+    ignoreLocation: true,
+  });
+
+  return fuse.search(query).map((result) => {
+    const metadataMatched = result.matches?.some(
+      (match) => match.key === "title" || match.key === "description",
+    );
+    const bodyMatch = result.matches?.find((match) => match.key === "content");
+    const searchExcerpt =
+      !metadataMatched && bodyMatch
+        ? createSearchExcerpt(result.item.content, query, bodyMatch)
+        : undefined;
+
+    return {
+      ...result.item.item,
+      ...(searchExcerpt ? { searchExcerpt } : {}),
+    };
+  });
+}

--- a/website/src/lib/researchSearchCorpus.ts
+++ b/website/src/lib/researchSearchCorpus.ts
@@ -1,0 +1,50 @@
+import { getPostsSorted } from "@/data/posts/postTransformers";
+import { getArticleContent } from "@/lib/articles";
+import { extractMarkdownFromNotebook } from "@/lib/notebookUtils";
+import type { ResearchSearchIndexEntry } from "@/lib/researchSearch";
+import type { Notebook } from "@/types/blog";
+
+const FENCED_CODE_BLOCK = /```[\s\S]*?```/g;
+const HTML_CONTENT_BLOCK = /<(iframe|script|style)\b[\s\S]*?<\/\1>/gi;
+const MARKDOWN_IMAGE = /!\[([^\]]*)\]\([^)]*\)/g;
+const MARKDOWN_LINK = /\[([^\]]+)\]\([^)]*\)/g;
+const HTML_TAG = /<[^>]+>/g;
+const HEADING_OR_LIST_PREFIX = /^\s*(?:#{1,6}|[-+*]|\d+\.)\s+/gm;
+const FOOTNOTE_MARKER = /\[\^\d+\](?::)?/g;
+const MARKDOWN_DECORATION = /[*_~`>|]/g;
+
+function markdownToSearchText(markdown: string): string {
+  return markdown
+    .replace(FENCED_CODE_BLOCK, " ")
+    .replace(HTML_CONTENT_BLOCK, " ")
+    .replace(MARKDOWN_IMAGE, "$1")
+    .replace(MARKDOWN_LINK, "$1")
+    .replace(HTML_TAG, " ")
+    .replace(HEADING_OR_LIST_PREFIX, "")
+    .replace(FOOTNOTE_MARKER, " ")
+    .replace(MARKDOWN_DECORATION, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function getSearchableArticleText(
+  filename: string,
+  rawContent: string,
+): string {
+  if (filename.endsWith(".ipynb")) {
+    const notebook = JSON.parse(rawContent) as Notebook;
+    return markdownToSearchText(extractMarkdownFromNotebook(notebook));
+  }
+
+  return markdownToSearchText(rawContent);
+}
+
+export function buildResearchSearchIndex(): ResearchSearchIndexEntry[] {
+  return getPostsSorted().map((post) => ({
+    slug: post.slug,
+    content: getSearchableArticleText(
+      post.filename,
+      getArticleContent(post.filename),
+    ),
+  }));
+}


### PR DESCRIPTION
Fixes #1155

## Summary

- generate a reader-visible search corpus from Markdown articles and notebook Markdown cells
- serve that corpus through a statically generated, cacheable endpoint
- search article bodies with lower weight than titles and descriptions
- show bounded, quoted, italic excerpts with light-primary highlighting for body-only matches
- preserve metadata-only search for interactive apps and the existing research filters

## Root cause

The research client only passed `title` and `description` to Fuse, article content was loaded exclusively on article pages, and result cards always rendered the stored description.

## User impact

Users can now find research by words or phrases in article text and see the matching context directly on the result card.

## Tests

- `bun run test` — 129 tests passed
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `git diff --check`